### PR TITLE
Fix typo reported in issue #58

### DIFF
--- a/baselines/xml/FedRAMP_HIGH-baseline-resolved-profile_catalog.xml
+++ b/baselines/xml/FedRAMP_HIGH-baseline-resolved-profile_catalog.xml
@@ -9,7 +9,7 @@
       <oscal-version>1.0.0-milestone3</oscal-version>
       <prop name="resolution-timestamp">2020-09-01T21:44:06.632415Z</prop>
       <link rel="resolution-source" href="FedRAMP_HIGH-baseline_profile.xml">FedRAMP High Baseline</link>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/baselines/xml/FedRAMP_HIGH-baseline_profile.xml
+++ b/baselines/xml/FedRAMP_HIGH-baseline_profile.xml
@@ -7,7 +7,7 @@
       <last-modified>2020-06-01T10:00:00.000-04:00</last-modified>
       <version>1.2</version>
       <oscal-version>1.0.0-milestone3</oscal-version>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/baselines/xml/FedRAMP_LI-SaaS-baseline-resolved-profile_catalog.xml
+++ b/baselines/xml/FedRAMP_LI-SaaS-baseline-resolved-profile_catalog.xml
@@ -9,7 +9,7 @@
       <oscal-version>1.0.0-milestone3</oscal-version>
       <prop name="resolution-timestamp">2020-09-01T21:44:20.087921Z</prop>
       <link rel="resolution-source" href="FedRAMP_LI-SaaS-baseline_profile.xml">FedRAMP Tailored Low Impact Software as a Service (LI-SaaS) Baseline</link>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/baselines/xml/FedRAMP_LI-SaaS-baseline_profile.xml
+++ b/baselines/xml/FedRAMP_LI-SaaS-baseline_profile.xml
@@ -7,7 +7,7 @@
       <last-modified>2020-06-01T10:00:00.000-05:00</last-modified>
       <version>1.2</version>
       <oscal-version>1.0.0-milestone3</oscal-version>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/baselines/xml/FedRAMP_LOW-baseline-resolved-profile_catalog.xml
+++ b/baselines/xml/FedRAMP_LOW-baseline-resolved-profile_catalog.xml
@@ -9,7 +9,7 @@
       <oscal-version>1.0.0-milestone3</oscal-version>
       <prop name="resolution-timestamp">2020-09-01T21:44:30.056502Z</prop>
       <link rel="resolution-source" href="FedRAMP_LOW-baseline_profile.xml">FedRAMP Low Baseline</link>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/baselines/xml/FedRAMP_LOW-baseline_profile.xml
+++ b/baselines/xml/FedRAMP_LOW-baseline_profile.xml
@@ -7,7 +7,7 @@
       <last-modified>2020-06-01T10:00:00.000-04:00</last-modified>
       <version>1.2</version>
       <oscal-version>1.0.0-milestone3</oscal-version>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/baselines/xml/FedRAMP_MODERATE-baseline-resolved-profile_catalog.xml
+++ b/baselines/xml/FedRAMP_MODERATE-baseline-resolved-profile_catalog.xml
@@ -9,7 +9,7 @@
       <oscal-version>1.0.0-milestone3</oscal-version>
       <prop name="resolution-timestamp">2020-09-01T21:44:40.959559Z</prop>
       <link rel="resolution-source" href="FedRAMP_MODERATE-baseline_profile.xml">FedRAMP Moderate Baseline</link>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/baselines/xml/FedRAMP_MODERATE-baseline_profile.xml
+++ b/baselines/xml/FedRAMP_MODERATE-baseline_profile.xml
@@ -7,7 +7,7 @@
       <last-modified>2020-06-01T10:00:00.000-04:00</last-modified>
       <version>1.2</version>
       <oscal-version>1.0.0-milestone3</oscal-version>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/src/baselines/xml/FedRAMP_HIGH-baseline_profile.xml
+++ b/src/baselines/xml/FedRAMP_HIGH-baseline_profile.xml
@@ -7,7 +7,7 @@
       <last-modified>2020-06-01T10:00:00.000-04:00</last-modified>
       <version>1.2</version>
       <oscal-version>1.0.0-milestone3</oscal-version>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/src/baselines/xml/FedRAMP_LI-SaaS-baseline_profile.xml
+++ b/src/baselines/xml/FedRAMP_LI-SaaS-baseline_profile.xml
@@ -7,7 +7,7 @@
       <last-modified>2020-06-01T10:00:00.000-05:00</last-modified>
       <version>1.2</version>
       <oscal-version>1.0.0-milestone3</oscal-version>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/src/baselines/xml/FedRAMP_LOW-baseline_profile.xml
+++ b/src/baselines/xml/FedRAMP_LOW-baseline_profile.xml
@@ -7,7 +7,7 @@
       <last-modified>2020-06-01T10:00:00.000-04:00</last-modified>
       <version>1.2</version>
       <oscal-version>1.0.0-milestone3</oscal-version>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">

--- a/src/baselines/xml/FedRAMP_MODERATE-baseline_profile.xml
+++ b/src/baselines/xml/FedRAMP_MODERATE-baseline_profile.xml
@@ -7,7 +7,7 @@
       <last-modified>2020-06-01T10:00:00.000-04:00</last-modified>
       <version>1.2</version>
       <oscal-version>1.0.0-milestone3</oscal-version>
-      <role id="parpared-by">
+      <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">


### PR DESCRIPTION
CI test results can be [found here](https://github.com/ohsh6o/fedramp-automation/runs/1168272906).

This closes #58.