### PR TITLE
Adjustments to the CI scripting

### DIFF
--- a/.github/workflows/content-artifacts.yml
+++ b/.github/workflows/content-artifacts.yml
@@ -16,6 +16,7 @@ env:
   CICD_DIR_PATH: oscal/build/ci-cd
   CONTENT_CONFIG_PATH: src/config
   SAXON_VERSION: 9.9.0-1
+  HOME_REPO: GSA/fedramp-automation
 jobs:
   validate-and-publish-content:
     name: Content Validation Checking, Conversion and Validation
@@ -59,13 +60,13 @@ jobs:
       # job-deploy-artifacts
       - name: Setup SSH key
         # only do this on master
-        if: github.ref == 'refs/heads/master'
+        if: github.repository == env.HOME_REPO && github.ref == 'refs/heads/master'
         run: |
           eval "$(ssh-agent -s)"
           ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
       - name: Publish Artifacts
         # only do this on master
-        if: github.ref == 'refs/heads/master'
+        if: github.repository == env.HOME_REPO && github.ref == 'refs/heads/master'
         uses: stefanzweifel/git-auto-commit-action@v4.4.1
         with:
           repository: git-content

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "oscal"]
 	path = oscal
-	url = git@github.com:usnistgov/OSCAL.git
+	url = https://github.com/usnistgov/OSCAL.git
 	branch = master


### PR DESCRIPTION
Updating the OSCAL submodule to use HTTP. See usnistgov/OSCAL#753.
Configure CI workflow to skip push when not in the home repo on the master branch. See usnistgov/OSCAL#747.