### PR TITLE
Update fedramp_values.json

### DIFF
--- a/resources/json/fedramp_values.json
+++ b/resources/json/fedramp_values.json
@@ -1,1370 +1,7787 @@
 {
-    "fedramp-values": {
-        "xmlns": "https://fedramp.gov/ns/oscal",
+    "information-types": {
         "metadata": {
-            "title": "[EXPERIMENTAL] FedRAMP Defined Identifiers and Accepted Values [DRAFT]",
-            "title-short": "FedRAMP Data Values (DRAFT)",
-            "last-modified": "2020-03-03Z",
+            "title": "FedRAMP Acceptable Information Types",
+            "title-short": "Info. Types",
+            "last-modified": "2020-11-25Z",
             "version": "DRAFT",
-            "author": "FedRAMP PMO",
-            "description": "This EXPERIMENTAL and DRAFT file provides the FedRAMP defined identifiers and acceptable values in a machine-readable format.",
-            "remarks": ""
+            "description": "This DRAFT file provides all information types currently acceptable to FedRAMP.\nAt time of development, this is limited to NIST SP 800-60, Volume 2, Revision 1, with no plans to change.\nIf NIST releases another revision to SP 800-60, Volume 2, FedRAMP will evaluate the change and adjust this file accordingly.",
+            "author": "FedRAMP PMO"
         },
-        "files": {
-            "link": [
-                {
-                    "id": "fedramp_high_baseline",
-                    "media-type": "application/xml",
-                    "rel": "profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/xml/FedRAMP_HIGH-baseline_profile.xml",
-                    "content": "FedRAMP High Baseline Profile (XML)"
-                },
-                {
-                    "id": "fedramp_high_baseline",
-                    "media-type": "application/json",
-                    "rel": "profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/json/FedRAMP_HIGH-baseline_profile.json",
-                    "content": "FedRAMP High Baseline Profile (JSON)"
-                },
-                {
-                    "id": "fedramp_high_baseline",
-                    "media-type": "application/xml",
-                    "rel": "resolved-profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/xml/FedRAMP_HIGH-baseline-resolved-profile_catalog.xml",
-                    "content": "FedRAMP High Baseline Resolved Profile Catalog (XML)"
-                },
-                {
-                    "id": "fedramp_high_baseline",
-                    "media-type": "application/json",
-                    "rel": "resolved-profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/json/FedRAMP_HIGH-baseline-resolved-profile_catalog.json",
-                    "content": "FedRAMP High Baseline Resolved Profile Catalog (JSON)"
-                },
-                {
-                    "id": "fedramp_moderate_baseline",
-                    "media-type": "application/xml",
-                    "rel": "profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/xml/FedRAMP_MODERATE-baseline_profile.xml",
-                    "content": "FedRAMP Moderate Baseline Profile (XML)"
-                },
-                {
-                    "id": "fedramp_moderate_baseline",
-                    "media-type": "application/json",
-                    "rel": "profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/json/FedRAMP_MODERATE-baseline_profile.json",
-                    "content": "FedRAMP Moderate Baseline Profile (JSON)"
-                },
-                {
-                    "id": "fedramp_moderate_baseline",
-                    "media-type": "application/xml",
-                    "rel": "resolved-profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/xml/FedRAMP_MODERATE-baseline-resolved-profile_catalog.xml",
-                    "content": "FedRAMP Moderate Baseline Resolved Profile Catalog (XML)"
-                },
-                {
-                    "id": "fedramp_moderate_baseline",
-                    "media-type": "application/json",
-                    "rel": "resolved-profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/json/FedRAMP_MODERATE-baseline-resolved-profile_catalog.json",
-                    "content": "FedRAMP Moderate Baseline Resolved Profile Catalog (JSON)"
-                },
-                {
-                    "id": "fedramp_low_baseline",
-                    "media-type": "application/xml",
-                    "rel": "profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/xml/FedRAMP_LOW-baseline_profile.xml",
-                    "content": "FedRAMP Low Baseline Profile (XML)"
-                },
-                {
-                    "id": "fedramp_low_baseline",
-                    "media-type": "application/json",
-                    "rel": "profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/json/FedRAMP_LOW-baseline_profile.json",
-                    "content": "FedRAMP Low Baseline Profile (JSON)"
-                },
-                {
-                    "id": "fedramp_low_baseline",
-                    "media-type": "application/xml",
-                    "rel": "resolved-profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/xml/FedRAMP_LOW-baseline-resolved-profile_catalog.xml",
-                    "content": "FedRAMP Low Baseline Resolved Profile Catalog (XML)"
-                },
-                {
-                    "id": "fedramp_low_baseline",
-                    "media-type": "application/json",
-                    "rel": "resolved-profile",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/fedramp.gov/json/FedRAMP_LOW-baseline-resolved-profile_catalog.json",
-                    "content": "FedRAMP Low Baseline Resolved Profile Catalog (JSON)"
-                },
-                {
-                    "id": "nist_sp-800-53_rev4",
-                    "media-type": "application/xml",
-                    "rel": "catalog",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml",
-                    "content": "NIST SP 800-63, Rev 4 (XML)"
-                },
-                {
-                    "id": "nist_sp-800-53_rev4",
-                    "media-type": "application/json",
-                    "rel": "catalog",
-                    "href": "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/nist.gov/SP800-53/rev4/json/NIST_SP-800-53_rev4_catalog.json",
-                    "content": "NIST SP 800-63, Rev 4 (JSON)"
-                }
-            ]
-        },
-        "namespace": {
-            "ns": {
-                "name": "FedRAMP",
-                "ns": "https://fedramp.gov/ns/oscal"
-            }
-        },
-        "value-set": [
+        "information-type": [
             {
-                "name": "system-identifier-type",
-                "formal-name": "System Identifier Type",
-                "description": "Indicates the source of the unique ID assigned to the system. FedRAMP requires a FedRAMP-assigned identifier; however, additional identifiers may also be provided.",
-                "binding": {"pattern": "system-id/@identifier-type"},
-                "allowed-values": {
-                    "allow-other": "yes",
-                    "enum": [
-                        {
-                            "value": "http://fedramp.gov",
-                            "short-label": "FedRAMP ID",
-                            "content": "FedRAMP-Assigned Identifier"
-                        },
-                        {
-                            "value": "https://ietf.org/rfc/rfc4122",
-                            "short-label": "UUIDv4",
-                            "content": "RFC-4122 UUIDv4 Value"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "address-type",
-                "formal-name": "Address Type",
-                "description": "The type of address for the party",
-                "binding": {"pattern": "party/address/@type"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "home",
-                            "short-label": "Home",
-                            "content": "Home"
-                        },
-                        {
-                            "value": "work",
-                            "short-label": "Work",
-                            "content": "Work"
-                        }
-                    ]
-                },
-                "remarks": "FedRAMP requires work addresses."
-            },
-            {
-                "name": "eauth-level",
-                "formal-name": "eAuth Level",
-                "description": "The eAuthentication level as defined by NIST SP 800-63, Revision 3.",
-                "binding": {"pattern": "system-characteristics/prop[@name='security-eauth-level'][@ns='https://fedramp.gov/ns/oscal']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": 1,
-                            "short-label": "L",
-                            "content": "Low"
-                        },
-                        {
-                            "value": 2,
-                            "short-label": "M",
-                            "content": "Moderate"
-                        },
-                        {
-                            "value": 3,
-                            "short-label": "H",
-                            "content": "High"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "identity-assurance-level",
-                "formal-name": "Identity Assurance Level",
-                "description": "The identity assurance level as defined by NIST SP 800-63, Revision 3.",
-                "binding": {"pattern": "system-characteristics/prop[@name='identity-assurance-level']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": 1,
-                            "short-label": "L",
-                            "content": "Low"
-                        },
-                        {
-                            "value": 2,
-                            "short-label": "M",
-                            "content": "Moderate"
-                        },
-                        {
-                            "value": 3,
-                            "short-label": "H",
-                            "content": "High"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "authenticator-assurance-level",
-                "formal-name": "Authenticator Assurance Level",
-                "description": "The authenticator assurance level as defined by NIST SP 800-63, Revision 3.",
-                "binding": {"pattern": "system-characteristics/prop[@name='authenticator-assurance-level']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": 1,
-                            "short-label": "L",
-                            "content": "Low"
-                        },
-                        {
-                            "value": 2,
-                            "short-label": "M",
-                            "content": "Moderate"
-                        },
-                        {
-                            "value": 3,
-                            "short-label": "H",
-                            "content": "High"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "federation-assurance-level",
-                "formal-name": "Federation Assurance Level",
-                "description": "The federation assurance level as defined by NIST SP 800-63, Revision 3.",
-                "binding": {"pattern": "system-characteristics/prop[@name='federation-assurance-level']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": 1,
-                            "short-label": "L",
-                            "content": "Low"
-                        },
-                        {
-                            "value": 2,
-                            "short-label": "M",
-                            "content": "Moderate"
-                        },
-                        {
-                            "value": 3,
-                            "short-label": "H",
-                            "content": "High"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "authorization-type",
-                "formal-name": "Authorization Type",
-                "description": "The FedRAMP Authorization Type",
-                "binding": {"pattern": "system-characteristics/prop[@name='authorization-type'][@ns='https://fedramp.gov/ns/oscal']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "fedramp-jab",
-                            "short-label": "JAB",
-                            "content": "FedRAMP JAB P-ATO"
-                        },
-                        {
-                            "value": "fedramp-agency",
-                            "short-label": "Agency",
-                            "content": "FedRAMP Agency ATO"
-                        },
-                        {
-                            "value": "fedramp-li-saas",
-                            "short-label": "LI-SaaS",
-                            "content": "FedRAMP Tailored for LI-SaaS"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "service-model",
-                "formal-name": "Service Model",
-                "description": "The cloud service model.",
-                "binding": {"pattern": "system-characteristics/annotation[@name='service-model']/@value"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "saas",
-                            "short-label": "SaaS",
-                            "content": "Software as a Service"
-                        },
-                        {
-                            "value": "paas",
-                            "short-label": "PaaS",
-                            "content": "Platform as a Service"
-                        },
-                        {
-                            "value": "iaas",
-                            "short-label": "IaaS",
-                            "content": "Infrastructure as a Service"
-                        },
-                        {
-                            "value": "other",
-                            "short-label": "Other",
-                            "content": "Other"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "deployment-model",
-                "formal-name": "Deployment Model",
-                "description": "The cloud deployment model.",
-                "binding": {"pattern": "system-characteristics/annotation[@name='deployment-model']/@value"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "public-cloud",
-                            "short-label": "Public",
-                            "content": "Public Cloud"
-                        },
-                        {
-                            "value": "private-cloud",
-                            "short-label": "Private",
-                            "content": "Private Cloud"
-                        },
-                        {
-                            "value": "community-cloud",
-                            "short-label": "Community",
-                            "content": "Community Cloud"
-                        },
-                        {
-                            "value": "government-only-cloud",
-                            "short-label": "USG-Only",
-                            "content": "U.S. Government Only"
-                        },
-                        {
-                            "value": "hybrid-cloud",
-                            "short-label": "Hybrid",
-                            "content": "Hybrid"
-                        },
-                        {
-                            "value": "other",
-                            "short-label": "Other",
-                            "content": "Other"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "security-objective-level",
-                "formal-name": "Security Objective Level",
-                "description": "The security objective level as defined by FIPS-199.",
-                "binding": [
-                    {"pattern": "system-characteristics/security-impact-level/security-objective-confidentiality"},
-                    {"pattern": "system-characteristics/security-impact-level/security-objective-availability"},
-                    {"pattern": "system-characteristics/security-impact-level/security-objective-integrity"}
-                ],
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "fips-199-low",
-                            "short-label": "L",
-                            "content": "Low"
-                        },
-                        {
-                            "value": "fips-199-moderate",
-                            "short-label": "M",
-                            "content": "Moderate"
-                        },
-                        {
-                            "value": "fips-199-high",
-                            "short-label": "H",
-                            "content": "High"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "security-impact-level",
-                "formal-name": "Security Impact Level",
-                "description": "The security objective level as defined by NIST SP 800-60.",
-                "binding": [
-                    {"pattern": "information-type/confidentiality-impact/base"},
-                    {"pattern": "information-type/confidentiality-impact/selected"},
-                    {"pattern": "information-type/availability-impact/base"},
-                    {"pattern": "information-type/availability-impact/selected"},
-                    {"pattern": "information-type/integrity-impact/base"},
-                    {"pattern": "information-type/integrity-impact/selected"}
-                ],
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "fips-199-low",
-                            "short-label": "L",
-                            "content": "Low"
-                        },
-                        {
-                            "value": "fips-199-moderate",
-                            "short-label": "M",
-                            "content": "Moderate"
-                        },
-                        {
-                            "value": "fips-199-high",
-                            "short-label": "H",
-                            "content": "High"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "privacy-designation",
-                "formal-name": "Privacy Designation",
-                "description": "Indicates whether this system is privacy sensitive.",
-                "binding": {"pattern": "system-information/prop[@name='privacy-sensitive']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "yes",
-                            "short-label": "Yes",
-                            "content": "Privacy Sensitive"
-                        },
-                        {
-                            "value": "no",
-                            "short-label": "No",
-                            "content": "Not Privacy Sensitive"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "privacy-threshold-analysis-q1",
-                "formal-name": "Privacy Threshold Analysis (Q1)",
-                "description": "Does the ISA collect, maintain, or share PII in any identifiable form?",
-                "binding": {"pattern": "system-information/prop[@name='pta-1'][@ns='https://fedramp.gov/ns/oscal']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "yes",
-                            "short-label": "Yes",
-                            "content": "Yes"
-                        },
-                        {
-                            "value": "no",
-                            "short-label": "No",
-                            "content": "No"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "privacy-threshold-analysis-q2",
-                "formal-name": "Privacy Threshold Analysis (Q2)",
-                "description": "Does the ISA collect, maintain, share PII info from or about the public?",
-                "binding": {"pattern": "system-information/prop[@name='pta-2'][@ns='https://fedramp.gov/ns/oscal']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "yes",
-                            "short-label": "Yes",
-                            "content": "Yes"
-                        },
-                        {
-                            "value": "no",
-                            "short-label": "No",
-                            "content": "No"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "privacy-threshold-analysis-q3",
-                "formal-name": "Privacy Threshold Analysis (Q3)",
-                "description": "Has a Privacy Impact Assessment ever been performed for the ISA?",
-                "binding": {"pattern": "system-information/prop[@name='pta-3'][@ns='https://fedramp.gov/ns/oscal']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "yes",
-                            "short-label": "Yes",
-                            "content": "Yes"
-                        },
-                        {
-                            "value": "no",
-                            "short-label": "No",
-                            "content": "No"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "privacy-threshold-analysis-q4",
-                "formal-name": "Privacy Threshold Analysis (Q4)",
-                "description": "Is there a Privacy Act System of Records Notice (SORN) for this ISA system?",
-                "binding": {"pattern": "system-information/prop[@name='pta-4'][@ns='https://fedramp.gov/ns/oscal']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "yes",
-                            "short-label": "Yes",
-                            "content": "Yes"
-                        },
-                        {
-                            "value": "no",
-                            "short-label": "No",
-                            "content": "No"
-                        }
-                    ]
-                },
-                "remarks": "If \"yes\" a SORN ID must be provided."
-            },
-            {
-                "name": "security-sensitivity-level",
-                "formal-name": "Security Sensitivity Level",
-                "description": "The security sensitivity level for the system.",
-                "binding": {"pattern": "security-sensitivity-level"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "low",
-                            "short-label": "L",
-                            "content": "Low"
-                        },
-                        {
-                            "value": "moderate",
-                            "short-label": "M",
-                            "content": "Moderate"
-                        },
-                        {
-                            "value": "high",
-                            "short-label": "H",
-                            "content": "High"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "likelihood",
-                "formal-name": "Likelihood",
-                "description": "The likelihood of a risk.",
-                "binding": {"pattern": "risk/risk-metric[@name='likelihood'][@system='https://fedramp.gov']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "low",
-                            "short-label": "L",
-                            "content": "Low"
-                        },
-                        {
-                            "value": "moderate",
-                            "short-label": "M",
-                            "content": "Moderate"
-                        },
-                        {
-                            "value": "high",
-                            "short-label": "H",
-                            "content": "High"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "impact-level",
-                "formal-name": "Impact Level",
-                "description": "The impact level of a risk.",
-                "binding": {"pattern": "risk/risk-metric[@name='impact'][@system='https://fedramp.gov']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "low",
-                            "short-label": "L",
-                            "content": "Low"
-                        },
-                        {
-                            "value": "moderate",
-                            "short-label": "M",
-                            "content": "Moderate"
-                        },
-                        {
-                            "value": "high",
-                            "short-label": "H",
-                            "content": "High"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "information-type-system",
-                "formal-name": "Information Type System",
-                "description": "Identifies the system from which the information type was defined.",
-                "binding": {"pattern": "information-type/information-type-id/@system"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": {
-                        "value": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
-                        "short-label": "SP 800-60 V2R1",
-                        "content": "NIST SP 800-60, Volume 2, Revision 1"
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.1.2"
                     }
                 },
-                "remarks": "FedRAMP only allows information types defined in NIST SP 800-60v2r1."
-            },
-            {
-                "name": "system-operational-status",
-                "formal-name": "Operational Status (system)",
-                "description": "The operational status of the system",
-                "binding": {"pattern": "system-characteristics/status/@state"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "operational",
-                            "short-label": "Operational",
-                            "content": "Operational"
-                        },
-                        {
-                            "value": "under-development",
-                            "short-label": "Development",
-                            "content": "Under Development"
-                        },
-                        {
-                            "value": "under-major-modification",
-                            "short-label": "Major Mod.",
-                            "content": "Major Modification"
-                        },
-                        {
-                            "value": "disposition",
-                            "short-label": "Alternative",
-                            "content": "Alternative Implementation"
-                        },
-                        {
-                            "value": "other",
-                            "short-label": "Other",
-                            "content": "Other"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "component-operational-status",
-                "formal-name": "Operational Status (component)",
-                "description": "The operational status of the component",
-                "binding": {"pattern": "component/status/@state"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "operational",
-                            "short-label": "Operational",
-                            "content": "Operational"
-                        },
-                        {
-                            "value": "under-development",
-                            "short-label": "Development",
-                            "content": "Under Development"
-                        },
-                        {
-                            "value": "disposition",
-                            "short-label": "Alternative",
-                            "content": "Alternative Implementation"
-                        },
-                        {
-                            "value": "other",
-                            "short-label": "Other",
-                            "content": "Other"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "user-type",
-                "formal-name": "User Type",
-                "description": "Identifies the user type.",
-                "binding": {"pattern": "user/annotation[@name='type']/@value"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "internal",
-                            "short-label": "I",
-                            "content": "Internal"
-                        },
-                        {
-                            "value": "external",
-                            "short-label": "E",
-                            "content": "External"
-                        },
-                        {
-                            "value": "general-public",
-                            "short-label": "P",
-                            "content": "General Public"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "user-privilege",
-                "formal-name": "User Privilege",
-                "description": "Identifies the privilege level of the user.",
-                "binding": {"pattern": "user/annotation[@name='privilege-level']/@value"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "privileged",
-                            "short-label": "P",
-                            "content": "Privileged"
-                        },
-                        {
-                            "value": "non-privileged",
-                            "short-label": "NP",
-                            "content": "Non-Privileged"
-                        },
-                        {
-                            "value": "no-logical-access",
-                            "short-label": "NLA",
-                            "content": "No Logical Access"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "user-sensitivity-level",
-                "formal-name": "User Sensitivity level",
-                "description": "Identifies the sensitivity level of the user.",
-                "binding": {"pattern": "user/prop[@name='sensitivity'][@ns='https://fedramp.gov/ns/oscal']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "high-risk",
-                            "short-label": "High",
-                            "content": "High Risk"
-                        },
-                        {
-                            "value": "severe",
-                            "short-label": "Sev.",
-                            "content": "Severe"
-                        },
-                        {
-                            "value": "moderate",
-                            "short-label": "Mod.",
-                            "content": "Moderate"
-                        },
-                        {
-                            "value": "limited",
-                            "short-label": "Lim.",
-                            "content": "Limited"
-                        },
-                        {
-                            "value": "not-applicable",
-                            "short-label": "N/A",
-                            "content": "Not Applicable"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "interconnection-direction",
-                "formal-name": "Interconnection Direction",
-                "description": "Identifies the direction of information flow for the interconnection.",
-                "binding": {"pattern": "component[@component-type='interconnection']/prop[@name='direction'][@ns='https://fedramp.gov/ns/oscal']"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "incoming",
-                            "short-label": "In",
-                            "content": "Incoming"
-                        },
-                        {
-                            "value": "outgoing",
-                            "short-label": "Out",
-                            "content": "Outgoing"
-                        },
-                        {
-                            "value": "incoming-outgoing",
-                            "short-label": "In/Out",
-                            "content": "Bi-Directional"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "interconnection-security",
-                "formal-name": "Interconnection Security",
-                "description": "Identifies the type of security applied to the interconnection.",
-                "binding": {"pattern": "component[@component-type='interconnection']/annotation[@name='connection-security'][@ns='https://fedramp.gov/ns/oscal']/@value"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "ipsec",
-                            "short-label": "IPsec",
-                            "content": "IPsec"
-                        },
-                        {
-                            "value": "vpn",
-                            "short-label": "VPN",
-                            "content": "Virtual Private Network"
-                        },
-                        {
-                            "value": "ssl",
-                            "short-label": "SSL",
-                            "content": "Secure Socket Layer"
-                        },
-                        {
-                            "value": "certificate",
-                            "short-label": "Cert",
-                            "content": "Certificate"
-                        },
-                        {
-                            "value": "secure-file-transfer",
-                            "short-label": "SFT",
-                            "content": "Secure File Transfer"
-                        },
-                        {
-                            "value": "other",
-                            "short-label": "Other",
-                            "content": "Other"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "component-type",
-                "formal-name": "Component Type",
-                "description": "identifies the component type.",
-                "binding": {"pattern": "component/@component-type"},
-                "allowed-values": {
-                    "allow-other": "yes",
-                    "enum": [
-                        {
-                            "value": "software",
-                            "short-label": "S/W",
-                            "content": "Software"
-                        },
-                        {
-                            "value": "hardware",
-                            "short-label": "H/W",
-                            "content": "Hardware"
-                        },
-                        {
-                            "value": "service",
-                            "short-label": "Svc",
-                            "content": "Service"
-                        },
-                        {
-                            "value": "policy",
-                            "short-label": "Pol",
-                            "content": "Policy"
-                        },
-                        {
-                            "value": "process",
-                            "short-label": "Pros",
-                            "content": "Process"
-                        },
-                        {
-                            "value": "procedure",
-                            "short-label": "Proc",
-                            "content": "Procedure"
-                        },
-                        {
-                            "value": "plan",
-                            "short-label": "Plan",
-                            "content": "Plan"
-                        },
-                        {
-                            "value": "guidance",
-                            "short-label": "Guide",
-                            "content": "Guidance"
-                        },
-                        {
-                            "value": "standard",
-                            "short-label": "Std",
-                            "content": "Standard"
-                        },
-                        {
-                            "value": "validation",
-                            "short-label": "Val",
-                            "content": "Validation"
-                        },
-                        {
-                            "value": "system",
-                            "short-label": "Sys",
-                            "content": "This System"
-                        },
-                        {
-                            "value": "interconnection",
-                            "short-label": "Int",
-                            "content": "Interconnection"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "asset-type",
-                "formal-name": "Asset Type",
-                "description": "Identifies the type of asset.",
-                "binding": [
-                    {"pattern": "component/prop[@name='asset-type']"},
-                    {"pattern": "inventory-item/prop[@name='asset-type']"}
-                ],
-                "allowed-values": {
-                    "allow-other": "yes",
-                    "enum": [
-                        {
-                            "value": "os",
-                            "short-label": "OS",
-                            "content": "Operating System"
-                        },
-                        {
-                            "value": "database",
-                            "short-label": "DB",
-                            "content": "Database"
-                        },
-                        {
-                            "value": "web-server",
-                            "short-label": "Web",
-                            "content": "Service"
-                        },
-                        {
-                            "value": "dns-server",
-                            "short-label": "DNS",
-                            "content": "Policy"
-                        },
-                        {
-                            "value": "email-server",
-                            "short-label": "eMail",
-                            "content": "Process"
-                        },
-                        {
-                            "value": "directory-server",
-                            "short-label": "LDAP",
-                            "content": "Procedure"
-                        },
-                        {
-                            "value": "pbx",
-                            "short-label": "PBX",
-                            "content": "Private Branch Exchange"
-                        },
-                        {
-                            "value": "firewall",
-                            "short-label": "FW",
-                            "content": "Firewall"
-                        },
-                        {
-                            "value": "router",
-                            "short-label": "Rtr",
-                            "content": "Router"
-                        },
-                        {
-                            "value": "switch",
-                            "short-label": "Swtch",
-                            "content": "Switch"
-                        },
-                        {
-                            "value": "storage-array",
-                            "short-label": "Store",
-                            "content": "Storage Array"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "scan-type",
-                "formal-name": "Scan Type",
-                "description": "Identifies the type of scan.",
-                "binding": [
-                    {"pattern": "component/prop[@name='scan-type'][@ns='https://fedramp.gov/ns/oscal']"},
-                    {"pattern": "inventory-item/prop[@name='scan-type'][@ns='https://fedramp.gov/ns/oscal']"}
-                ],
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "infrastructure",
-                            "short-label": "Inf./OS",
-                            "content": "Infrastructure and Operating System Scan"
-                        },
-                        {
-                            "value": "database",
-                            "short-label": "DB",
-                            "content": "Database Scan"
-                        },
-                        {
-                            "value": "web",
-                            "short-label": "Web",
-                            "content": "Web Scan"
-                        },
-                        {
-                            "value": "other",
-                            "short-label": "Other",
-                            "content": "Web Scan"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "transport-type",
-                "formal-name": "Transport Type",
-                "description": "The internet protocol transport type.",
-                "binding": {"pattern": "component[@component-type='service']/protocol/port-range/@transport"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "TCP",
-                            "short-label": "TCP",
-                            "content": "TCP"
-                        },
-                        {
-                            "value": "UDP",
-                            "short-label": "UDP",
-                            "content": "UDP"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "virtual",
-                "formal-name": "Virtual",
-                "description": "Indicates if the asset is virtual.",
-                "binding": [
-                    {"pattern": "inventory-item/prop[@name='virtual']"},
-                    {"pattern": "component/prop[@name='virtual']"}
-                ],
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "yes",
-                            "short-label": "Y",
-                            "content": "Yes"
-                        },
-                        {
-                            "value": "no",
-                            "short-label": "N",
-                            "content": "No"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "public",
-                "formal-name": "Public",
-                "description": "Indicates if the asset is exposed to the public Internet.",
-                "binding": [
-                    {"pattern": "inventory-item/prop[@name='public']"},
-                    {"pattern": "component/prop[@name='public']"}
-                ],
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "yes",
-                            "short-label": "Y",
-                            "content": "Yes"
-                        },
-                        {
-                            "value": "no",
-                            "short-label": "N",
-                            "content": "No"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "allows-authenticated-scan",
-                "formal-name": "Allows Authenticated Scan",
-                "description": "Indicates if the asset is capable of having an authenticated scan.",
-                "binding": [
-                    {"pattern": "inventory-item/annotation[@name='allows-authenticated-scan']/@value"},
-                    {"pattern": "component/annotation[@name='allows-authenticated-scan']/@value"}
-                ],
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "yes",
-                            "short-label": "Y",
-                            "content": "Yes"
-                        },
-                        {
-                            "value": "no",
-                            "short-label": "N",
-                            "content": "No"
-                        }
-                    ]
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Controls and Oversight",
+                "title": "Corrective Action Information Type",
+                "description": "Corrective Action involves the enforcement functions necessary to remedy programs that have been found non-compliant with a given law, regulation, or policy. The recommended security categorization for the corrective action information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
                 },
-                "remarks": "if the value is \"no\", the annotation remarks must contain the reason why."
-            },
-            {
-                "name": "is-scanned",
-                "formal-name": "Is Scanned",
-                "description": "Indicates if the asset is scan.",
-                "binding": [
-                    {"pattern": "inventory-item/annotation[@name='is-scanned']/@value"},
-                    {"pattern": "component/annotation[@name='is-scannan']/@value"}
-                ],
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "yes",
-                            "short-label": "Y",
-                            "content": "Yes"
-                        },
-                        {
-                            "value": "no",
-                            "short-label": "N",
-                            "content": "No"
-                        }
-                    ]
+                "availability-impact": {
+                    "base": "fips-199-low"
                 },
-                "remarks": "if the value is \"no\", the annotation remarks must contain the reason why."
-            },
-            {
-                "name": "control-implementation-status",
-                "formal-name": "Control Implementation Status",
-                "description": "The implementation status of the control.",
-                "binding": {"pattern": "implemented-requirement/annotation[@name='implementation-status']/@value"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "implemented",
-                            "short-label": "Implemented",
-                            "content": "Implemented"
-                        },
-                        {
-                            "value": "partial",
-                            "short-label": "Partial",
-                            "content": "Partially Implemented"
-                        },
-                        {
-                            "value": "planned",
-                            "short-label": "Planned",
-                            "content": "Planned"
-                        },
-                        {
-                            "value": "alternative",
-                            "short-label": "Alternative",
-                            "content": "Alternative Implementation"
-                        },
-                        {
-                            "value": "not-applicable",
-                            "short-label": "N/A",
-                            "content": "Not Applicable"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "control-origination",
-                "formal-name": "Control Origination",
-                "description": "The point(s) from which the control satisfaction originates.",
-                "binding": {"pattern": "implemented-requirement/annotation[@name='control-origination'][@ns='https://fedramp.gov/ns/oscal']/@value"},
-                "allowed-values": {
-                    "allow-other": "no",
-                    "enum": [
-                        {
-                            "value": "sp-corporate",
-                            "short-label": "SP Corporate",
-                            "content": "Service Provider (Corporate)"
-                        },
-                        {
-                            "value": "sp-system",
-                            "short-label": "SP System",
-                            "content": "Service Provider (System Specific)"
-                        },
-                        {
-                            "value": "customer-configured",
-                            "short-label": "Cust. Configured",
-                            "content": "Configured by Customer"
-                        },
-                        {
-                            "value": "customer-provided",
-                            "short-label": "Cust. Provided",
-                            "content": "Provided by Customer"
-                        },
-                        {
-                            "value": "inherited",
-                            "short-label": "Inherited",
-                            "content": "Inherited"
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "attachment-type",
-                "formal-name": "Attachment Type",
-                "description": "Identifies the type of attachment.",
-                "binding": {"pattern": "resource/prop[@name='type'][@ns='https://fedramp.gov/ns/oscal']"},
-                "allowed-values": {
-                    "allow-other": "yes",
-                    "enum": [
-                        {
-                            "value": "law",
-                            "short-label": "Law",
-                            "content": "Law or Statute"
-                        },
-                        {
-                            "value": "regulation",
-                            "short-label": "Regulation",
-                            "content": "Regulation or Directive"
-                        },
-                        {
-                            "value": "standard",
-                            "short-label": "Standard",
-                            "content": "Industry Standard"
-                        },
-                        {
-                            "value": "guidance",
-                            "short-label": "Guidance",
-                            "content": "Guidance"
-                        },
-                        {
-                            "value": "pii",
-                            "short-label": "P.I.I.",
-                            "content": "Privacy Impact Information"
-                        },
-                        {
-                            "value": "policy",
-                            "short-label": "Policy",
-                            "content": "Polciy"
-                        },
-                        {
-                            "value": "procedure",
-                            "short-label": "Procedure",
-                            "content": "Procedure"
-                        },
-                        {
-                            "value": "guide",
-                            "short-label": "Guidance",
-                            "content": "Guidance Document"
-                        },
-                        {
-                            "value": "pia",
-                            "short-label": "P.I.A.",
-                            "content": "Privacy Impact Assessment"
-                        },
-                        {
-                            "value": "rob",
-                            "short-label": "R.O.B.",
-                            "content": "Rules of Behavior"
-                        },
-                        {
-                            "value": "plan",
-                            "short-label": "Plan",
-                            "content": "Plan"
-                        },
-                        {
-                            "value": "system-security-plan",
-                            "short-label": "SSP",
-                            "content": "System Security Plan"
-                        },
-                        {
-                            "value": "artifact",
-                            "short-label": "artifact",
-                            "content": "Artifact"
-                        },
-                        {
-                            "value": "evidence",
-                            "short-label": "evidence",
-                            "content": "Evidence"
-                        },
-                        {
-                            "value": "screen-shot",
-                            "short-label": "screen",
-                            "content": "Screen Shot"
-                        },
-                        {
-                            "value": "image",
-                            "short-label": "image",
-                            "content": "Image"
-                        },
-                        {
-                            "value": "tool-report",
-                            "short-label": "Report",
-                            "content": "Tool Report"
-                        },
-                        {
-                            "value": "raw-tool-output",
-                            "short-label": "Raw",
-                            "content": "Raw Tool Output"
-                        },
-                        {
-                            "value": "interview-notes",
-                            "short-label": "Notes",
-                            "content": "Interview Notes"
-                        },
-                        {
-                            "value": "questionnaire",
-                            "short-label": "Questions",
-                            "content": "Questions"
-                        },
-                        {
-                            "value": "report",
-                            "short-label": "Report",
-                            "content": "Report"
-                        }
-                    ]
+                "integrity-impact": {
+                    "base": "fips-199-low"
                 },
-                "remarkas": "Not all values apply to all FedRAMP artifacts."
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of corrective action information on the ability of responsible agencies to remedy internal or external programs that have been found non-compliant with a given law, regulation, or policy. Unauthorized disclosure of most corrective action information should have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will probably be personal information subject to the Privacy Act of 1974 or information that is proprietary to a corporation or other organization. Such information will often be assigned a moderate confidentiality impact level. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Additionally, there are legislative mandates prohibiting unauthorized disclosure of trade secrets. Trade secrets will generally be assigned a moderate confidentiality impact level."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for corrective action information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the corrective action information. The availability impact is also dependent on whether the data is time-critical. In most cases, disruption of access to corrective action information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for corrective action information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The consequences of undetected unauthorized modification or destruction of corrective action information can conceivably compromise the effectiveness of compliance enforcement actions (e.g., by providing violators with a basis for claiming investigative or enforcement irregularities, thus supporting legal challenges to proposed corrective actions). The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of most corrective action information should have only a limited adverse effect on agency operations, assets, or individuals."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for corrective action information is low."
+                    }
+                ]
             },
             {
-                "name": "hash-algorithm",
-                "formal-name": "Hash Algorithm",
-                "description": "Identifies the algorithm used to create the hash value of the attachment.",
-                "binding": {"pattern": "resource/hash/@algorithm"},
-                "allowed-values": {
-                    "allow-other": "yes",
-                    "enum": [
-                        {
-                            "value": "SHA-224",
-                            "short-label": "SHA-224",
-                            "content": "SHA-224"
-                        },
-                        {
-                            "value": "SHA-256",
-                            "short-label": "SHA-256",
-                            "content": "SHA-256"
-                        },
-                        {
-                            "value": "SHA-384",
-                            "short-label": "SHA-384",
-                            "content": "SHA-384"
-                        },
-                        {
-                            "value": "SHA-512",
-                            "short-label": "SHA-512",
-                            "content": "SHA-512"
-                        },
-                        {
-                            "value": "RIPEMD-160",
-                            "short-label": "RIPEMD-160",
-                            "content": "RIPEMD-160"
-                        }
-                    ]
-                }
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.1.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Controls and Oversight",
+                "title": "Program Evaluation",
+                "description": "Program Evaluation involves the analysis of internal and external program effectiveness and the determination of corrective actions as appropriate. The impact levels should be commensurate with the impact levels of the program that is being evaluated. For example, if the program contains very sensitive financial data with moderate impact levels for confidentiality and integrity, the program evaluation impact levels for confidentiality and integrity should also be moderate. The recommended security categorization for the program evaluation information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of program evaluation information on the abilities of responsible agencies to analyze internal and external program effectiveness and to determine appropriate corrective actions. The confidentiality impact of program evaluation information is largely event-driven. Once the evaluation has been reported, most program evaluation information is in the public domain. However, premature unauthorized disclosure of program evaluation information can alert personnel associated with programs under evaluation to the focus and preliminary findings of investigative and evaluation activities. Special Factors Affecting Confidentiality Impact Determination: Where a major programs or human safety is at stake, actions taken based on unauthorized disclosure of program evaluation information can pose a threat to human life or a loss of major assets. In such cases, the confidentiality impact is high. Unauthorized disclosure of most program evaluation information often has the potential to seriously affect agency operations. Also, some program evaluation information, particularly in the case of current investigations, includes personal information subject to the Privacy Act of 1974 and/or information that is proprietary to a corporation or other organization. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Additionally, there are legislative mandates prohibiting unauthorized disclosure of trade secrets. Trade secrets will generally be assigned a moderate confidentiality impact level. If the program evaluation information is moved to the public domain, the confidentiality impact level becomes Not Applicable (NA)."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Because there are many cases in which unauthorized disclosure of program evaluation information will have only a limited adverse effect on agency operations, assets, or individuals, the provisional confidentiality impact level recommended for program evaluation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the program evaluation information. Although there are time-sensitive exceptions, most program evaluation processes are tolerant of reasonable delays. In most cases, disruption of access to program evaluation information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for program evaluation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The consequences of undetected unauthorized modification or destruction of program evaluation information can compromise the effectiveness of an evaluation program (e.g., by providing false information intended to mislead investigators or evaluators or to give program personnel a basis for claiming investigative or evaluative irregularities). The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Although there are time-sensitive exceptions, unauthorized modification or destruction of most program evaluation information should have only a limited adverse effect on agency operations, assets, or individuals."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for program evaluation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.1.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Controls and Oversight",
+                "title": "Program Monitoring",
+                "description": "Program Monitoring involves the data-gathering activities required to determine the effectiveness of internal and external programs and the extent to which they comply with related laws, regulations, and policies. The impact levels should be commensurate with the impact levels of the programs that are being monitored. For example, if a program contains very sensitive financial data with moderate impact levels for confidentiality and integrity, the program monitoring impact levels for confidentiality and integrity should also be moderate. Subject to exception conditions described below, the recommended security categorization for the program monitoring information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of program monitoring information on the ability of responsible agencies to perform data-gathering activities required to determine the effectiveness of internal and external programs and the extent to which they comply with related laws, regulations, and policies. Special Factors Affecting Confidentiality Impact Determination: There are legislative mandates prohibiting unauthorized disclosure of trade secrets. Trade secrets will generally be assigned a moderate confidentiality impact level. Note that national security information and national security systems are outside the scope of this guideline. Otherwise, where the data being collected belongs to one of the information types described in this guideline, the confidentiality impact assigned the data and system is that of the highest impact information type collected. Unauthorized disclosure of program monitoring information can alert personnel associated with programs being monitored to the focus and implications of monitoring activities. Where a major programs or human safety is at stake, actions taken based on unauthorized disclosure of program monitoring information can pose a threat to human life or a loss of major assets. In such cases, the confidentiality impact is high. If the program monitoring information is moved to the public domain, the confidentiality impact level becomes Not Applicable (NA)."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Although there are many circumstances in which serious adverse effects on agency operations, agency assets, or individuals can result to justify a moderate base confidentiality impact level for program monitoring information, in most Federal environments, unauthorized disclosure will have only a limited adverse effect on agency operations, assets, or individuals. Consequently, for most systems, a low provisional confidentiality impact level is recommended for program monitoring information."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the program monitoring information. Although there may be time-sensitive program monitoring situations, more typically, disruption of access to program monitoring information will have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: There are a limited number of compliance monitoring operations for which temporary loss of availability is likely to significantly degrade mission capability, place the agency at a significant disadvantage, result in loss of major assets, or pose a threat to human life. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for program monitoring information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The consequences of unauthorized modification or destruction of program monitoring information can compromise the effectiveness of the monitoring program. Although there may be time-sensitive program monitoring situations, the integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The damage likely to be caused by unauthorized modification or destruction of program monitoring information may have consequent serious adverse effects on agency operations or public confidence in the agency."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "There are some regulatory environments in which a high or moderate impact level is appropriate. For most compliance monitoring information, the recommended provisional integrity impact level is low. Special Factors Affecting Integrity Impact Determination: The consequences can be particularly serious if the destruction or modification of monitoring information invalidates evaluation results concerning major programs or concerning threats to human safety. The integrity impact resulting from unauthorized modification or deletion of program monitoring information depends in part on the nature of the laws or policies with which compliance is being determined and in part on the criticality of the processes being monitored. For example, in the case of safety regulations affecting manned space flight, the integrity impact level may be high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.2.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Regulatory Development",
+                "title": "Policy and Guidance Development",
+                "description": "Policy and Guidance Development involves the creation and dissemination of guidelines to assist in the interpretation and implementation of regulations. In most cases, the effect on public welfare of a loss of policy and guidance development mission capability can be expected to be delayed rather than immediate. As a result, the potential for consequent loss of human life or of major national assets is relatively low, since these most catastrophic consequences of impairment to mission capability can, in most cases, be corrected before they are fully realized. The recommended security categorization for the policy and guidance development information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of policy and guidance information on the ability of responsible agencies to create and disseminate guidelines to assist in the interpretation and implementation of regulations. The confidentiality impact of policy and guidance information is largely event-driven. Once a policy or guidance statement has been promulgated, most policy and guidance information is in the public domain. However, premature unauthorized disclosure of candidate policy and guidance material can result in disruption of (and inappropriate influence of special interests on) the policy development process. Special Factors Affecting Confidentiality Impact Determination: The effects of loss of confidentiality of guidelines during the formative stage can result in attempts by affected entities and other interested parties to influence and/or impede the policy and guideline development process. Premature public release of formative policies and guidelines before internal coordination and review can result in unnecessary damage to public confidence in the agency. This is particularly likely where the release includes unedited internal commentary and discussion. Delays can impair an agency\u2019s mission, but loss of public confidence can do serious and persistent harm to an agency\u2019s ability to effectively perform its mission. In such cases, the provisional confidentiality impact level recommended for policy and guidance development information is moderate. When the policy and guidance information is in the public domain, the confidentiality impact level becomes Not Applicable (NA)."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Although there are cases in which unauthorized and premature disclosure of policy and guidance information can result in serious consequences for an agency, most of this information is intended to be available to the general public. Consequently, the provisional confidentiality impact level recommended for policy and guidance development information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the policy and guidance development information. Though some policy and guidance information is time-critical, the policy and guidance development process is usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for policy and guidance development information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Special Factors Affecting Integrity Impact Determination: Some policy and guidance information is time-critical. Unauthorized modification or destruction of information affecting external communications that contain policy and guidance development information (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Public confidence consequences can be expected to be much more serious in cases of agencies that have national defense, intelligence, or information security missions. In such cases, the impact may be at least moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity level recommended for policy and guidance development information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.2.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Regulatory Development",
+                "title": "Public Comment Tracking",
+                "description": "Public Comment Tracking involves the activities of soliciting, maintaining, and responding to public comments regarding proposed regulations. Subject to exception conditions described below, the recommended security categorization for the public comment tracking information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of public comment tracking information on the ability of responsible agencies to solicit, maintain, and respond to public comments regarding proposed regulations. The effects of loss of confidentiality of information associated with the public comment process are unlikely to pose the threat of serious harm to agency assets, personnel or operations. In a few cases, the rationale for public comments can include information that is sensitive in terms of proprietary information sensitive Federal government information, or even national security information. However, such cases are exceptional and the information in question would be expected to be representative of information types covered elsewhere in this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for public comment tracking information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the public comment tracking information. The effects of disruption of access to public comment tracking information or information systems can delay development of standards, guidelines, or regulations. The public comment tracking process is usually tolerant of delays. Permanent loss of comment information may disrupt some government operations by showing a lack of due diligence in response to comments."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for public comment tracking information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external communications that contain public comment tracking information (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for public comment tracking information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.2.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Regulatory Development",
+                "title": "Regulatory Creation",
+                "description": "Regulatory Creation involves the activities of researching and drafting proposed and final regulations. Subject to exception conditions described below, the recommended security categorization for the regulatory creation information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The level of confidentiality impact level is the effect of unauthorized disclosure of regulatory creation information on the ability of responsible agencies to research and draft proposed and final regulations. The effects of loss of confidentiality of early drafts of regulations can result in attempts by affected entities and other affected parties to influence and/or impede the regulation development process. Special Factors Affecting Confidentiality Impact Determination: Premature public release of draft regulations before internal coordination and review has been conducted can result in unnecessary criticism of the proposed regulation and even damage public confidence in the agency. In such cases, the provisional confidentiality impact level recommended for regulatory creation information is moderate. These consequences are particularly likely where the release includes unedited internal commentary and discussion. Delays can impair an agency\u2019s mission, but loss of public confidence can do serious and persistent harm to an agency\u2019s ability to effectively perform its mission. If the regulatory information is moved to the public domain, the confidentiality impact level becomes Not Applicable (NA)."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Because most regulatory information is intended for release to the public, the provisional confidentiality impact level recommended for regulatory creation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the regulatory creation information. The regulatory creation process is usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for regulatory creation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications that contain regulatory information (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency. The consequences of a reduction in public confidence will be more serious for agencies that have national defense, intelligence, or information security missions. In such cases, the impact level may be at least moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for regulatory creation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.2.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Regulatory Development",
+                "title": "Rule Publication",
+                "description": "Rule Publication includes all activities associated with the publication of a proposed or final rule in the Federal Register and Code of Federal Regulations. Subject to exception conditions described below, the recommended security categorization for the rule publication information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of rule publication information on the ability of responsible agencies to publish proposed or final rules in the Federal Register and Code of Federal Regulations. The published rules are, by definition, public information. The effects of loss of confidentiality of information associated with the rule publication process are unlikely to pose the threat of serious harm to agency assets, personnel or operations."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "In general, the provisional confidentiality impact level recommended for rule publication information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the rule publication information. Rule publication processes are usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for rule publication information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In the worst cases, errata can be published. Unauthorized modification or destruction of information may result in unnecessary expenditures, some confusion, and limited damage to public confidence in the agency."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for rule publication information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.3.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Planning and Budgeting",
+                "title": "Budget Formulation",
+                "description": "Budget Formulation involves all activities undertaken to determine priorities for future spending and to develop an itemized forecast of future funding and expenditures during a targeted period of time. This includes the collection and use of performance information to assess the effectiveness of programs and develop budget priorities. Subject to exception conditions described below, the recommended security categorization for the budget formulation information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of budget formulation information on the ability of responsible agencies to determine priorities for future spending and to develop an itemized forecast of future funding and expenditures during a targeted period of time. Most budget information is supposed to be available to the public. Special Factors Affecting Confidentiality Impact Determination: Some budget information of is classified national security information and is outside the scope of this guideline. The effects of loss of confidentiality of budget information or of early drafts of budgets can result in attempts by competing interests to influence and/or impede the regulation development process. The consequences to agency programs and even of the ability of an agency to perform its mission can be very serious. Premature public release of draft budgets before internal coordination and review has been conducted can result in unnecessary criticism of the proposed regulation and even damage public confidence in the agency. These consequences are particularly likely where the release includes unedited internal commentary and discussion. Delays that result from confidentiality compromise can imperil specific agency programs, but loss of public confidence can do persistent harm to an agency\u2019s ability to effectively perform its mission. In such cases, the confidentiality impact level for budget formulation information is moderate. If the budget formulation information is moved to the public domain, the confidentiality impact level becomes Not Applicable (NA)."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "In spite of the serious harm that can be suffered by an agency due to unauthorized and premature disclosure of draft budget information (and associated commentary), the provisional confidentiality impact level recommended for budget formulation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the budget formulation information. Although some budget formulation information is time-critical, the budget formulation processes are usually tolerant of delays. Excessive recovery delays may result in loss of funding."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for budget formulation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "not on the time required to detect the modification or destruction of information. Special Factors Affecting Integrity Impact Determination: Some budget formulation information is time-critical. Also, unauthorized modification or destruction of information affecting external communications that contain budget information (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Public confidence consequences will be more serious for agencies that have national defense, intelligence, or information security missions. In such cases, the impact may be at least moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for budget formulation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.3.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Planning and Budget",
+                "title": "Capital Planning",
+                "description": "Capital Planning involves the processes for ensuring that appropriate investments are selected for capital expenditures. The recommended provisional security categorization for capital planning information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of capital planning information on the ability of responsible agencies to ensure that appropriate investments are selected for capital expenditures. The effects of loss of confidentiality of capital investment plans during the formative stage can result in attempts by affected entities and other interested parties to influence and/or impede the policy and guideline development process. Premature public release of draft plans before internal coordination and review can result in unnecessary damage to public confidence in the agency. This is particularly likely where the release includes unedited internal commentary and discussion. The diversion of investment funds that can result from compromise of draft plans can pervert investment priorities in a manner that is prejudicial to public interest. However, the consequence of loss of confidentiality of most capital planning information is likely to do only limited harm to government assets, personnel, or missions. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some of the background information that supports development of capital investment plans can reveal sensitive vulnerabilities, capabilities, or methods of anti-terrorism, law enforcement, or national security activities. Depending on the information in question, the confidentiality impact can be moderate, high, or involve national security information (outside the scope of this guideline). Also, some capital investment plans of some Federal agencies contain national security information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of capital planning information on the ability of responsible agencies to ensure that appropriate investments are selected for capital expenditures. The effects of loss of confidentiality of capital investment plans during the formative stage can result in attempts by affected entities and other interested parties to influence and/or impede the policy and guideline development process. Premature public release of draft plans before internal coordination and review can result in unnecessary damage to public confidence in the agency. This is particularly likely where the release includes unedited internal commentary and discussion. The diversion of investment funds that can result from compromise of draft plans can pervert investment priorities in a manner that is prejudicial to public interest. However, the consequence of loss of confidentiality of most capital planning information is likely to do only limited harm to government assets, personnel, or missions. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some of the background information that supports development of capital investment plans can reveal sensitive vulnerabilities, capabilities, or methods of anti-terrorism, law enforcement, or national security activities. Depending on the information in question, the confidentiality impact can be moderate, high, or involve national security information (outside the scope of this guideline). Also, some capital investment plans of some Federal agencies contain national security information."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the capital planning information. The capital planning processes are usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for capital planning information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications that contain capital planning information (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Public confidence consequences will be more serious for agencies that have national defense, intelligence, or information security missions. In such cases, the impact may be at least moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity level recommended for capital planning information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.3.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Planning and Budget",
+                "title": "Enterprise Architecture",
+                "description": "Enterprise Architecture is an established process for describing the current state and defining the target state and transition strategy for an organization\u2019s people, processes, and technology. The recommended provisional security categorization for the enterprise architecture information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of enterprise architecture information on the ability of responsible agencies to describe the current state and define the target state and transition strategy for an organizations people, processes, and technology. The effects of loss of confidentiality of preliminary draft enterprise architecture plans can result in attempts by affected entities and other interested parties to influence and/or impede the policy and guideline development process. Premature public release of draft plans before internal coordination and review can result in unnecessary damage to public confidence in the agency. This is particularly likely where the release includes unedited internal commentary and discussion. However, the consequence of loss of confidentiality of most enterprise architecture information is likely to do only limited harm to government assets, personnel, or missions. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some of the background information that supports development of Federal enterprise architecture can reveal sensitive vulnerabilities, capabilities, or methods of anti-terrorism, law enforcement, or national security activities.13 Depending on the information in question, the confidentiality impact can be moderate, high, or involve national security information (outside the scope of this guideline). Also, some enterprise architecture plans of some Federal agencies are themselves national security information. Finally, important financial decisions and planning information may be included in this category of information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for enterprise architecture information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the enterprise architecture information. The enterprise architecture processes are usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for enterprise architecture information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications that contain enterprise architecture information (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Public confidence consequences will be more serious for agencies that have national defense, intelligence, or information security missions. In such cases, the impact may be at least moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "In general, the provisional integrity level recommended for enterprise architecture information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.3.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Planning and Budget",
+                "title": "Strategic Planning",
+                "description": "Strategic Planning entails the determination of long-term goals and the identification of the best approach for achieving those goals. The recommended provisional security categorization for strategic planning information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of the unauthorized disclosure of strategic planning information on the ability of responsible agencies to determine long-term goals and to identify the best approach for achieving those goals. Premature public release of draft plans before internal coordination and review can result in unnecessary damage to public confidence in the agency. This is particularly likely where the release includes unedited internal commentary and discussion. However, the consequence of loss of confidentiality of most strategic planning information is likely to do only limited harm to government assets, personnel, or missions. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some of the background information that supports development of some Federal strategic plans can reveal sensitive vulnerabilities, capabilities, or methods of anti-terrorism, law enforcement, or national security activities. Depending on the information in question, the confidentiality impact can be moderate, high, or involve national security information (outside the scope of this guideline). Also, some strategic plans are themselves national security information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for strategic planning information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the strategic planning information. Strategic planning processes are usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for strategic planning information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications that contain strategic planning information (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Public confidence consequences will be more serious for agencies that have national defense, intelligence, or information security missions. In such cases, the impact may be at least moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for strategic planning information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.3.5"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Planning and Budget",
+                "title": "Budget Execution",
+                "description": "Budget Execution involves day-to-day requisitions and obligations for agency expenditures, invoices, billing dispute resolution, reconciliation, service level agreements, and distributions of shared expenses. The recommended provisional security categorization for budget execution information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of budget execution information on the ability of responsible agencies to manage day-to-day requisitions and obligations for agency expenditures, invoices, billing dispute resolution, reconciliation, service level agreements, and distributions of shared expenses. The effects of loss of confidentiality of most budget execution information are unlikely to pose the threat of serious harm to agency assets, personnel or operations. Special Factors Affecting Confidentiality Impact Determination: The effects of loss of confidentiality of budget execution information can violate privacy regulations, reveal information proprietary to private institutions, and reveal procurement-sensitive information. In aggregate, budget execution information can reveal capabilities and methods that some agencies (e.g., law enforcement, homeland security, national defense, intelligence) consider extremely sensitive. In these cases, the potential harm that can result from unauthorized disclosure ranges from moderate to high to national security-related. In the last case, the information is outside the scope of this document. Public release of sensitive budget execution information can result in unnecessary damage to public confidence in the agency. This is particularly likely where the release includes unedited internal commentary and discussion."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most budget execution information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the budget execution information. The budget execution processes are usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for budget execution information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Where small dollar amounts are modified, the potential damage to an agency\u2019s mission is limited. Special Factors Affecting Integrity Impact Determination: In the case of agreements or transactions involving large monetary values, asset losses, and damage to agency operations, the potential for serious loss of public confidence is high. The consequent integrity impact level is moderate to high. If the budget execution information is time-critical or very sensitive, the integrity impact level may be moderate or high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most budget execution information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.3.6"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Planning and Budget",
+                "title": "Workforce Planning",
+                "description": "Workforce Planning involves the processes for identifying the workforce competencies required to meet the agency\u2019s strategic goals and for developing the strategies to meet these requirements. The recommended security categorization for workforce planning information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of workforce planning information on the ability of responsible agencies to identify workforce competencies required to meet the agency\u2019s strategic goals and for developing the strategies to meet these requirements. Unauthorized disclosure of most workforce planning information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some background information that supports development of Federal workforce plans can reveal sensitive vulnerabilities, tables of organization, capabilities, or methods of anti-terrorism, law enforcement, or national security activities. Depending on the information in question, the confidentiality impact can be moderate, high, or involve national security information (outside the scope of this guideline)."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for workforce planning information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the workforce planning information. The workforce planning processes are generally tolerant of reasonable delays. In most cases, disruption of access to workforce planning information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for workforce planning information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Therefore, consequences of undetected unauthorized modification or destruction of workforce planning information may compromise the effectiveness of compliance enforcement actions (e.g., by providing violators with a basis for claiming investigative or enforcement irregularities)."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for workforce planning information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.3.7"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Planning and Budget",
+                "title": "Management Improvement",
+                "description": "Management Improvement includes all efforts to gauge the ongoing efficiency of business processes and identify opportunities for reengineering or restructuring. The recommended provisional security categorization for the management improvement information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of management improvement information on the ability of responsible agencies to gauge the ongoing efficiency of business processes and identify opportunities for reengineering or restructuring. Premature public release of draft plans before internal coordination and review can result in unnecessary damage to public confidence in the agency. This is particularly likely where the release includes unedited internal commentary and discussion. However, the consequence of loss of confidentiality of most management improvement information is likely to involve only limited harm to government assets, personnel, or missions. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some background information that supports development of Federal management improvement plans can reveal personnel-sensitive information, including information subject to the Privacy Act of 1974. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Other background information can reveal sensitive vulnerabilities, capabilities, or methods of anti-terrorism, law enforcement, or national security activities. Depending on the information in question, the confidentiality impact can be moderate, high, or involve national security information (outside the scope of this guideline). Also, some strategic plans are themselves national security information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for management improvement information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the management improvement information. The management improvement planning processes are usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for management improvement information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications that contain management improvement information (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Public confidence consequences can be expected to be more serious for agencies that have national defense, intelligence, or information security missions. In such cases, the impact may be at least moderate. Failure to detect malicious modification of personnel information (mostly background information) can result in disruption of some agency operations and disruptive administrative or legal actions."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for management improvement information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.3.8"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Planning and Budget",
+                "title": "Budget and Performance Integration",
+                "description": "Budget and Performance Integration involves activities that align Federal resources allocated through budget formulation, execution, and management actions with examinations of program objectives, performance, and demonstrated results such as Program Performance Assessments, Government Performance Results Act (GPRA) plans and reports, performance-based agency budget submissions, and Financial Management Cost Accounting and Performance Measurement data. Subject to exception conditions described below, the recommended security categorization for the budget and performance integration information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure budget and performance integration information on the abilities of responsible agencies to align Federal resources allocated through budget formulation, execution, and management actions. The consequences of unauthorized disclosure of the majority of budget and performance integration information will result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: The effects of loss of confidentiality of budget and performance integration information can violate privacy regulations, reveal information proprietary to private institutions, and reveal procurement-sensitive information. In aggregate, budget and performance integration information can reveal capabilities and methods that some agencies (e.g., law enforcement, homeland security, national defense, intelligence) consider extremely sensitive. In these cases, the potential harm that can result from unauthorized disclosure ranges from moderate to high to national security-related. In the last case, the information is outside the scope of this document. Public release of sensitive budget and performance integration information can result in unnecessary damage to public confidence in the agency. This is particularly likely where the release includes unedited internal commentary and discussion."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for resource budget and performance integration information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to budget and performance integration information. The budget and performance integration processes are usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for budget and performance integration information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications that contain budget and performance integration information (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Public confidence consequences will be more serious for agencies that have national defense, intelligence, or information security missions. In such cases, the impact may be at least moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for budget and performance integration information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.3.9"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Planning and Budget",
+                "title": "Tax and Fiscal Policy",
+                "description": "Tax and Fiscal Policy encompasses analysis of the implications for economic growth and stability in the United States and the world of Federal tax and spending policies. This includes assessing the sustainability of current programs and policies, the best means for raising revenues, the distribution of tax liabilities, and the appropriate limits on debt. The recommended provisional security categorization for tax and fiscal policy information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "information on the abilities of responsible agencies to analyze the implications for economic growth and stability in the United States and the world of Federal tax and spending policies. The consequences of unauthorized disclosure of the majority of tax and fiscal policy information will result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: The effects of loss of confidentiality of tax and fiscal policy information can be more critical during the policy development process and may severe impacts to the agency mission and privacy information. Premature or accidental public release of sensitive tax and fiscal policy information can result in unnecessary damage to public confidence in the agency. Additionally, premature release of this information may create unfair economic advantages based on economic projections and fiscal policies. In these cases, the potential harm that can result from unauthorized disclosure ranges from moderate to high depending on the mission impacted."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended tax and fiscal policy information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to tax and fiscal policy information. Tax and fiscal policy processes are usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended tax and fiscal policy information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications that tax and fiscal policy information (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Public confidence consequences will be more serious for agencies that have national defense, intelligence, or information security missions. In such cases, the impact may be at least moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for tax and fiscal policy information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.4.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Internal Risk Management and Mitigation",
+                "title": "Contingency Planning",
+                "description": "Contingency planning involves the actions required to plan for, respond to, and mitigate damaging events. The recommended provisional security categorization for the contingency planning information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of contingency planning information on the ability of responsible agencies to plan for, respond to, and mitigate damaging events. Unauthorized disclosure of contingency planning information may equip an adversary with the information necessary to attack a system so that recovery is impaired. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of background information that supports development of Federal contingency plans can reveal sensitive vulnerabilities, capabilities, intelligence assessments, intelligence sources, or methods employed in anti-terrorism, law enforcement, or national security activities. Depending on the information in question, the confidentiality impact can be moderate, high, or involve national security information (outside the scope of this guideline). Also, some contingency plans are themselves national security information. However, the purpose of most contingency planning information is to protect against inadvertent or accidental damaging events rather than against malicious attacks. Even so, in the case of Federal government systems, the case of hostile attacks on systems must be considered. The consequences of unauthorized disclosure of extracts from contingency plans are likely to have negligible to limited adverse effects on agency operations. In such cases, the confidentiality impact would be, at most, low. Unauthorized disclosure of the entire plan to malicious entities may have serious effects. As a result, the consequence of loss of confidentiality of comprehensive contingency plans is likely to involve serious harm to government assets, personnel, or missions. In such cases, the confidentiality impact would be, at least, moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for contingency planning information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the contingency planning information. The effects of disruption of access to contingency planning information or information systems depend on the timing of the disruption. If access to contingency planning information is denied because of a power outage, recovery may be delayed and the work of government agencies disrupted. Special Factors Affecting Availability Impact Determination: The contingency planning processes are usually tolerant of delays. In contrast, the contingency plan implementation process is not tolerant of delays. The consequences of disruption of access to contingency planning information depend on both the period of the outage and the criticality of the disrupted processes. The consequent impact level may range from low to high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for contingency planning information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Errors in contingency plans that result from integrity compromise can result in serious consequences to system recovery capabilities. These can range from incorrect telephone numbers and e-mail addresses on notification lists to erroneous schedules and file designations for database back-ups and archives or software baselines, updates, and patches."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for contingency planning information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.4.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Internal Risk Management and Mitigation",
+                "title": "Continuity of Operations",
+                "description": "Continuity of operations involves the activities associated with the identification of critical systems and processes, and the planning and preparation required to ensure that these systems and processes will be available in the event of a catastrophic event. The recommended provisional security categorization for the continuity of operations information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of continuity of operations information on the ability of responsible agencies to identify critical systems and processes, and to conduct the planning and preparation required to ensure that these systems and processes will be available in the event of a catastrophic event. Unauthorized disclosure of the entire plan to malicious entities may have serious effects. As a result, the consequence of loss of confidentiality of most continuity of operations plans (and comprehensive continuity of operations plans) is likely to do serious harm to government assets, personnel, or missions. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of background information that supports development of Federal continuity of operations plans can reveal sensitive vulnerabilities, capabilities, intelligence assessments, intelligence sources, or methods employed in anti-terrorism, law enforcement, or national security activities. Depending on the information in question, the confidentiality impact can be moderate, high, or involve national security information (outside the scope of this guideline). Unauthorized disclosure of continuity of operations information for critical infrastructures and key national assets may require a high impact level. However, the purpose of most continuity of operations information is to protect against inadvertent or accidental damaging events rather than against malicious attacks. Even so, in the case of Federal government systems, hostile attacks on systems must be considered. The consequences of unauthorized disclosure of extracts from continuity of operations plans are likely to have negligible to limited adverse effects on agency operations. In such cases, the confidentiality impact would be, at most, low. Unauthorized disclosure of continuity of operations information may inform an adversary regarding what facilities and processes are considered to be critical. Such unauthorized disclosure may also equip an adversary with the information necessary to attack a system so that operations are disrupted, and that recovery is impaired. In such cases, the confidentiality impact would be, at least, moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for continuity of operations information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the continuity of operations information. Special Factors Affecting Availability Impact Determination: The effects of disruption of access to continuity of operations information or information systems depend on the timing of the disruption. If access to continuity of operations information is denied because of a power outage, recovery may be delayed and the work of government agencies disrupted. The continuity of operations planning process is usually tolerant of delays. In contrast, the continuity of operations implementation process is not tolerant of delays. The consequences of disruption of access to continuity of operations information depend on both the period of the outage and the criticality of the disrupted processes. The consequent impact level will range from low to high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for continuity of operations information is moderate"
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Errors in continuity of operations plans that result from integrity compromise can result in serious consequences to system recovery capabilities. These can range from incorrect telephone numbers and e-mail addresses on notification lists to erroneous version numbers for database back-ups and archives or software baselines, updates, and patches."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for continuity of operations information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.4.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Internal Risk Management and Mitigation",
+                "title": "Service Recovery",
+                "description": "Service recovery involves the internal actions necessary to develop a plan for resuming operations after a catastrophe occurs, such as a fire or earthquake. The recommended provisional security categorization for the service recovery information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of the unauthorized disclosure of service recovery information on the ability of responsible agencies to develop plans for resuming operations after a catastrophe occurs, such as a fire or earthquake. In the case of service recovery plans for natural catastrophes, the information associated with service recovery planning is not intrinsically sensitive. In the case of catastrophes caused by malicious activity, unauthorized disclosure of service recovery information may inform an adversary regarding what facilities and processes are considered to be critical. Such unauthorized disclosure may also equip an adversary with the information necessary to attack a system in such a way that operations are disrupted, and that recovery is impaired or even blocked. The purpose of most service recovery information is to protect against natural catastrophes rather than against malicious attacks. In most cases, the consequence of loss of confidentiality of service recovery information is not likely to do serious harm to government assets, personnel, or missions. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of background information that supports development of Federal service recovery plans can reveal sensitive vulnerabilities, capabilities, intelligence assessments, intelligence sources, or methods employed in anti-terrorism, law enforcement, or national security activities. Depending on the information in question, the confidentiality impact can be moderate, high, or involve national security information (outside the scope of this guideline). Also, some service recovery plans are themselves national security information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for service recovery information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the service recovery information. The effects of disruption of access to service recovery information or information systems depend on the timing of the disruption. If access to service recovery information is denied because of a power outage, recovery may be delayed and the work of government agencies disrupted. Special Factors Affecting Availability Impact Determination: Service recovery planning processes are usually tolerant of delay. In contrast, the implementation of recovery plans is not tolerant of delays. For service recovery implementation, the consequences of access disruption depend on the time period of the disruption and the criticality of the disrupted processes. The consequent impact level may range from low to high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for service recovery information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for service recovery information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.5.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Revenue Collection",
+                "title": "Debt Collection",
+                "description": "Debt Collection supports activities associated with the collection of money owed to the United States government from both foreign and domestic sources. The recommended security categorization for debt collection information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of debt collection information on the ability of responsible agencies to properly and efficiently collect money owed to the United States government from both foreign and domestic sources. The consequences of unauthorized disclosure of debt collection information are generally dependent on the identity of the debtor and of the nature and value of the debt being collected. Typically, unauthorized disclosure of debt collection information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will commonly be personal information subject to the Privacy Act of 1974, information that is proprietary to a corporation or other organization, or information that is politically sensitive by a foreign government. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Such information will often be associated with debt collection processes. Where the amount of the debt is significant, and unauthorized knowledge might imperil successful collection, then the associated confidentiality impact assigned to debt collection information might be moderate (or even high in the case of extremely high dollar value cases)."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for debt collection information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the debt collection information. Most Federal debt collection processes are tolerant of delays. Also, the consequences of temporary inability to access information concerning foreign or domestic debt will be minimal."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for debt collection information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Therefore, the consequences of unauthorized modification or destruction of debt collection information depend on the type of property being managed and on the immediacy with which the information is expected to be used. Special Factors Affecting Integrity Impact Determination: If the modified or destroyed information is substantive financial data, there is a greater potential for harm to result from actions being taken based on incomplete or false information. This can have serious adverse effects on individual financial actions with consequent loss of revenue from, or other unanticipated consequences regarding the personal property under disposition. The severity of the consequences depends on the type of the debt and of the debtor but would be most likely be moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for debt collection information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.5.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Revenue Collection",
+                "title": "User Fee Collection",
+                "description": "User fee Collection involves the collection of fees assessed on individuals or organizations for the provision of Government services and for the use of Government goods or resources (i.e. National Parks). The recommended security categorization for the user fee collection information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of user fee collection information on the ability of responsible agencies to correctly and efficiently enforce, regulate, and effect the collection of fees assessed on individuals or organizations for the provision of Government services and for the use of Government goods or resources. In general, particularly in aggregate, this information is public record."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The recommended provisional confidentiality impact level for user fee collection information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the user fee collection information. The missions supported by user fee collection information are generally tolerant of delay. However, any extended period of unavailability would likely be seriously disruptive to the operations for which fees are collected."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for user fee collection information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. For example, there may be some circumstances when the unauthorized modification or destruction of user fee collection information is undertaken as part of a scheme to divert payments, conceal underpayment of failure to make payment of fees, or otherwise defraud the government. In addition, the consequences of unauthorized modification or destruction of user fee collection information may depend on the urgency with which the information is needed or the immediacy with which the information is used. In most cases, it is unlikely that the information will be needed urgently or acted upon immediately. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications might have an adverse effect on agency operations, image and reputation. The integrity impact level assigned may be moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for user fee collection information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.5.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Revenue Collection",
+                "title": "Federal Asset Sales",
+                "description": "Federal Asset Sales encompasses the activities associated with the acquisition, oversight, tracking, and sale of non-internal assets managed by the Federal Government with a commercial value and sold to the private sector. The recommended security categorization for the Federal asset sales information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of the unauthorized disclosure of Federal asset sales information on the ability of responsible agencies to properly and efficiently acquire, oversee, track, and sell non-internal assets managed by the Federal Government with a commercial value and sold to the private sector. The consequences of unauthorized disclosure of Federal asset sales information are generally dependent on the nature and value of the property being disposed. Generally, Federal asset sales information is public. Most managed property would not be of sufficient individual value to occasion such an occurrence (bid rigging, etc.). Special Factors Affecting Confidentiality Impact Determination: Where unauthorized knowledge regarding the property being disposed of might lead to unfair advantage (i.e., ability to accurately bid on an auction lot to the detriment of other bidders), then the associated confidentiality impact assigned to Federal asset sales information might be moderate. Such an instance might arise if a disruption of the proper procedures could reasonably cause an adverse effect on future operations of the responsible agency, or if the agency\u2019s image, or individual reputations might be damaged."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for Federal asset sales information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the Federal asset sale information. The missions supported by Federal asset sale information are generally tolerant of delay. Generally, the consequences of temporary inability to access solicitations for bid, official notices of disposition, etc., will be minimal."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for Federal asset sale information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of Federal asset sale information is partially dependent on the type of property being managed and whether the data is time-critical. If the modified or destroyed information is substantive financial data, actions that are taken based on incomplete or false information could have serious adverse effects on individual financial actions. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, solicitations for bid, official notices of disposition, etc.) may adversely affect the operations, image or reputation of an agency. However, the damage to the management mission would usually be of more immediate concern. The severity of the consequent integrity impact depends on the nature of the property but would be most likely be moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for Federal asset sales information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.6.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Public Affairs",
+                "title": "Customer Services",
+                "description": "Customer Service supports activities associated with providing and managing the delivery of information and support to the government\u2019s customers. The recommended security categorization for the customer service information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of customer service information on the ability of responsible agencies to provide and manage the delivery of information and support to the government\u2019s customers. Most customer service information is likely to be in the public domain and poses no confidentiality impact. In most cases, unauthorized disclosure of customer service information will have at most a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Some customer service information may include customer-provided information covered by the provisions of the Privacy Act of 1974. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Unauthorized disclosure of large volumes of information protected under the Privacy Act can be expected to have a serious to severe effect on public confidence in the agency. Actions taken that are intended to establish blame, compensate victims, or repair damage done with the exposed information can cause serious disruption of an agency\u2019s mission capability. In such cases, the confidentiality impact can be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for customer service information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the customer service information. The effects of disruption of access to or use of customer service information can usually be In addition, customer service operations are not typically tolerant of delay. Even temporary loss of availability of customer service information is likely to disrupt customer operations. In most cases, disruption of access to customer service information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: While most outages will result in only limited adverse effects on government operations, repeated outages can have a serious adverse effect on public confidence in the agency. In such cases, the availability impact might be moderate."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for customer service information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Typically, the adverse effects of unauthorized modification or destruction of customer service information on overall agency mission functions or public confidence in the agency are limited. The more serious integrity impacts become increasingly likely as E-government initiatives progress. Typically, the unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) will result in limited adverse affect on operations or public confidence in the agency and the damage to most missions would usually be limited. Special Factors Affecting Integrity Impact Determination: An increasing proportion of customer service activities are interactive. Consequently, there is a potential for customer actions being taken based on modified or incomplete information. Similarly, unauthorized modification or deletion of customer-supplied information can result in government mishandling of interactions with customers. If this occurs on a large-scale serious damage to public confidence in the agency may result. In such cases, a moderate integrity may be associated with customer service information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for customer service information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.6.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Public Affairs",
+                "title": "Official Information Dissemination",
+                "description": "Official Information Dissemination includes all efforts to provide official government information to external stakeholders through the use of various types of media, such as video, paper, web, etc. The recommended security categorization for the official information dissemination information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of official information dissemination information on the ability of responsible agencies to provide official Federal government information to external stakeholders through the use of various communications media. Official information dissemination information is usually in the public domain and poses no confidentiality impact."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for official information dissemination information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "mission, not on the time required to re-establish access to the official information dissemination information. Official information dissemination processes are generally tolerant of limited delays. However, even temporary loss of availability of official information dissemination information is likely to have an adverse effect on public confidence in the agency. In most cases, disruption of access to official information dissemination information can be expected to have only a limited adverse effect on overall agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: While most cases will result in only limited consequences, repeated outages can have a serious adverse effect on public confidence in the agency. This can significantly degrade the official information dissemination mission capability. In such cases, the availability impact might be moderate."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for official information dissemination information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In general, the adverse effects of unauthorized modification or destruction of official information dissemination information on overall agency mission functions will be limited. Special Factors Affecting Integrity Impact Determination: There is a potential for customer actions taken based on modified or incomplete information. In addition, unauthorized modification or destruction of official information dissemination information may result in distribution of false and misleading information (e.g., modified web pages, electronic mail, video). Such events can adversely affect operations or public confidence in the agency. This can significantly degrade the official information dissemination mission capability. In such cases, a moderate integrity impact may exist. Also, the more serious integrity impacts become increasingly likely as E-government initiatives progress."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for official information dissemination information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.6.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Public Affairs",
+                "title": "Product Outreach",
+                "description": "Product Outreach relates to the marketing of government services products, and programs to the general public in an attempt to promote awareness and increase the number of customers/beneficiaries of those services and programs. The recommended security categorization for the product outreach information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of product outreach information on the ability of responsible agencies to market government services products, and programs to the general public in an attempt to promote awareness and increase the number of customers/beneficiaries of those services and programs. Product outreach information is usually in the public domain and poses no confidentiality impact."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for product outreach information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the product outreach information. Product outreach processes are generally tolerant of limited delays. In most cases, disruption of access to product outreach information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for product outreach information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In most cases, the adverse effect of unauthorized modification or destruction of product outreach information on overall agency mission functions will be limited. Special Factors Affecting Integrity Impact Determination: The unauthorized modification or destruction of product outreach information may result in distribution of false and misleading information. Such events may adversely affect operations or public confidence in the agency and may significantly degrade the product marketing mission capability. In such cases, a moderate integrity impact may exist."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for product outreach information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.6.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Public Affairs",
+                "title": "Public Relations",
+                "description": "Public Relations activities involve the efforts to promote an organizations image through the effective handling of citizen concerns. The recommended security categorization for the public relations information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of public relations information on the ability of responsible agencies to promote an organizations image through the effective handling of citizen concerns. Public relations information itself is usually in the public domain and poses no confidentiality impact. Special Factors Affecting Confidentiality Impact Determination: Internal correspondence associated with development of public relations information can contain information, the unauthorized disclosure of which can have a serious adverse effect on agency operations. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for public relations information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the public relations information. Public relations processes are generally tolerant of limited delays. In most cases, disruption of access to public relations information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for public relations information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In most cases, the adverse effects of unauthorized modification or destruction of public relations information on overall agency mission functions will be limited. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of public relations information may result in distribution of false and misleading information. Such events can be expected to adversely affect operations and/or public confidence in the agency. This can significantly degrade the public relations mission capability. In such cases, a moderate integrity impact may exist."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for public relations information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.7.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Legistlative Relations",
+                "title": "Legislation Tracking",
+                "description": "Legislation Tracking involves following legislation from conception to adoption. The recommended security categorization for the legislation tracking information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of legislation tracking information on the ability of responsible agencies to follow legislation from conception to adoption. Legislation tracking information itself is usually in the public domain and poses no confidentiality impact. Special Factors Affecting Confidentiality Impact Determination: In some cases, internal correspondence associated with legislation tracking information can contain information, that if improperly disclosed, will have a serious adverse effect on agency relationships with other agencies and with the legislative branch. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for legislation tracking information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the legislation tracking information. Legislation tracking processes are generally tolerant of limited delays. In most cases, disruption of access to legislation tracking information will have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for legislation tracking information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In most cases, the adverse effects of unauthorized modification or destruction of legislation tracking information on overall agency mission functions will be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for legislation tracking information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.7.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Legislative Relations",
+                "title": "Legislative Testimony",
+                "description": "Legislation Testimony involves activities associated with providing testimony/evidence in support or, or opposition to, legislation from conception to adoption. Subject to exception conditions described below, the recommended security categorization for the legislation testimony information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of legislation testimony information on the ability of responsible agencies to provide testimony/evidence in support or, or opposition to, legislation from conception to adoption. Most testimony regarding legislation is in the public domain, and even premature release should result in no more than limited harm to agency assets, personnel, or operations. Special Factors Affecting Confidentiality Impact Determination: The effects of loss of confidentiality of some information applicable to pending testimony may result in attempts by competing interests to influence and/or impede a specific legislative process. The consequences to agency programs and of the ability of an agency to perform its mission can be very serious. Premature public release of draft testimony before internal coordination and review has been conducted can result in unnecessary criticism of the proposed testimony and damage public confidence in the agency. These consequences are particularly likely where the release includes unedited internal commentary and discussion. The results of unauthorized disclosure of information to the public can imperil specific agency programs, but a consequent loss of public confidence can do persistent harm to an agency\u2019s ability to effectively perform its mission. This can result in assignment of a moderate impact level to such information. Some information associated with legislative testimony is classified national security information and is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for legislation testimony information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the legislation testimony information. The legislation testimony processes are usually tolerant of delays. Special Factors Affecting Availability Impact Determination: Excessive recovery delays can result in damage to agency reputation and to interests associated with specific legislation. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for legislation testimony information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external publication of testimony associated with legislation (e.g., web pages, electronic mail) may adversely affect inter-agency relationships, relations with Congress, or public confidence in the agency. However, damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for legislation testimony information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.7.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Legislative Relations",
+                "title": "Proposal Development",
+                "description": "Proposal Development involves drafting proposed legislation that creates or amends laws subject to Congressional legislative action. Subject to exception conditions described below, the recommended security categorization for the proposal development information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of proposal development information on the ability of responsible agencies to draft proposed legislation that creates or amends laws subject to Congressional legislative action. Legislation is normally in the public domain. However, the effects of loss of confidentiality of background information used in the development of proposed legislation or of early drafts of proposed legislation could result in attempts by competing interests to influence and/or impede a specific legislative process. The consequences to agency programs and of the ability of an agency to perform its mission can be very serious. Premature public release of proposed legislation before internal coordination and review has been conducted can result in unnecessary criticism of the proposed legislation and even damage public confidence in the agency. These consequences are particularly likely where the release includes unedited internal commentary and discussion. In general, unauthorized disclosure of much legislative proposal information, particularly in early phases of the process, is likely to result in serious harm to agency assets or operations. 40 Special Factors Affecting Confidentiality Impact Determination: Some proposal development information used by specific Federal agencies (e.g., homeland security, law enforcement, defense, intelligence community) is very sensitive or classified national security information. National security information is outside the scope of this guideline. The sensitivity level recommended for the very sensitive information is high. If the proposal development information is moved to the public domain, the confidentiality impact level becomes Not Applicable (NA)."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "In order to accommodate event-driven consequences of unauthorized disclosure of pre-release drafts, the provisional confidentiality impact level recommended for proposal development information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the proposal development information. Proposal development processes are usually tolerant of delays. Special Factors Affecting Availability Impact Determination: Excessive recovery delays can result in damage to agency reputation and to interests associated with specific legislation. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for proposal development information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external publication of proposed legislation (e.g., web pages, electronic mail) might adversely affect inter-agency relationships, relations with Congress, or public confidence in the agency. However, damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for proposal development information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.7.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Legislative Relations",
+                "title": "Congressional Liaison Operations",
+                "description": "Congressional Liaison Operations involves all activities associated with supporting the formal relationship between a Federal Agency and the U.S. Congress. Subject to exception conditions described below, the recommended security categorization for the Congressional liaison information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of Congressional liaison information on the ability of responsible agencies to support their formal relationships with U.S. Congress. The effects of loss of confidentiality of information associated with Congressional liaison can facilitate attempts by competing interests to influence and/or impede a specific legislative process or poison inter-branch relations. The consequences to agency programs and even of the ability of an agency to perform its mission can be very serious. Premature public release of information associated with Congressional liaison before internal coordination and review has been conducted can result in unnecessary criticism of the preliminary data or positions, and even damage public confidence in the agency. These consequences are particularly likely where the release includes unedited internal commentary and discussion. In general, unauthorized disclosure of much Congressional liaison information is likely to result in serious harm to agency assets and/or operations. If the Congressional liaison information is moved to the public domain, the confidentiality impact level becomes Not Applicable (NA). Special Factors Affecting Confidentiality Impact Determination: Some Congressional liaison information used by Federal agencies (e.g., homeland security, law enforcement, defense, intelligence community) is very sensitive or even classified national security information. National security information is outside the scope of this guideline. The sensitivity level associated with the very sensitive information is high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for Congressional liaison information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the Congressional liaison information. Congressional liaison processes are usually tolerant of delays. Special Factors Affecting Availability Impact Determination: Excessive recovery delays can result in damage to agency reputation and to interests associated with specific legislation. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for Congressional liaison information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for Congressional liaison information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Central Fiscal Operations",
+                "description": "Central Fiscal Operations includes the fiscal operations that the Department of Treasury performs on behalf of the Government.14 [Note: Tax-related functions are associated with the Taxation Management information type.] Impacts to some information and information systems associated with central fiscal operations may affect the security of the critical banking and finance infrastructure. In most cases, the effect on public welfare of a loss of central fiscal operations functionality can be expected to be delayed rather than immediate. The potential for consequent loss of human life or of major national assets is low. . The provisional security categorization recommended for the central fiscal operations information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of central fiscal operations information on the fiscal operations that the Department of Treasury performs on behalf of the Government. The effects of loss of confidentiality can reasonably be expected to jeopardize relationships and administrative actions necessary to mission fulfillment and/or to seriously damage public confidence in the agency. For example, the unauthorized disclosure of investigative and enforcement information can have serious economic impact on both individual companies and the broader market place (e.g., short-term stock market perturbations). The consequences of such unauthorized disclosures may have a serious adverse effect on public confidence in the agency. Special Factors Affecting Confidentiality Impact Determination: Where the operations in question involve liaison with law enforcement or homeland security organizations, the consequences of unauthorized disclosure can imperil operations critical to the security of human life, critical infrastructure protection, ore the protection of key national assets. For those operations, the consequences to key financial infrastructure elements can be serious to severe. In such cases, the associated confidentiality impact level will be high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The confidentiality impact level recommended for most central fiscal operations information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the central fiscal operations information. Central fiscal operations processes are usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for central fiscal operations information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external communications that include central fiscal operations information (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for central fiscal operations information is normally low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Legislative Functions",
+                "description": "Legislative functions include the service support activities associated with costs of the Legislative Branch other than the Tax Court, the Library of Congress, and the Government Printing Office revolving fund. The recommended security categorization for the legislative service support information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of legislative functions information on the ability of responsible agencies to provide service support activities associated with costs of the Legislative Branch other than the Tax Court, the Library of Congress, and the Government Printing Office revolving fund. The effects of loss of confidentiality of information associated with legislative functions can be expected to have only a limited impact on Federal government assets, operations, or personnel welfare."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for legislative functions information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the legislative service support information. Legislative functions processes are usually tolerant of delays. Special Factors Affecting Availability Impact Determination: Excessive recovery delays can result in damage to agency reputation and to interests associated with specific legislation. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for legislative functions information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Misunderstandings resulting from modified information that is actually exchanged can usually be resolved and any resulting damage to the support function from modified information that is exchanged would usually be limited. Unauthorized modification or destruction of information affecting external publication of legislative service support information (e.g., web pages, electronic mail) may adversely affect inter-agency relationships, relations with Congress, or public confidence in the agency. However, damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for legislative functions information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Executive Functions",
+                "description": "Subject to exception conditions described below, the recommended provisional security categorization for the executive information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level associated with the executive information type is associated with executive functions. The effects of loss of confidentiality of policies and guidance during the formative stage can result in attempts by affected entities and other interested parties to influence and/or impede the policy and guidance development process. Premature public release of formative policies and guidance before internal coordination and review can result in unnecessary damage to public confidence in the executive office. These consequences may occur when the release includes unedited internal commentary and discussion."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for executive functions information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the executive information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for executive functions information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external communications that contain executive information (e.g., web pages, electronic mail) may adversely affect public confidence in the government."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for executive information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Central Property Management",
+                "description": "Central Property Management involves most of the operations of the General Services Administration. The following recommended provisional security categorization of central property management information is particularly subject to change where critical infrastructure elements or key national assets are involved:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of central property management information on the ability of the General Services Administration to acquire, provide, and centrally administer offices buildings, fleets, machinery, and other capital assets and consumable supplies used by the Federal government. The consequences of unauthorized disclosure of most central property management information are likely to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of information associated with very large procurements can result in fraud, waste, abuse, and/or legal proceedings that can have a serious to severe effect on Federal government assets and operations. Also, information associated with acquisition, maintenance, administration, and operation of many Federal government office buildings, transportation fleets, and operational facilities can be of material use to criminals seeking to gain access to Federal facilities to facilitate or perpetrate fraud, theft, or some other criminal enterprise. In this case, unauthorized disclosure of information can have a serious adverse effect on agency operations, agency assets, or individuals. The consequent confidentiality impact would be at least moderate. Information associated with maintenance, administration, and operation of other Federal government facilities can be of material use to terrorists seeking to penetrate and/or commandeer such facilities as part of operations intended to harm critical infrastructures, key national assets, or people. Examples of more potentially damaging information include architectural, maintenance and administrative information that might permit either covert pedestrian or unimpeded vehicular access to government buildings (e.g., Congressional office buildings, FBI Headquarters, the National Archives, Smithsonian Institution buildings, dams, nuclear power plants, etc.). In such cases, the confidentiality impact level may be high. [Some information is classified as national security and is outside the scope of this guideline.] Anticipated or realized unauthorized disclosure of one agency\u2019s central property management information by GSA could result in negative impacts on cross-jurisdictional coordination within the central property management infrastructure and the general effectiveness of organizations tasked with acquiring and managing government facilities and supplies."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for central property management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the central property management information. The functions supported by most central property management information are tolerant of delays. Typically, the disruption of access to central property management information will have a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Exceptions may include emergency response aspects of disaster management. In such cases, delays measured in hours can cost lives and major property damage. Consequently, the availability impact level associated with unauthorized modification or destruction of central property management information needed to respond to emergencies may be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for central property management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In addition, the consequences of unauthorized modification or destruction of central property management information usually depends on the urgency with which the information is needed or the immediacy with which the information is used. In most cases, it is unlikely that the information will be time-critical or acted upon immediately. Unauthorized modification or destruction of information affecting external publication of central property management information (e.g., web pages, electronic mail) may adversely affect public confidence in the agency. However, damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for central property management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.5"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Central Personnel Management",
+                "description": "Central Personnel Management involves most of the operating activities of the Office of Personnel Management and related agencies. The recommended security categorization for the central personnel management information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of central personnel management information on the ability of the Office of Personnel Management (OPM) to build a high quality and diverse Federal workforce, based on merit system principles. Central personnel management information includes human resources management and consulting services, education and leadership development services, and investigation services. The unauthorized disclosure of most central personnel management information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Very sensitive information is typically personal information subject to the Privacy Act of 1974. (The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type.) Such information will often be assigned a moderate confidentiality impact level. Some information associated with investigative services may be particularly sensitive and require a high confidentiality impact level."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for central personnel management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the central personnel management information. Central personnel management processes are generally tolerant of reasonable delays. In most cases, disruption of access to central personnel management information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for central personnel management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of undetected unauthorized modification or destruction of central personnel management information can conceivably disrupt central personnel management operations (e.g., (e.g., by modifying sensitive private personal information or compromising confidentiality mechanisms). Unauthorized modification or destruction of information affecting external publication of central personnel management information (e.g., web pages, electronic mail) may adversely affect public confidence in the government. However, damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for central personnel management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.6"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Taxation Management",
+                "description": "Taxation Management includes activities associated with the implementation of the Internal Revenue Code and the collection of taxes in the United States and abroad. The recommended security categorization for the taxation management information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of taxation management information on the ability of the Internal Revenue Service (IRS) to enforce the Internal Revenue Code and to collect taxes in the United States and abroad. The IRS Guidebook for Information Sensitivity Analysis provides guidelines for identifying IRS Official Use Only (OUO) Information. Sensitive information is identified in the IRM as any information which if lost, stolen, (accessed), or altered without proper authorization may adversely affect Service operations. The IRM states that unauthorized disclosure of sensitive information may cause lawsuits against Service officials as well as the Service, unwanted notoriety for the Service, and public distrust of the Service\u2019s ability to protect such information \u2013 all of which may result in an increase in noncompliance with tax laws. It notes that unauthorized release of information such as the name and address of an informant (in cases of tax evasion or fraud) may threaten a person\u2019s life.17 Additionally, sensitive information is defined in Section 25.10 of the IRM as information that requires protection due to the risk or magnitude of loss that could result from inadvertent or deliberate disclosure of the information. Sensitive information includes information whose improper use could adversely affect the ability of the agency to accomplish its mission, proprietary information, records about individuals that require protection under the Privacy Act, and information not releasable under the Freedom of Information Act. The IRS OUO guideline notes that prevention of unauthorized disclosure of information revealing internal matters, the disclosure of which would risk circumvention of a legal requirement or agency rules and regulations has assumed an increasingly important role in homeland security. Unauthorized disclosure of sensitive or private IRS information can be expected to have a serious effect on both the welfare of individuals and public confidence in the government. Special Factors Affecting Confidentiality Impact Determination: In cases where unauthorized disclosure of taxation information can impede anti-terrorism or other homeland security activities or endanger the lives of agents or informants, the confidentiality impact level is high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for taxation management information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the taxation management information. Taxation management processes are generally tolerant of limited delays. In most cases, disruption of access to taxation management information can be expected to have only a limited adverse effect on overall agency operations, agency assets, or individuals. However, even temporary loss of availability of taxation management information is likely to have an adverse effect on public confidence in the agency and on Federal government cash flow. Special Factors Affecting Availability Impact Determination: While most cases will result in only limited consequences, repeated disruptions can have a serious adverse effect on public confidence in the agency. This can significantly degrade the taxation management mission capability. In such cases, the availability impact might be moderate. Loss of availability of significant amounts of taxation management information over long periods of time can do serious harm to Federal government operations. The economic ramifications would potentially be severe."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for taxation management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In addition, the consequences of unauthorized modification or destruction of taxation management information may depend on the urgency with which the information is needed or the immediacy with which the information is used. In most cases, it is unlikely that the information will be needed urgently or acted upon immediately. Also, the adverse effects of unauthorized modification or destruction of taxation management information on overall agency mission functions is expected to be limited. Special Factors Affecting Integrity Impact Determination: There is a potential for tax code enforcement, other law enforcement, or anti-terrorism actions being taken based on modified or incomplete information. Also, unauthorized modification or destruction of taxation management information may result in distribution of false and misleading information. Such events can be expected to adversely affect individuals, operations, and/or public confidence in the agency. This can significantly degrade the taxation management mission capability. In extreme cases (e.g., misidentification of an informant), the consequences can be life threatening. In such cases, a high integrity impact may exist."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for taxation management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.7"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Central Records and Statistics Management",
+                "description": "Central Records and Statistics Management involves the operations surrounding the management of official documents, statistics, and records for the entire Federal Government. This information type is intended to include information and information systems associated with the management of records and statistics for the Federal government as a whole, such as the records management performed by NARA or the statistics and data collection performed by the Bureau of the Census. Note: Many agencies perform records and statistics management for a particular business function and as such should be mapped to the service support, management, or mission area associated with that business function. The central records and statistics management information type is intended for functions performed on behalf of the entire Federal government. The recommended security categorization for the central records and statistics management information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of central records and statistics management information on the ability of responsible agencies to manage official documents, statistics, and records for the entire Federal Government. Unauthorized disclosure of raw data and other source information for central records and statistics management operations is likely to violate the Privacy Act of 1974 and other regulations applicable to the dissemination of personal and government information. (The provisional impact levels for personnel information are documented in the Personal Identity and Authentication, Income, Representative Payee, and Entitlement Event information types.) Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some centrally managed records can pose a threat to human life or a loss of major assets. In such cases, the confidentiality impact is high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for central records and statistics management information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the central records and statistics management information. Central records and statistics management processes are generally tolerant of reasonable delays. Generally, disruption of access to central records and statistics management information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for central records and statistics management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In addition, the consequences of unauthorized modification or destruction of central records and statistics management information may depend on the urgency with which the information is needed or the immediacy with which the information is used. In most cases, it is unlikely that the information will be time-critical or acted upon immediately."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for central records and statistics management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.8"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Income Information",
+                "description": "Income information includes all the wages, self-employment earnings, savings data and other financial resources information that is needed to help determine the amount of Retirement, Survivor, or Disability benefits that individuals may be entitled to receive or not receive from the Supplementary Security Income or RSDI Title II Programs. In most cases, the impact levels are based on the effects of unauthorized disclosure, modification, or loss of availability of income information on the ability of the Federal government to identify citizen entitlements and obligations and to protect individuals against identity theft and the Federal government against fraud. The recommended security categorization for the income information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is based on the effects of unauthorized disclosure of income information on the ability of the Federal government to identify citizen entitlements and obligations and to protect individuals against identity theft and the Federal government against fraud. Unauthorized disclosure of raw data and other source information for benefits determination and revenue collection operations is likely to violate the Privacy Act of 1974 and other regulations applicable to the dissemination of personal and government information. Unauthorized disclosure of centrally managed income information can have a serious adverse effect on agency missions. Therefore, for agencies that manage large income information involving records of the general public, the provisional confidentiality impact level can be expected to be at least moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for income information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific purpose to which income information is put; and not on the time required to re-establish access to the income information. Benefits determination and liability calculation (e.g., taxation) processes are generally tolerant of reasonable delays. In many cases, disruption of access to income information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: In the case of very large data bases containing income information relating to the general public, there is a significant probability that processing delays will affect the benefits entitlements or liabilities (e.g., tax liabilities) of large numbers of individuals. The larger the number of records affected, the longer the delays that can be expected to result. This can result in financial hardship for citizens and in serious disruption of the agency operations due to large time and resource requirements for backlog processing. In such cases, the availability impact level would be at least moderate. In the case of permanent loss of records, the impact might even be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for income information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific purpose to which income information is put; and not on the time required to detect the modification or destruction of information. In the case of very large data bases containing income information relating to the general public, there is a significant probability that erroneous actions will be taken affecting the benefits entitlements or liabilities (e.g., tax liabilities) of large numbers of individuals. This can result in at least short-term financial hardship for citizens. It can also be expected to result in very serious disruption of the agency operations due to large time and resource requirements for taking corrective actions. In such cases, the integrity impact level would be at least moderate. Special Factors Affecting Integrity Impact Determination: In the case of smaller organizations, and where the information affected is limited to employees, the consequences may justify only a low provisional impact rating."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for income information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.9"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Personal Identity and Authentication Information",
+                "description": "Personal identity and authentication information includes that information necessary to ensure that all persons who are potentially entitled to receive any federal benefit are enumerated and identified so that Federal agencies can have reasonable assurance that they are paying or communicating with the right individuals. This information include individual citizen\u2019s Social Security Numbers, names, dates of birth, places of birth, parents\u2019 names, etc.18 The recommended security categorization for the personal identity and authentication information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is based on the effects of unauthorized disclosure of personal identity and authentication information on the ability of Federal agencies to determine that communications with and payments to individuals are being made with or to the correct individuals - and to protect individuals against identity theft and the Federal government against fraud. Unauthorized disclosure of raw data and other source information for identity authentication operations is likely to violate the Privacy Act of 1974 and other regulations applicable to the dissemination of personal and government information. There are many cases in which unauthorized disclosure of personal identity and authentication information will have only a limited adverse effect on government operations, assets, or individuals. However, the potential for use of such information by criminals to perpetrate identity theft and related fraud can do serious harm to individuals. Unauthorized disclosure of centrally managed personal identity and authentication information, such as passport and visa control databases can have a serious adverse effect on agency missions. Special Factors Affecting Confidentiality Impact Determination: For agencies that manage large income information involving records of the general public, the provisional confidentiality impact level can be expected to be at least moderate. Where personal identity and authentication information is used in controlling access to facilities (e.g., Federal facilities, critical infrastructure facilities, key national assets) or for border control purposes, the consequences of unauthorized disclosure that permits credentials forgery can justify a high impact assignment."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for personal identity and authentication information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific purpose to which personal identity and authentication information is put; and not on the time required to re-establish access to the personal identity and authentication information. Benefits determination processes are generally tolerant of reasonable delays. In many cases, disruption of access to personal identity and authentication information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: In the case of very large data bases containing personal identity and authentication information relating to the general public, there is a significant probability that processing delays will affect the benefits entitlements of or access to facilities by large numbers of individuals. The larger the number of records affected, the longer the delays that can be expected to result. This can result in financial hardship for citizens and in serious disruption of the agency operations due to large time and resource requirements for backlog processing. In such cases, the availability impact level would be at least moderate. In the case of permanent loss of records or access to facilities by emergency personnel, the impact might even be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for personal identity and authentication information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific purpose to which personal identity and authentication information is put; and not on the time required to detect the modification or destruction of information. In the case of very large databases containing personal identity and authentication information relating to the general public, there is a significant probability that erroneous actions will be taken affecting benefits entitlements of or access to facilities by large numbers of individuals. In the case of benefits, this can result in at least short-term financial hardship for citizens. It can also be expected to result in very serious disruption of the agency operations due to large time and resource requirements for taking corrective actions. Special Factors Affecting Integrity Impact Determination: In the case of smaller organizations, and where the information affected is limited to employees, there will still be an impact, but the consequences may justify only a low provisional impact rating. Where a data modification permits access to facilities (or ingress into the United States) by individuals to whom access should be prohibited, the integrity impact could be high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for personal identity and authentication information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.10"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Entitlement Event Information",
+                "description": "Entitlement event information includes information about events such as death and date of occurrence, date of a disabling event and the relating data that can reasonably prove the severity of such disability, proof of age for retirement benefits, birth and relationship of spouse and/or children who may be entitled to benefits only as auxiliaries of the primary beneficiary, and other related information needed to process a claim for benefits. This also includes means-related information required to administer all the means related benefits associated with the Title XVI (Supplementary Security Income Program) and the new drug provisions of the recently revised Medicare Program. The recommended security categorization for the entitlement event information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is based on the effects of unauthorized disclosure of entitlement event information on the ability of the Federal government to establish qualifications of individuals to receive government benefits - and to protect individuals and the Federal government against fraud. Unauthorized disclosure of raw data and other source information for entitlement operations is likely to violate the Privacy Act of 1974 and other regulations applicable to the dissemination of personal information. Unauthorized disclosure of centrally managed entitlement event information can have a serious adverse effect on agency missions. Therefore for agencies that manage large income information involving records of the general public, the provisional confidentiality impact level can be expected to be at least moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for entitlement event information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific use of the entitlement event information and not on the time required to re-establish access to the income information. Benefits determination processes are generally tolerant of reasonable delays. In many cases, disruption of access to entitlement event information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: In the case of very large data bases containing entitlement event information relating to the general public, there is a significant probability that processing delays will affect the benefits entitlements of large numbers of individuals. The larger the number of records affected, the longer the delays that can be expected to result. This can result in financial hardship for citizens. It can also result in very serious disruption of the agency operations due to large time and resource requirements for backlog processing. In such cases, the availability impact level would be at least moderate. In the case of permanent loss of records, the impact might even be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for income information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific use of the entitlement event information and not on the time required to detect the modification or destruction of information. In the case of very large databases containing entitlement event information relating to the general public, there is a significant probability that erroneous actions will be taken affecting the benefits entitlements of large numbers of individuals. This can result in at least short-term financial hardship for citizens. It can also be expected to result in serious disruption of the agency operations due to the time and resource requirements for taking corrective actions. In such cases, the integrity impact level would be at least moderate. Special Factors Affecting Integrity Impact Determination: In the case of smaller organizations, and where the information affected is limited to employees, the consequences may justify only a low provisional impact rating."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for entitlement event information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.11"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "Representative Payee Information",
+                "description": "Representative payee information includes the information required to determine the need for representative payees and the data that is gathered to make the determination of who should serve as the representative payee for all beneficiaries of federal benefits who are unable to manage their own funds. This also includes accountability information required to provide reasonable assurance that the funds are being used appropriately for the well being of entitled individuals. The recommended security categorization for the representative payee information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is based on the effects of unauthorized disclosure of representative payee information on the ability of the Federal government to determine that entitlement funds are being used appropriately for the well being of entitled individuals - and to protect individuals against identity theft and the Federal government against fraud. Unauthorized disclosure of data for representative payee operations is likely to violate the Privacy Act of 1974 and other regulations applicable to the dissemination of personal information. Unauthorized disclosure of centrally managed representative payee information can have a serious adverse effect on agency missions and on large numbers of individuals. Therefore, in the case of large representative payee information databases, the provisional confidentiality impact level can be expected to be at least moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for representative payee information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific use of the representative payee information and not on the time required to re-establish access to the representative payee information. Benefits payment processes are not necessarily tolerant of delays. In many cases, disruption of access to representative payee information can be expected to have a very serious adverse effect on individuals. Special Factors Affecting Availability Impact Determination: In the case of very large data bases containing representative payee information relating to the general public, there is a significant probability that processing delays will affect the benefits payments to large numbers of individuals. The larger the number of records affected, the longer the delays that can be expected to result. This can result in financial hardship for some individuals and in serious disruption of agency operations. In such cases, the availability impact level would be at least moderate. In the case of permanent loss of records, the impact might even be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for representative payee information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific use of the payee information and not on the time required to detect the modification or destruction of information. In the case of very large databases containing representative payee information relating to the general public, there is a significant probability that erroneous actions will be taken affecting the benefits payments to large numbers of individuals. This can result in at least short-term financial hardship for our most vulnerable citizens. Loss of integrity can result in serious disruption of the agency operations. In such cases, the integrity impact level would be at least moderate. Special Factors Affecting Integrity Impact Determination: In the case of fraudulent diversion of payments intended for particularly dependent individuals, there can be life-threatening consequences. In such cases, a high integrity impact rating may be justified."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for representative payee information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.2.8.12"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Government",
+                "title": "General Information",
+                "description": "An additional management and support sub-function information type has been defined to address General Information as a catch-all information type that may not be defined by the FEA BRM. As such, agencies may find it necessary to identify additional information types not defined in the BRM and assign impact levels to those types. Agency personnel may uniquely identify information types using a FIPS 199 process to identify information not contained neatly in the FEA BRM. Not all of these information types are likely to have the same impact levels. The impacts to some information types will jeopardize system functionality and the agency mission more than other information types. General Information impact levels must be assessed in the context of the agencies mission.",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is based on the effects of unauthorized disclosure of representative general information on the ability of the agency to accomplish its mission."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for general information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific use of the general information and not on the time required to re-establish access to the general information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for general information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific use of the general information and not on the time required to detect the modification or destruction of information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for general information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.1.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Administrative Management",
+                "title": "Facilities, Fleet, and Equipment Management",
+                "description": "Facilities, Fleet, and Equipment management involves the maintenance, administration, certification, and operation of office buildings, fleets, machinery, and other capital assets considered as possessions of the Federal government. Impacts to some information and information systems associated with facilities, fleet, and equipment management may affect the security of some key national assets (e.g., nuclear power plants, dams, and other government facilities). The following recommended provisional categorization of the facilities, fleet, and equipment management information type is particularly subject to change where critical infrastructure elements or key national assets are involved:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of facilities, fleet, and equipment management information on the ability of responsible agencies to maintain, administer, and operate offices buildings, fleets, machinery, and other capital assets of the Federal government. The consequences of unauthorized disclosure of most facilities, fleet, and equipment management information are likely to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Information associated with maintenance, administration, and operation of many Federal government office buildings, transportation fleets, and operational facilities can be of material use to criminals seeking to gain access to Federal facilities in order to facilitate or perpetrate fraud, theft, or some other criminal enterprise (e.g., extract inmates from Federal detention facilities). In this case, unauthorized disclosure of information can have a serious adverse effect on agency operations, agency assets, or individuals. The consequent confidentiality impact would be at least moderate. Information associated with maintenance, administration, and operation of other Federal government office buildings, transportation fleets, and operational facilities can be of material use to terrorists seeking to penetrate and/or commandeer such facilities as part of operations intended to harm critical infrastructures, key national assets, or people. Examples of this information include information that reveals specific measures respecting limiting access to and operation of government aircraft, maintenance and administrative information that might permit either covert pedestrian or unimpeded vehicular access to government buildings (e.g., Congressional office buildings, FBI Headquarters, the National Archives, Smithsonian Institution buildings, dams, nuclear power plants, etc.), and schedules/itineraries of government surface transportation fleets (e.g., for transport of executive personnel or hazardous materials). In these cases, the confidentiality impact must be considered to be high. [Some information regarding transportation and storage of nuclear materials is classified as national security related and is outside the scope of this guideline. Other information, such as Nuclear Regulatory Commission \u201cSAFEGUARDS\u201d information is not national security information, but must have a high confidentiality impact level.] Anticipated or realized unauthorized disclosure of one agency\u2019s facilities, fleet, and equipment management information by another agency could result in negative impacts on cross-jurisdictional coordination within the facilities, fleet, and equipment management infrastructure and the general effectiveness of organizations tasked with facilities, fleet, and/or equipment management."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for facilities, fleet, and equipment management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the facilities, fleet, and equipment management information. Functions supported by most facilities, fleet, and equipment management information are tolerant of delays. Typically, disruption of access to facilities, fleet, and equipment management information has a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Exceptions may include emergency response aspects of disaster management or leadership protection. In such cases, delays measured in seconds can cost lives and major property damage. Consequently, the availability impact level associated with unauthorized modification or destruction of facilities, fleet, and equipment management information needed to respond to emergencies will be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for facilities, fleet, and equipment management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In addition, the consequences of unauthorized modification to or destruction of facilities, fleet, and equipment management information may depend on the urgency with which the information is needed or the immediacy with which the information is used. In most cases, it is unlikely that the information will be time-critical or acted upon immediately. Special Factors Affecting Integrity Impact Determination: Exceptions may include emergency response aspects of disaster management or leadership protection. In such cases, the integrity impact level associated with unauthorized modification or destruction of facilities, fleet, and equipment management information can be high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for facilities, fleet, and equipment management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.1.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Administrative Management",
+                "title": "Help Desk Services",
+                "description": "Help Desk Services involves the management of a service center to respond to government employees' technical and administrative questions. Subject to exception conditions described below, the recommended provisional security categorization for the help desk service information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of help desk service information on the ability of responsible agencies to manage of service center responses to government employees' technical and administrative questions. The consequences of unauthorized disclosure of most help desk service information are likely to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Information associated with service center responses can provide useful information to adversaries seeking to penetrate Federal systems. If the contents or functions of a system have sufficient sensitivity and/or criticality, a moderate or high impact level may be considered for help desk information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for help desk service information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to help desk service information. Typically, disruption of access to help desk service information will have a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Exceptions may include emergency response components of disaster management or other time-critical functions (e.g., some systems that support air traffic control functions). Consequently, the availability impact level associated with unauthorized modification or destruction of help desk service information needed to respond to emergencies can be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for help desk service information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In addition, the consequences of unauthorized modification to or destruction of help desk service information usually depends on the urgency with which the information is needed or the immediacy with which the information is used. In most cases, it is unlikely that the information will be time-critical or acted upon immediately. Special Factors Affecting Integrity Impact Determination: In relatively few cases would the consequences of unauthorized modification of help desk information that is acted upon immediately result in more than limited damage to agency operations or assets. Exceptions may include bogus information regarding operation of communications processors, data base systems, or other systems necessary to emergency response aspects of disaster management, criminal apprehension, air traffic control or other time-critical missions. In such cases, a moderate or high integrity impact level might be considered for unauthorized modification or destruction of help desk service information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "he provisional integrity impact level recommended for help desk service information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.1.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Administrative Management",
+                "title": "Security Management",
+                "description": "Security Management involves the physical protection of an organization\u2019s personnel, assets, and facilities (including security clearance management). Impacts to some information and information systems associated with security management may affect the security of some critical infrastructure elements and key national assets (e.g., nuclear power plants, dams, and other government facilities). Impact levels associated with security information directly relate to the potential threat to human life associated with the asset(s) being protected (e.g., consequences to the public of terrorist access to dams or nuclear power plants). The following recommended categorization of the security management information type is subject to change where critical infrastructure elements or key national assets are involved:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of security management information on the ability of responsible organizations to physically protect their personnel, assets, and facilities. The consequences of unauthorized disclosure of most security management information depend on the likelihood that the information might jeopardize the physical security of an organization\u2019s assets and the value, and potential for damage of the assets being protected. Information associated with the physical security of many Federal government office buildings, transportation fleets, and operational facilities can be of material use to criminals seeking to gain access to Federal facilities in order to perpetrate a major crime (e.g., extraction of inmates from Federal detention facilities, theft of commodities market projections, access to information associated with a felony criminal investigation or prosecution, theft of blank license issuing facilities and/or materials, access to competition-sensitive information associated with major procurements, undetected access to national archives or museum properties, access to currency printing facilities or materials, theft of major currency or bullion storage facilities). In such cases, unauthorized disclosure of information can have a serious adverse effect on agency operations, agency assets, or individuals. Unauthorized disclosure of one agency\u2019s security management information by another agency could result in negative impacts on cross-jurisdictional coordination within the security management infrastructure and the general effectiveness of organizations tasked with physical protection of Federal facilities. The consequences of physical protection failures at most Federal facilities are more likely to result in serious21 adverse effects. Special Factors Affecting Confidentiality Impact Determination: Information associated with security management at other Federal government office buildings, transportation fleets, and operational facilities can be of material use to terrorists seeking to penetrate and/or commandeer such facilities as part of operations intended to harm critical infrastructures, key national assets, or people. Examples of more potentially damaging information includes information that reveals specific measures for protecting government aircraft, information that might permit access that creates an opportunity to bomb a government building (e.g., Congressional office buildings, FBI Headquarters, the National Archives, Smithsonian Institution buildings, dams, nuclear power plants, etc.), and leadership protection details that could result in assassination opportunities. In these cases, the confidentiality impact must be high. Unauthorized disclosure of security management information that can be reasonably expected to pose a serious threat to human life (including those of security guards) must also be assigned a high confidentiality impact. [Security management information associated with some Federal government assets is classified. The classified information is national security related and is outside the scope of this guideline.] Other security management information, such as that affecting Nuclear Regulatory Commission \u201cSAFEGUARDS\u201d or Internal Revenue Service \u201cLimited For Official Use Only\u201d information is not national security information, but must be treated as having high confidentiality impact."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The confidentiality impact level recommended for most security management information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the security management information. Functions supported by most security management information are tolerant of delays. Typically, disruption of access to security management information will have a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Exceptions may include alarm and alert communications and interconnections for security management systems and automated control systems that support security management processes (e.g., door and gate operations in buildings to which access is limited such as detention facilities and many Federal office buildings For these exceptions, the data is time-critical. The availability impact level associated with unauthorized modification or destruction of such alarm, alert, and automated process security management information may be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for security management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of security management information may depend on the urgency with which the information is needed or the immediacy with which the information is used. In cases of intrusion indications, security management information can be time-critical. The consequences of unauthorized modification or destruction of time-critical security management information can reasonably be expected to result in physical security vulnerabilities. The range of potential consequences is covered above in Confidentiality."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most security management information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.1.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Administrative Management",
+                "title": "Travel Information",
+                "description": "Travel involves the activities associated with planning, preparing, and monitoring of business related travel for an organization\u2019s employees. The following security categorization is recommended for the travel information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of travel information on the abilities of responsible agencies to plan, prepare, and monitor business related travel for the organization\u2019s employees. Generally, the consequences of unauthorized disclosure of the majority of travel information will result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of employee identification information coupled with credit information (e.g., name, social security number, credit card number) can result in moderate to serious consequences for individuals and local organizations. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Unauthorized disclosure of information concerning carrier/provider contract negotiations can have significant financial or legal consequences and put an agency at a serious disadvantage. Also, severe consequences may result from unauthorized disclosure of information regarding leadership travel plans that might jeopardize personnel security or the confidentiality of sensitive operations plans. In the most sensitive cases, the confidentiality impact level may be high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for travel information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the travel information. The nature of travel processes is usually tolerant of reasonable delays, at least on the agency mission scale."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for travel information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of travel information partially depends on the urgency with which the information is normally needed and the consequences of aborted or modified travel. In the case of travel planning information, the effects of such modifications are generally limited with respect to agency mission capabilities or assets. There may be scenarios in which integrity compromise of travel information may expose Federal leadership to harm or endanger a sensitive or critical operation. However, most such scenarios are dealt with in the context of impacts to mission operations information (Appendix D)."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for travel information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.1.5"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Administrative Management",
+                "title": "Workplace Policy Development and Management",
+                "description": "Workplace policy development and management includes all activities required to develop and disseminate workplace policies such as dress codes, time reporting requirements, telecommuting, etc. The following security categorization is recommended for the workplace policy development and management information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of workplace policy development and management information on the abilities of responsible agencies to develop and disseminate workplace policies such as dress codes, time reporting requirements, and telecommuting. The consequences of unauthorized disclosure of the majority of workplace policy development and management information will result in a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for workplace policy development and management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the workplace policy development and management information. Generally, workplace policy development and management processes are tolerant of reasonable delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for workplace policy development and management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification to or destruction of workplace policy development and management information depends primarily on the criticality of the information with respect to agency mission capability, protection of agency assets, and safety of individuals. Typically, the effects of modification or deletion of this information are generally limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for workplace policy development and management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.2.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Financial Management",
+                "title": "Assets and Liability Management",
+                "description": "Assets and Liability Management provide accounting support for the management of assets and liabilities of the Federal government. Assets and liability management activities measure the total cost and revenue of Federal programs, and their various elements, activities and outputs. Assets and liability management is essential for providing accurate program measurement information, performance measures, and financial statements with verifiable reporting of the cost of activities. The recommended security categorization for the assets and liability management information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of assets and liability management information on the ability of responsible agencies to provide accounting support for the management of assets and liabilities of the Federal government. Generally, the unauthorized disclosure of assets and liability management information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some asset and liability management information for programs that process high-impact information can assist some criminals to evade enforcement activities. Examples range from tax evasion resulting from unauthorized disclosure of information regarding audit budgets to unauthorized disclosure of budget details for specific border control, antiterrorism, or witness protection expenditures. Where actions taken based on unauthorized disclosure of assets and liability management details pose a threat to human life or a loss of major assets, the confidentiality impact is high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The recommended provisional confidentiality impact level for assets and liability management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the assets and liability management information. Assets and liability management processes are generally tolerant of delay. Typically, disruption of access to assets and liability management information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for assets and liability management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The accuracy of assets and liability management information is essential to providing accurate program measurement information, performance measures, and financial statements with verifiable reporting of the cost of activities. The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Also, the consequences of unauthorized modification or destruction of assets and liability management information may depend on the urgency with which the information is needed. Assets and liability management activities are not generally time-critical and a compromise would have only limited adverse effects on agency operations, agency assets, or individuals. Special Factors Affecting Integrity Impact Determination: If reports based on modified or incomplete information are circulated, the adverse effect on mission functions and public confidence in the agency can be serious. In such cases, the integrity impact would be moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for assets and liability management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.2.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Financial Management",
+                "title": "Reporting and Information",
+                "description": "Reporting and Information includes providing financial information, reporting and analysis of financial transactions. Financial reporting includes the activities necessary to support: management\u2019s fiduciary role; budget formulation and execution functions; fiscal management of program delivery and program decision making; and internal and external reporting requirements. The recommended security categorization for the \u201cfinancial reporting and information\u201d information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of financial reporting information on an agency\u2019s ability to provide financial information and reporting and analysis of financial transactions. Typically, the unauthorized disclosure of financial reporting information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of financial reporting information for programs that process high-impact information can give adversaries damaging insights into details of agency plans, priorities, and operations. In relatively rare cases, actions taken based on unauthorized disclosure of financial reporting details pose a threat to human life or a loss of major assets, so the confidentiality impact is high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for reporting and information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the assets and liability management information. Financial reporting processes are generally tolerant of delay. Typically, disruption of access to financial reporting information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact recommended for reporting and information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Financial reporting activities are not generally time-critical. Many integrity compromises would result in limited adverse effects on agency operations, agency assets, or individuals. If planning documents, proposals, or reports based on modified or incomplete information are circulated; the adverse effect on mission functions or public confidence in the agency can be serious. In most cases, serious adverse effects on agency operations, agency assets, or individuals can be expected. The extensive audit and investigative actions that often follow discovery of an agency\u2019s use of falsified financial reports or omission of financial reporting data can place the agency at a significant disadvantage."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for reporting and information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.2.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Financial Management",
+                "title": "Funds Control",
+                "description": "Funds Control includes the management of the Federal budget process including the development of plans and programs, budgets, and performance outputs as well as financing Federal programs and operations through appropriation and apportionment of direct and reimbursable spending authority, fund transfers, investments and other financing mechanisms. Funds control management includes the establishment of a system for ensuring an organization does not obligate or disburse funds in excess of those appropriated or authorized. The recommended security categorization for the funds control information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of funds control information on the ability of responsible agencies to develop plans and programs, budgets, and performance outputs and outcomes; and to finance Federal programs and operations through appropriation and apportionment of direct and reimbursable spending authority, fund transfers, investments and other financing mechanisms. In general, unauthorized disclosure of funds control information, particularly of budget allocations for specific programs or program elements, can be seriously detrimental to government interests in procurement processes. In many instances, such unauthorized disclosure is prohibited by executive order or by law (e.g., Federal Acquisition Regulation). Premature release of draft funds control information can yield advantages to competing interests and seriously endanger agency operations \u2013 or even agency mission. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of funds control information for programs that process classified or high-impact information can give adversaries damaging insights into details of agency plans, priorities, and operations. (Classified programs and systems are outside the scope of this guideline.) In rare cases, actions taken based on unauthorized disclosure of funds control details can pose a threat to human life or a loss of major assets, so the confidentiality impact would be high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "While, in many cases, unauthorized disclosure of funds control information will have only a limited adverse effect on agency operations, assets, or individuals, the potential for serious harm is such that the provisional confidentiality impact level recommended for funds control information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the funds control information. Funds control processes are generally tolerant of delay. Typically, disruption of access to funds control information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for funds control information is low. C.3.2.4 Accounting Information Type"
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Funds control activities are not generally time-critical. An accumulation of small changes to data or deletion of small entries can result in budget shortfalls or cases of excessive obligations or disbursements."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "In most cases, the adverse effects of consequent negative publicity on mission functions, image or public confidence in the agency can be serious. Therefore, the provisional integrity impact level recommended for funds control information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.2.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Financial Management",
+                "title": "Accounting",
+                "description": "Accounting entails accounting for assets, liabilities, fund balances, revenues and expenses associated with the maintenance of Federal funds and expenditure of Federal appropriations (Salaries and Expenses, Operation and Maintenance, Procurement, Working Capital, Trust Funds, etc.), in accordance with applicable Federal standards (FASAB, Treasury, OMB, GAO, etc.). The recommended security categorization for the accounting information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of accounting information on the abilities of government agencies to maintain Federal funds and expenditure of Federal appropriations in accordance with applicable Federal standards. Unauthorized disclosure of accounting information for programs that process classified or high-impact information can give adversaries damaging insights into details of agency plans, priorities, and operations. In most cases, unauthorized disclosure of accounting information will have only a limited adverse effect on agency operations, assets, or individuals. (Classified programs and systems are outside the scope of this guideline.) Special Factors Affecting Confidentiality Impact Determination: In relatively rare cases, actions taken based on unauthorized disclosure of accounting details can pose a threat to human life or a loss of major assets, so the confidentiality impact would be high. In some cases, unauthorized disclosure of accounting information can violate proprietary information or other non-disclosure agreements. In such cases, the government may suffer not only a loss of public confidence, but may become vulnerable to legal actions. Where sensitive or proprietary information is involved, the impact of unauthorized disclosure is likely to be moderate. Where the accounting information is involved in an audit associated with suspected fraud or other criminal activities, the investigation may be imperiled. Here too, the impact of unauthorized disclosure is likely to be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for accounting information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the accounting information. Accounting processes are generally tolerant of delay. Typically, disruption of access to accounting information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for accounting information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Accounting activities are not generally time-critical. An accumulation of small changes to data or deletion of small entries can result in cost overruns and other cases of excessive obligations or disbursements. In most cases, the adverse effects of consequent negative publicity and institution of corrective action programs on mission functions and public confidence in the agency can be serious. Special Factors Affecting Integrity Impact Determination: In some cases, undetected integrity compromises can be extremely expensive to the government and its employees in terms of both monetary losses and loss of reputation."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for accounting information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.2.5"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Financial Management",
+                "title": "Payments",
+                "description": "Payments include disbursements of Federal funds, via a variety of mechanisms, to Federal and private individuals, Federal agencies, state, local and international Governments, and the private sector, to effect payment for goods and services, or distribute entitlements, benefits, grants, subsidies, loans, or claims. Payment management provides appropriate control over all payments made by or on behalf of an organization, including but not limited to payments made to: vendors in accordance with contracts, purchase orders and other obligating documents; state governments under a variety of programs; employees for salaries and expense reimbursements; other Federal agencies for reimbursable work performed; individual citizens receiving Federal benefits; and recipients of Federal loans. The recommended security categorization for the payments information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of payments information on the ability of responsible agencies to provide appropriate control over all payments made by or on behalf of an organization. In most cases, unauthorized disclosure of payments information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Payment information typically includes information needed for electronic payments such as bank account numbers. Unauthorized access to this type of information could result in significant financial loss for both the Federal government and its payees. Where payment activities are part of an agency\u2019s service delivery mission (e.g., payment of benefits), Privacy Act information and other information subject to statutory or regulatory dissemination controls must appear in the payment vehicles (e.g., name and social security number on check records). (The provisional impact levels for personnel information are documented in the Personal Identity and Authentication, Income, Representative Payee, and Entitlement Event information types.) In such cases, the confidentiality impact level can be at least moderate. (See C.2.8.8.)"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for payments information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the payments information. Payment processes are generally tolerant of delay. Typically, disruption of access to payments information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Where payment activities are part of an agency\u2019s service delivery mission (e.g., payment of benefits), the consequences of loss of information availability that result in failure of payments to go to the appropriate entity can range from minor to life-threatening. In such cases, the availability impact level can be moderate or high. (See C.2.8.11.)"
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "For most Federal government payment systems, the provisional availability impact level recommended for payments information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Payments activities are not generally time-critical. An accumulation of small changes to data or deletion of small entries can result in cost overruns and other cases of excessive disbursements. In most cases, the adverse effects of consequent negative publicity and institution of corrective action programs on mission functions or public confidence in the agency can be serious. Special Factors Affecting Integrity Impact Determination: Where payment activities are part of an agency\u2019s service delivery mission (e.g., payment of benefits), the consequences of integrity compromises that result in failure of payments to go to the appropriate entity can range from minor to life-threatening. In such cases, the availability impact level can be high. (See C.2.8.11.)"
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "For most Federal government payment systems, the provisional integrity impact level recommended for payments information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.2.6"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Financial Management",
+                "title": "Collections and Receivables",
+                "description": "Collections and Receivables include deposits, fund transfers, and receipts for sales or service. Receivable management supports activities associated with recognizing and recording debts due to the Government, performing follow-up actions to collect on these debts, and recording cash receipts. The recommended security categorization for the collections and receivables information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of collections and receivables information on the ability of responsible agencies to recognize and record debts due to the Government, perform follow-up actions to collect on these debts, and record cash receipts. In most cases, unauthorized disclosure of receivable management information will have only a limited adverse effect on agency operations, assets, or individuals."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for collections and receivables information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the collections and receivables information. Collections and receivables processes are generally tolerant of delay. Typically, disruption of access to collections and receivables information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for collections and receivables information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. An accumulation of small changes to data or deletion of small entries can result in revenue shortfalls. In most cases, the adverse effects of consequent negative publicity and institution of corrective action programs on mission functions or public confidence in the agency can be serious."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact recommended for collections and receivables information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.2.7"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Financial Management",
+                "title": "Cost Accounting/ Performance Measurement",
+                "description": "Cost Accounting / Performance Measurement is the process of accumulating, measuring, analyzing, interpreting, and reporting cost information useful to both internal and external groups concerned with the way in which an organization uses, accounts for, safeguards, and controls its resources to meet its objectives. Cost accounting information is necessary in establishing strategic goals, measuring service efforts and accomplishments, and relating efforts to accomplishments. Also, cost accounting, financial accounting, and budgetary accounting all draw information from common data sources. The recommended security categorization for the cost accounting / performance measurement information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of cost accounting / performance measurement information on the ability of responsible agencies to process accumulating, measuring, analyzing, interpreting, and reporting cost information useful to both internal and external groups concerned with the way in which an organization uses, accounts for, safeguards, and controls its resources to meet its objectives, and will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In some cases, unauthorized disclosure of cost accounting / performance measurement information can violate proprietary information or other non-disclosure agreements. In such cases, the government may suffer not only a loss of public confidence, but may become vulnerable to legal actions. Where sensitive or proprietary information is involved, the impact of unauthorized disclosure is likely to be moderate. Where the cost accounting information is involved in an audit associated with suspected fraud or other criminal activities, the investigation may be imperiled. Here too, the impact of unauthorized disclosure is likely to be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for cost accounting / performance measurement information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to cost accounting / performance measurement information. Cost accounting / performance measurement processes are generally tolerant of delay. Typically, disruption of access to cost accounting / performance measurement information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for cost accounting / performance measurement information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In most cases, the adverse effects of consequent negative publicity and institution of corrective action programs on mission functions or public confidence in the agency can be serious."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for cost accounting / performance measurement information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.3.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Human Resource Management",
+                "title": "HR Strategy",
+                "description": "HR Strategy develops effective human capital management strategies to ensure federal organizations are able to recruit, select, develop, train, and manage a high-quality, productive workforce in accordance with merit system principles. This sub-function includes: conducting both internal and external environmental scans; developing human resources and human capital strategies and plans; establishing human resources policy and practices; managing current and future workforce competencies; developing workforce plans; developing succession plans; managing the human resources budget; providing human resources and human capital consultative support; and measuring and improving human resources performance. The recommended provisional security categorization for HR strategy information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of HR strategy information on the ability of responsible agencies to develop effective human capital management strategies to ensure federal organizations are able to recruit, select, develop, train, and manage a high-quality, productive workforce in accordance with merit system principles, and will have only a limited adverse effect on agency operations, assets, or individuals. The consequences of unauthorized disclosure of the majority of HR strategy information will result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will probably be personal information subject to the Privacy Act of 1974, the Health Insurance Portability and Accountability Act of 1996, or other laws and executive orders affecting the dissemination of information regarding individuals. In such cases, the consequences of unauthorized disclosure of HR strategy information could be serious. In such cases, the confidentiality impact level might be moderate. In a few cases (e.g., where some employees are potential targets for retaliation by criminal elements or targets of foreign intelligence organizations), unauthorized disclosure of some HR strategy information (e.g., succession plans, names, addresses, title, organization, dependents\u2019 information) can have life-threatening consequences and has a high confidentiality impact level."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of HR strategy information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to HR strategy information. HR strategy processes are generally tolerant of delay. Typically, disruption of access HR strategy information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for HR strategy information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of HR strategy information depends mostly on the criticality of the information with respect to agency mission, protection of agency assets, and safety of individuals. Although there can be serious short-term effects for individuals, the effects of modifications or deletion of this information are generally limited with respect to agency mission capabilities or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for HR strategy information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.3.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Human Resource Management",
+                "title": "Staff Acquisition",
+                "description": "Staff Acquisition establishes procedures for recruiting and selecting high-quality, productive employees with the right skills and competencies, in accordance with merit system principles. This sub-function includes: developing a staffing strategy and plan; establishing an applicant evaluation approach; announcing the vacancy, sourcing and evaluating candidates against the competency requirements for the position; initiating pre-employment activities; and hiring employees. The recommended provisional security categorization for staff acquisition information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of staff acquisition information on the ability of responsible agencies to establish procedures for recruiting and selecting high-quality, productive employees with the right skills and competencies, in accordance with merit system principles will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will probably be personal information subject to the Privacy Act of 1974. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of staff acquisition information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to staff acquisition information. Staff acquisition processes are generally tolerant of delay. Typically, disruption of staff acquisition information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for staff acquisition information is low"
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of staff acquisition information depends mostly on the criticality of the information with respect to agency mission, protection of agency assets, and safety of individuals. Although there can be serious short-term effects for individuals, the effects of modifications or deletion of this information are generally limited with respect to agency mission capabilities or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for staff acquisition information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.3.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Human Resource Management",
+                "title": "Organization & Position Management",
+                "description": "Organization and Position Management designs, develops, and implements organizational and position structures that create a high-performance, competency-driven framework that both advances the agency mission and serves agency human capital needs. The recommended provisional security categorization for organization and position management information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of organization and position management information on the ability of responsible agencies to design, develop, and implement organizational and position structures creating a high-performance, competency-driven framework that both advances the agency mission and serves agency human capital needs. In most cases, unauthorized disclosure of organization and position management information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will probably be personal information subject to the Privacy Act of 1974. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of organization and position management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to organization and position management information. Organization and position management processes are generally tolerant of delay. Typically, disruption of organization and position management information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for organization and position management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of organization and position management information depends mostly on the criticality of the information with respect to agency mission capability, protection of agency assets, and safety of individuals."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for organization and position management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.3.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Human Resource Management",
+                "title": "Compensation Management",
+                "description": "Compensation Management designs, develops, and implements compensation programs that attract, retain and fairly compensate agency employees. In addition, designs, develops, and implements pay for performance compensation programs to recognize and reward high performance, with both base pay increases and performance bonus payments. This sub-function includes: developing and implementing compensation programs; administering bonus and monetary awards programs; administering pay changes; managing time, attendance, leave and pay; and managing payroll. The recommended provisional security categorization for compensation management information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of compensation management information on the ability of responsible agencies to design, develop, and implements compensation programs that attract, retain and fairly compensate agency employees will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will probably be personal information subject to the Privacy Act of 1974. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. In a few cases (e.g., where some employees are potential targets for retaliation by criminal elements or targets of foreign intelligence organizations), unauthorized disclosure of some compensation management information (e.g., name, address, title, organization, dependents\u2019 information) can have life-threatening consequences and has a high confidentiality impact level."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure compensation management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to compensation management information. Compensation management processes are generally tolerant of delay. Typically, disruption compensation management information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended compensation management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Compensation management activities are not generally time-critical. Special Factors Affecting Integrity Impact Determination: An accumulation of small changes to data or deletion of small entries can result in excessive disbursements of payroll, bonus and monetary awards or affects pay changes, time and attendance, etc. In some cases, the adverse effects of consequent negative publicity on mission functions or public confidence in the agency can be serious. In some other cases, integrity compromises that adversely affect a significant subset of the workforce can result in staff issues and work stoppages that adversely affect the agency\u2019s mission. Where interruptions to agency missions can have serious or life-threatening consequences for individuals, the impacts of integrity compromises can be moderate or even high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for compensation management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.3.5"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Human Resource Management",
+                "title": "Benefits Management",
+                "description": "Benefits Management designs, develops, and implements benefit programs that attract, retain and support current and former agency employees. This sub-function includes: establishing and communicating benefits programs; processing benefits actions; and interacting as necessary with third party benefits providers. The recommended provisional security categorization for benefits management information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure benefits management information on the ability of responsible agencies to design, develop, and implement benefit programs that attract, retain and support current and former agency employees will have only a limited adverse effect on agency operations, assets, or individuals. The consequences of unauthorized disclosure of the majority of benefits management information will result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will probably be personal information subject to the Privacy Act of 1974, the Health Insurance Portability and Accountability Act of 1996, or information that is proprietary to a corporation or other organization. In such cases, the consequences of unauthorized disclosure of benefits management information could be serious (particularly in cases of exposure of large data bases that might reveal private medical information or facilitate identity theft or other financial fraud). (The provisional impact levels for personnel information are documented in the Personal Identity and Authentication, Income, and Entitlement Event information types.) In such cases, the confidentiality impact level would be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of benefits management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to benefits management information. Benefits management processes are generally tolerant of delay. Typically, disruption benefits management information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended benefits management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of benefits management information depends mostly on the criticality of the information with respect to agency mission capability, protection of agency assets, and safety of individuals. In general, the effects of modifications or deletion of this information are generally limited with respect to agency mission capabilities or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for benefits management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.3.6"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Human Resource Management",
+                "title": "Employee Performance Management",
+                "description": "Employee Performance Management designs, develops, and implements a comprehensive performance management approach to ensure agency employees are demonstrating competencies required of their work assignments. Design, develop and implement a comprehensive performance management strategy that enables managers to make distinctions in performance and links individual performance to agency goal and mission accomplishment. This sub-function also includes managing employee performance at the individual level and evaluating the overall effectiveness of the agency\u2019s employee development approach. The recommended provisional security categorization for employee performance management information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of employee performance management information regarding the agencies ability to design, develop, and implement a comprehensive performance management approach to ensure agency employees are demonstrating competencies required of their work assignments. In most cases, unauthorized disclosure of employee performance management information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will probably be personal information subject to the Privacy Act of 1974. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of employee performance management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to employee performance management information. Employee performance management processes are generally tolerant of delay. Typically, disruption employee performance management information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended employee performance management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of employee performance management information depends mostly on the criticality of the information with respect to agency mission capability, protection of agency assets, and safety of individuals. Although there can be serious short-term effects for individuals, the effects of modifications or deletion of this information are generally limited with respect to agency mission capabilities or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for employee performance management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.3.7"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Human Resource Management",
+                "title": "Employee Relations",
+                "description": "Employee Relations designs, develops, and implements programs that strive to maintain an effective employer-employee relationship that balance the agency\u2019s needs against its employees\u2019 rights. This sub-function includes: addressing employee misconduct; addressing employee performance problems; managing administrative grievances; providing employee accommodation; administering employees assistance programs; participating in administrative third party proceedings; and determining candidate and applicant suitability. The recommended provisional security categorization for employee relations information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of employee relations information on the ability of responsible agencies to design, develop, and implement programs that strive to maintain an effective employer-employee relationship that balance the agency\u2019s needs against its employees\u2019 rights. The consequences of unauthorized disclosure of the employee relations information will result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will probably be personal information subject to the Privacy Act of 1974, the Health Insurance Portability and Accountability Act of 1996, or other laws and executive orders affecting the dissemination of information regarding individuals. (The provisional impact levels for personnel information are documented in the Personal Identity and Authentication.) In such cases, the consequences of unauthorized disclosure of Employee Relations information could be serious. In such cases, the confidentiality impact level might be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of employee relations information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access employee relations information. Employee relations processes are generally tolerant of delay. Typically, disruption employee relations information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended employee relations information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of employee relations information depends mostly on the criticality of the information with respect to agency mission capability, protection of agency assets, and safety of individuals. Although there can be serious short-term effects for individuals, the effects of modifications or deletion of this information are generally limited with respect to agency mission capabilities or assets. Special Factors Affecting Integrity Impact Determination: In some cases, integrity compromises that adversely affect a significant subset of the workforce can result in work stoppages that adversely affect the agency\u2019s mission. Where interruptions to agency missions can have serious or life-threatening consequences for individuals, the impacts of integrity compromises can be moderate or even high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for employee relations information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.3.8"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Human Resource Management",
+                "title": "Labor Relations",
+                "description": "Labor Relations manages the relationship between the agency and its unions and bargaining units. This includes negotiating and administering labor contracts and collective bargaining agreements; managing negotiated grievances; and participating in negotiated third party proceedings. The recommended provisional security categorization for labor relations information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of labor relations information on the ability of responsible agencies to manage the relationship between the agency and its unions and bargaining units. This includes negotiating and administering labor contracts and collective bargaining agreements; managing negotiated grievances; and participating in negotiated third party proceedings. The consequences of unauthorized disclosure of the majority of labor relations information will result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In cases where the consequences of unauthorized disclosure of labor relations information could seriously affect the agencies mission capability, protection of agency assets, and safety of individuals, the confidentiality impact level might be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of labor relations information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to labor relations information. Labor relations processes are generally tolerant of delay. Typically, disruption labor relations information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: In some cases (e.g., where an agency\u2019s mission is strongly dependent on organized labor), loss of availability of information that adversely affects a significant subset of the workforce can result in work stoppages that adversely affect the agency\u2019s mission. Where interruptions to agency missions can have serious or life-threatening consequences for individuals, the impacts of availability compromises can be moderate or even high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended labor relations information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of labor relations information depends mostly on the criticality of the information with respect to agency mission capability, protection of agency assets, and safety of individuals. Although there can be serious short-term effects for individuals, the effects of modifications or deletion of this information are generally limited with respect to agency mission capabilities or assets. Special Factors Affecting Integrity Impact Determination: In some cases (e.g., where an agency\u2019s mission is strongly dependent on organized labor), integrity compromises that adversely affect a significant subset of the workforce can result in work stoppages that adversely affect the agency\u2019s mission. Where interruptions to agency missions can have serious or life-threatening consequences for individuals, the impacts of integrity compromises can be moderate or even high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for labor relations information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.3.9"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Human Resource Management",
+                "title": "Separation Management",
+                "description": "Separation Management conducts efficient and effective employee separation programs that assist employees in transitioning to non-Federal employment; facilitates the removal of unproductive, non-performing employees; and assists employees in transitioning to retirement. The recommended provisional security categorization for separation management information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of separation management information on the ability of responsible agencies conducts efficient and effective employee separation programs that assist employees in transitioning to non-Federal employment; facilitates the removal of unproductive, non-performing employees; and assists employees in transitioning to retirement. In most cases, unauthorized disclosure of separation management information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will probably be personal information subject to the Privacy Act of 1974. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of separation management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access separation management. Separation management processes are generally tolerant of delay. Typically, disruption separation management information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended separation management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of separation management information is generally limited with respect to agency mission capabilities or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for separation management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.3.10"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Human Resource Management",
+                "title": "Human Resources Development",
+                "description": "Human Resources Development designs, develops, and implements a comprehensive employee development approach to ensure that agency employees have the right competencies and skills for current and future work assignments. This sub-function includes conducting employee development needs assessments; designing employee development programs; administering and delivering employee development programs; and evaluating the overall effectiveness of the agency\u2019s employee development approach. The recommended provisional security categorization for human resources development information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of human resources development information on the ability of responsible agencies to design, develop, and comprehensive employee development approach to ensure that agency employees have the right competencies and skills for current and future work assignments. In most cases, unauthorized disclosure of human resource development information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will probably be personal information subject to the Privacy Act of 1974. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of human resources development information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish human resources development information. Human resources development information is generally tolerant of delay. Typically, disruption of human resources development information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended human resources development information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of human resource development information depends mostly on the criticality of the information with respect to agency mission capability, protection of agency assets, and safety of individuals. Although there can be serious short-term effects for individuals, the effects of modifications or deletion of this information are generally limited with respect to agency mission capabilities or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for human resources development information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.4.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Supply Chain Management",
+                "title": "Goods Acquisition",
+                "description": "Goods acquisition involves the procurement of physical goods, products, and capital assets to be used by the Federal government. The recommended security categorization for the goods acquisition information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of goods acquisition information on the ability of agencies to procure physical goods, products, and capital assets to be used by the Federal government. The consequences of unauthorized disclosure of most goods acquisition information will have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of information associated with large procurements can result in fraud, waste, abuse, and/or legal proceedings that can have a serious to severe effect on Federal government assets and operations. Also, information associated with acquisition of many Federal government facilities can be useful to criminals seeking to gain access to those facilities. In these cases, unauthorized disclosure of information can have a serious adverse effect on agency operations, agency assets, or individuals. The consequent confidentiality impact would range from moderate to high. Also, unauthorized disclosure of one agency\u2019s goods acquisition information by another agency could result in negative impacts on cross-jurisdictional coordination within the goods acquisition infrastructure and the general effectiveness of organizations tasked with acquisition of government facilities and supplies. Additionally, some procurement information associated with proposals is proprietary. In the case of competitive procurements, much information associated with unsuccessful bids remains proprietary following award of the contract (e.g., pricing information). Unauthorized disclosure of proprietary information can have serious consequences for agencies and have at least a moderate confidentiality impact level. Some procurement information is classified. The classified information is national security related and is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for goods acquisition information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the goods acquisition information. Functions and processes supported by most goods acquisition information are tolerant of delays i.e., the data supporting the functions/processes are not time-critical. Typically, disruption of access will have a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Exceptions may include emergency procurements necessary to support response aspects of disaster management. In such cases, delays may cost lives and major property damage. Consequently, the availability impact level associated with disruption of access to goods acquisition information needed to respond to emergencies may be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for goods acquisition information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of goods acquisition information usually depends on the urgency with which the information is needed or the immediacy with which the information is used Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external publication of goods acquisition information (e.g., web pages, electronic mail) may adversely affect public confidence in the agency. However, damage to the mission would usually be limited. Unauthorized modification or destruction of information relating to procurement actions (particularly proposal information) can result in serious disruption of procurement processes that can be important or even critical to agency operations. In such cases, the integrity impact level can be moderate or even high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for modification or destruction of most goods acquisition information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.4.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Supply Chain Management",
+                "title": "Inventory Control",
+                "description": "Inventory control refers to the tracking of information related to procured assets and resources with regards to quantity, quality, and location. The recommended security categorization for the inventory control information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of inventory control information on the ability of agencies to track information related to procured assets and resources with regards to quantity, quality, and location. The consequences of unauthorized disclosure of most inventory control information are likely to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of information associated with inventories of hazardous materials (e.g., radioactive materials, toxins, bio-hazardous items, explosives) can facilitate terrorist or other criminal activities that may result in serious effects on Federal government assets and operations and on the general public. In general, inventory control information can be of material use to criminals seeking to perpetrate fraud, theft, or some other criminal enterprise. In these cases too, unauthorized disclosure of information can have a serious adverse effect on agency operations, agency assets, or individuals. The consequent confidentiality impact of these types of criminal exploitation of unauthorized disclosure of inventory control information would range from moderate to high. Also, unauthorized disclosure of one agency\u2019s inventory control information by another agency could result in negative impacts on cross-jurisdictional coordination within the inventory control infrastructure and the general effectiveness of organizations tasked with the distribution and accounting of government facilities and supplies. Some inventory control information is classified. The classified information is national security related and is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Regardless of the moderate or high impact associated with unauthorized disclosure of some inventory control information, the provisional confidentiality impact level recommended for inventory control information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to inventory control information. Functions and processes supported by most inventory control information are tolerant of delays i.e., the data supporting the functions/processes are not time-critical. Typically, disruption of access to inventory control information will have a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Exceptions may include emergency requirements to access and distribute materials necessary for disaster management. In such cases, delays may cost lives and major property damage. Consequently, the impact level for inventory control information needed to respond to emergencies will be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for inventory control information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of inventory control information usually depends on the urgency with which the information is needed or the immediacy with which the information is used. In most cases, it is unlikely that the information will be needed urgently or acted upon immediately. Unauthorized modification or destruction of information affecting external publication of inventory control information (e.g., web pages, electronic mail) may adversely affect public confidence in the agency. However, damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for inventory control information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.4.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Supply Chain Management",
+                "title": "Logistics Management",
+                "description": "Logistics management involves the planning and tracking of personnel and their resources in relation to their availability and location. The recommended security categorization for the logistics management information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of logistics management information on the ability of agencies to plan and track the availability and location of personnel and their resources. The consequences of unauthorized disclosure of most logistics management information are likely to have only limited adverse effects on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of logistics information associated with homeland security, law enforcement and some transportation activities (e.g., air transport) can facilitate terrorist or other criminal activities that may result in serious on Federal government assets and operations and on the general public. Logistics management information associated with a broad range of mission areas can be of material use to criminals seeking to perpetrate fraud, theft, or other criminal enterprises. Also, this information is a key intelligence target for those seeking information on defense or law enforcement capabilities, dispositions and intent. In all these cases, the unauthorized disclosure of logistics management information may result in serious adverse effects on agency operations, agency assets, and individuals. Therefore, the confidentiality impact level for these types of criminal exploitation of unauthorized disclosure of logistics management information will range from moderate to high. Some logistics management information is classified (e.g., some military logistics information). The classified information is national security related and is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most logistics management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to logistics management information. Functions and processes supported by most logistics management information are tolerant of delays i.e., the data supporting the functions/processes are not time-critical. Typically, disruption of access to logistics management information will have a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Exceptions may include emergency requirements to deploy personnel and their resources to support disaster management. In such cases, delays may cost lives and major property damage. Consequently, the impact level for logistics management information needed to respond to emergencies will be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The availability impact level recommended for logistics management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of logistics management information usually depends on the urgency with which the information is needed or the immediacy with which the information is used. In most cases, the information will not be needed urgently or acted upon immediately. Unauthorized modification or destruction of information affecting external publication of logistics management information (e.g., web pages, electronic mail) may adversely affect public confidence in the agency. However, damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for logistics management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.4.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Supply Chain Management",
+                "title": "Services Acquisition",
+                "description": "Services acquisition involves the oversight and/or management of contractors and service providers from the private sector. The recommended security categorization for the services acquisition information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of services acquisition information on the ability of agencies to oversee and/or manage contractors and service providers from the private sector. The consequences of unauthorized disclosure of most services acquisition information are likely to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of information associated with very large procurements can result in fraud, waste, abuse, and/or legal proceedings that can have a serious effect on Federal government assets and operations. Also, information associated with acquisition of some services (e.g., security or protection services) can be of material use to criminals seeking to gain access to Federal facilities or information in order to facilitate or perpetrate sabotage, murder, fraud, theft, or other criminal enterprises. In these cases, unauthorized disclosure of information can have a serious adverse effect on agency operations, agency assets, and/or individuals. The consequent confidentiality impact will range from moderate to high. Additionally, some procurement information associated with proposals is proprietary. In the case of competitive procurements, much information associated with unsuccessful bids remains proprietary following award of the contract (e.g., pricing information). Unauthorized disclosure of proprietary information can have serious consequences for agencies and have at least a moderate confidentiality impact level. Some services procurement information is classified. The classified information is national security related and is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most services acquisition information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to services acquisition information. Functions and processes supported by most services acquisition information are tolerant of delays i.e., the data supporting the functions/processes are not time-critical. In most cases, disruption of access to services procurement information can be expected to have a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for services acquisition information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of services acquisition information usually depends on the urgency with which the information is needed or the immediacy with which the information is used. In most cases, the information will not be needed urgently or acted upon immediately. Also, unauthorized modification or destruction of information affecting external publication of services acquisition information (e.g., web pages, electronic mail) may adversely affect public confidence in the agency. However, damage to the mission would usually be limited. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information relating to procurement actions (particularly proposal information) can result in serious disruption of procurement processes and loss of availability of services that can be important or even critical to agency operations. In such cases, the integrity impact level can be moderate or even high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most services acquisition information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.5.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Information and Technology Management",
+                "title": "System Development",
+                "description": "System Development supports all activities associated with the in-house design and development of software applications. The recommended security categorization for the system development information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of system development information on the ability of responsible agencies to design and develop software applications in-house. In the system development phase, a system\u2019s security configuration baseline is established. In most cases, the system development information is not particularly sensitive and is distributed to the users. In general, disclosure of the system development information is likely to result in only limited adverse effects on the confidentiality of system information and processes."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for system development information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to system development information. Functions and processes supported by most system development information are not time-critical. That is, temporary disruption of access to system development information will usually have only a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for system development information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of system development information depend on the maximum aggregate sensitivity and criticality of the information and processes associated with the system. Special Factors Affecting Integrity Impact Determination: The Recommended Integrity Impact Level may range from low to high to national security information (outside the scope of this guideline)."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most system development information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.5.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Information and Technology Management",
+                "title": "Lifecycle/Change Management",
+                "description": "Lifecycle/Change Management involves the processes that facilitate a smooth evolution, composition, and workforce transition of the design and implementation of changes to agency resources such as assets, methodologies, systems, or procedures. The recommended security categorization for the lifecycle/change management information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of lifecycle/change management information on the ability of responsible agencies to execute processes that facilitate a smooth evolution, composition, and workforce transition of the design and implementation of changes to agency resources such as assets, methodologies, systems, or procedures. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some lifecycle/change management information can provide adversaries with intelligence information that may be useful in efforts to compromise the system. This can result in assignment of a moderate impact level to such information. Additionally, there are legislative mandates prohibiting unauthorized disclosure of trade secrets. Trade secrets will generally be assigned a moderate confidentiality impact level."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for lifecycle/change management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to lifecycle/change management information. Functions and processes supported by most lifecycle/change management information are not time-critical. That is, temporary disruption of access to lifecycle/change management information will usually have only a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for lifecycle/change management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of undetected or unauthorized modification or destruction of lifecycle/change management information depends on the maximum aggregate sensitivity and criticality of the information and processes associated with the system. Special Factors Affecting Integrity Impact Determination: The Recommended Integrity Impact Level can range from low to high to national security information (outside the scope of this guideline)."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for lifecycle/change management information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.5.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Information and Technology Management",
+                "title": "System Maintenance",
+                "description": "System Maintenance supports all activities associated with the maintenance of in-house designed software applications. The recommended security categorization for the system maintenance information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of system maintenance information on the ability of responsible agencies to maintain in-house designed software applications. In most cases, system maintenance information is not particularly sensitive and is distributed to the users. In general, disclosure of system maintenance information is likely to result in only limited adverse effects on the confidentiality of system information and processes."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional impact level recommended for system maintenance information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to maintenance information. Functions and processes supported by most maintenance information are not time-critical. That is, temporary disruption of access to maintenance information will usually have only a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for system maintenance information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of system maintenance information can be particularly serious because specific modifications to system changes can be difficult to identify. Special Factors Affecting Integrity Impact Determination: The consequences of undetected or unauthorized modification or destruction of system maintenance information may depend on the maximum aggregate sensitivity and criticality of the information and processes associated with the system. The Recommended Integrity Impact Level can range from low to high to national security information (outside the scope of this guideline)."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for system maintenance information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.5.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Information and Technology Management",
+                "title": "IT Infrastructure Maintenance",
+                "description": "IT infrastructure maintenance involves the planning, design, implementation, and maintenance of an IT Infrastructure to effectively support automated needs (i.e. operating systems, applications software, platforms, networks, servers, printers, etc.). IT infrastructure maintenance also includes information systems configuration and security policy enforcement information. This information includes password files, network access rules and implementing files and/or switch setting, hardware and software configuration settings, and documentation that may affect access to the information system\u2019s data, programs, and/or processes. The impact levels associated with IT infrastructure maintenance information are primarily a function of the information processed in and through that infrastructure. The IT Maintenance Information type represents a complex set of data elements that are used to secure the design, implementation, and maintenance of systems and networks. The security of each of these data elements is dependent on the security of the other data elements. Security compromise of one data element type will propagate to others. The recommended security categorization for the IT infrastructure maintenance information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of IT infrastructure maintenance information on the ability of responsible agencies to plan, design, implement, and maintain an IT Infrastructure to effectively support automated needs (i.e. operating systems, applications software, platforms, networks, servers, printers, etc.). [See also Appendices C.3.5.5, IT Security Information and C.3.5.7, Information Management Information.] IT infrastructure maintenance also includes information systems configuration and security policy enforcement information. Unauthorized disclosure of some IT infrastructure maintenance information can lead to confidentiality compromise of information processed by the system (e.g., password files, file access tables, cryptographic keying information, network access rules, and hardware and software configuration settings, and documentation that may affect access to the information system\u2019s data, programs, and/or processes). As a result, the confidentiality impact associated with this information is that of the highest impact information processed by the system. Also, a higher confidentiality impact may be associated with information in aggregate than is associated with any single element of information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Particularly in the case of passwords and cryptographic keys, the provisional impact level recommended for IT infrastructure maintenance information depends on the sensitivity and criticality of system information and processes. Although an individual organization\u2019s IT infrastructure maintenance information type base may include data elements that will require a higher rating, the recommended provisional impact is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to IT infrastructure maintenance information. Functions and processes supported by most IT infrastructure maintenance information are not time-critical. Also, disruption of access will have a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Exceptions may include emergency response aspects of disaster management or other high load and time critical functions (e.g., some systems that support air traffic control functions). The effects of disruption of access to IT infrastructure maintenance information or information systems may be to deny mission-critical IT resources to all affected organizations. The availability impact level associated with denial-of-service to IT infrastructure maintenance information needed to respond to emergencies or critical to public safety can be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for IT infrastructure maintenance information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of IT infrastructure maintenance information usually depends on the urgency with which the data processed in the IT infrastructure is needed or the time-critical nature of the data. In most cases, it is unlikely that the information will be needed urgently or acted upon immediately. In most cases, the consequences of unauthorized modification of IT infrastructure maintenance information will result in limited damage to agency operations or assets. Special Factors Affecting Integrity Impact Determination: Exceptions may include incorrect information used for emergency response aspects of disaster management, criminal apprehension, air traffic control or other time-critical missions. In such cases, a moderate or high integrity impact level might be considered."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for IT infrastructure maintenance information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.5.5"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Information and Technology Management",
+                "title": "Information Security",
+                "description": "IT Security involves all functions pertaining to the securing of Federal data and systems through the creation and definition of security policies, procedures and controls covering such services as identification, authentication, and non-repudiation. The recommended security categorization for the IT security information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of IT security information on the ability of responsible agencies to secure Federal data and systems through the creation and definition of security policies, procedures and controls covering such services as identification, authentication, and non-repudiation. In most cases, the security policy, procedures, and available controls are not particularly sensitive. Typically, the security information is used in initializing and implementing the controls (e.g., passwords, cryptographic keys) that need to be protected. In general, disclosure of the security policies, procedures, and controls will result in only limited adverse effects on the confidentiality of system information and processes."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The recommended provisional confidentiality impact level recommended for IT security information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to IT security information. Temporary disruption of access to IT security information can usually be expected to have a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "provisional availability impact level recommended for IT security information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for IT security information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.5.6"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Information and Technology Management",
+                "title": "Record Retention",
+                "description": "Records Retention involves the operations surrounding the management of the official documents and records for an agency. Subject to exception conditions described below, the recommended security categorization for the record retention information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of record retention information on the ability of responsible organizations to store, track, account for, maintain, retrieve, and disseminate official documents and records. When the data being retained belongs to one of the information types described in this guideline, the confidentiality impact assigned the data and system is at least that of the highest impact information type collected. Typically, the unauthorized disclosure of most business management information retained will have only a limited adverse effect on agency operations, assets, or individuals. National security information and national security systems are outside the scope of this guideline. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will most commonly be personal information subject to the Privacy Act of 1974 or information that is proprietary to a corporation or other organization. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Such information will often be assigned a moderate confidentiality impact level. Where any of the information to be collected can reasonably be expected to have a high confidentiality impact level, then the record retention system must be assigned a high confidentiality impact level. In some cases, the impact assessment should consider that the aggregate of information retained might have a higher confidentiality impact than any individual information element."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for record retention information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to record retention information. Functions and processes supported by most record retention information are not time-critical. Record retention processes are generally tolerant of reasonable delays. In most cases, disruption of access to record retention information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Not many business management systems perform functions for which temporary loss of availability can cause significant degradation in mission capability, place the agency at a significant disadvantage, result in major damage to assets, or pose a threat to human life."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for record retention information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Special Factors Affecting Integrity Impact Determination: Where integrity compromise adversely affects the ability of an organization to access its records or results in erroneous back-up information or archives, the impact on agency operations can be serious. In such cases, the integrity impact level would be moderate. In the case of large-scale archives or archives involving key national assets (e.g., national archives), the integrity impact can be particularly severe and the impact level would be high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for record retention information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.5.7"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Information and Technology Management",
+                "title": "Information Management",
+                "description": "Information Management involves the coordination of information collection, storage, and dissemination, and destruction as well as managing the policies, guidelines, and standards regarding information management. Subject to exception conditions described below, the recommended security categorization for the information management information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "management information on the ability of responsible agencies to perform the day-to-day processes of information collection, storage, dissemination, and destruction and managing the policies, guidelines, and standards regarding information management. The consequences of unauthorized disclosure depend largely on the content and use of the information being managed. The unauthorized disclosure of information management information relevant to most information managed by the government will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Information collection and storage involve the day-to-day processes of gathering and storing data from agency programs, partners, and stakeholders. More sensitive information being managed is usually personal information subject to the Privacy Act of 1974 or information that is proprietary to a corporation or other organization. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Such information will often be assigned a moderate confidentiality impact level Where any of the information to be managed can be expected to have a high confidentiality, impact level, then the information management information must be assigned a high confidentiality impact level. When the data being managed belongs to one of the information types described in this guideline, the confidentiality impact assigned to the system is that of the highest impact information type processed by the system. Depending on the agency and the mission being supported, the sensitivity of the information can range from none (public information) to high. (National security information and national security systems are outside the scope of this guideline.)"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Particularly in the case of passwords and cryptographic keys, the provisional impact level recommended for information management information depends on the sensitivity and criticality of system information and processes. Although an individual organization\u2019s IT infrastructure maintenance information type base may include data elements that will require a higher rating, the recommended provisional impact is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to information management information. The effects of disruption of access to information management information may temporarily impair agency operations. The level of impact depends on the sensitivity of the information being managed and the criticality of the system to the agency mission. Except for information needed by real-time processes (e.g., information that feeds real-time monitoring or audit functions), information management processes are generally tolerant of reasonable delays. In most cases, disruption of access to information management information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Not many business management systems perform functions for which loss of availability can cause significant degradation in mission capability, place the agency at a significant disadvantage, result in major damage to assets, or pose a threat to human life."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for information management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of information management information (e.g., configuration settings, passwords, authorization codes, cryptographic keying material) can compromise the effectiveness of the system and impair agency operations. The level of impact depends on the criticality of system functionality to the agency mission Special Factors Affecting Integrity Impact Determination: The loss of integrity for some information management information (e.g., encryption keys) can be very serious for agency operations and can have serious consequences for public confidence in the agency. The integrity impact level recommended for information management information associated with highly critical information is high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "Potentially serious adverse effects can be expected in most government organizations resulting from the unauthorized modification or deletion of information management information. Therefore, the provisional integrity impact level recommended for information management information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.5.8"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Information and Technology Management",
+                "title": "System and Network Monitoring",
+                "description": "System and Network Monitoring supports all activities related to the real-time monitoring of systems and networks for optimal performance. System and network monitoring describes the use of tools and observation to determine the performance and status of information systems and is closely tied to other Information and Technology Management sub-functions. System and network monitoring information type should be considered broadly to include an agency\u2019s network [performance, health, and status] and security operations [intrusion monitoring, auditing, etc.] support. Subject to exception conditions described below, the recommended security categorization for the information management information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of system and network monitoring information on the ability of responsible agencies to perform the day-to-day processes of real-time monitoring of systems and networks for optimal performance. The consequences of unauthorized disclosure depend largely on the content and use of the monitoring information gathered, retained, and reported. The unauthorized disclosure of system and network monitoring containing architectural information, vulnerabilities, and availability information may have a serious adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where the system and network monitoring information collected can be expected to have a high confidentiality impact level, then the system and network monitoring information must be assigned a high confidentiality impact level. When the system and network monitoring data being collected supports information types described in this guideline, agency personnel should consider a confidentiality impact assignment of the highest impact information type processed by the system. Depending on the agency and the mission being supported, the sensitivity of the information can range from low to high. (National security information and national security systems are outside the scope of this guideline.)"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Particularly in the case of architectural information (IP addresses, etc.), vulnerabilities, and availability information, the provisional impact level recommended for system and network monitoring information depends on the sensitivity and criticality of system information and processes. The provisional confidentiality impact level recommended is Moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to system and network monitoring information. The effects of disruption of access to system and network monitoring information may temporarily impair or blind agency operations personnel from actual network and security performance. The level of impact depends on the sensitivity of the information and the criticality of the system to the agency mission. In most cases [the exception dual-fault situations], disruption of access to system and network monitoring information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Not many system and network monitoring systems perform functions for which loss of availability can cause significant degradation in mission capability, place the agency at a significant disadvantage, result in major damage to assets, or pose a threat to human life."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for system and network monitoring information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of system and network monitoring information can compromise the effectiveness of the system and impair agency network and security operations leading to inaction or incorrect decisions and actions. The level of impact depends on the criticality of system functionality to the agency mission Special Factors Affecting Integrity Impact Determination: The loss of integrity for some system and network monitoring information can be very serious for agency network and security operations, as well as, the functionality of the information system. Additionally, a loss of integrity can have severe consequences for the agency\u2019s mission and critical business functions. The integrity impact level recommended for system and network monitoring information associated with highly critical information is high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "Potentially serious adverse effects can be expected in most government organizations resulting from the unauthorized modification or deletion of system and network monitoring information. Therefore, the provisional integrity impact level recommended for system and network monitoring information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "C.3.5.9"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Information and Technology Management",
+                "title": "Information Sharing",
+                "description": "The BRM provided in the FEA Consolidated Reference Model Document, Version 2.3, October 2007 specifies Information Sharing as relating to any method or function, for a given business area, facilitating: data being received in a usable medium by one or more departments or agencies as provided by a separate department or agency or other entity; and data being provided, disseminated or otherwise made available or accessible by one department or agency for use by one or more separate departments or agencies, or other entities, as appropriate. Since Information Sharing, as a function, is receiving and disseminating data [other information types] from business areas already identified, this BRM information type will not require its own impact assessment. Therefore, agency personnel should identify the information sharing information type as a pure resource management support activity for the evaluated information system. With the information sharing information type identified, agency personnel can track the flow of information to interfacing systems. The recommended security categorization for the information sharing information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "na"
+                },
+                "availability-impact": {
+                    "base": "na"
+                },
+                "integrity-impact": {
+                    "base": "na"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "N/A"
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.2.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Homeland Security",
+                "title": "Border and Transportation Security",
+                "description": "Border and Transportation Security includes facilitating or deterring entry and exit of people, goods, and conveyances at and between U.S. ports of entry, as well as ensuring the security of transportation and infrastructure networks, facilities, vehicles, and personnel within the United States. Border control involves enforcing the laws regulating the admission of foreign-born persons (i.e., aliens) to the United States. This includes patrolling and monitoring borders and deportation of illegal aliens. Some border control information is also associated with other mission information types (e.g., criminal apprehension, and criminal investigation and surveillance information). In such cases, the impact levels of the associated mission information may determine impact levels associated with border control information. Some aspects of ensuring security of transportation and infrastructure networks, facilities, vehicles, and personnel within the United States are also covered under the information types associated with the transportation mission. In some cases the border control information may be classified. Any classified information is treated under separate rules established for national security information. The recommended categorization for unclassified border and transportation security information follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of border control information on the ability of responsible agencies to enforce laws regulating the admission of foreign-born persons (i.e., aliens) to the United States. Generally, the effects of unauthorized disclosure of border control information are usually confined to a single geographic region, immigration case, or deportation case. Even so, unauthorized disclosure may have a serious adverse effect on mission functions, cause significant degradation in mission capability, or place the agency at a significant disadvantage with respect to its border control responsibilities. Particularly in the case of immigration, naturalization, and deportation activities, unauthorized disclosure of information can violate privacy policies. Such unauthorized disclosures can have a serious effect on public confidence in the agency. Special Factors Affecting Confidentiality Impact Determination: Where border control information is also associated with other mission information types (e.g., criminal apprehension, and criminal investigation and surveillance information), the confidentiality impact level associated with the information may be high. Where unauthorized disclosure of border control information may put the physical safety of personnel into serious jeopardy, the confidentiality impact level associated with the information may be high. Unauthorized disclosure of confidentiality of information associated with ensuring security of transportation and infrastructure networks, facilities, vehicles, and personnel within the United States can result in facilitation of terrorist activities that endanger human life. In some cases, the consequent threat to critical infrastructures, key national assets, and human life can be catastrophic. Consequently, the confidentiality impact level associated with information associated with ensuring security of transportation and infrastructure networks, facilities, vehicles, and personnel within the United States is normally high"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most border control information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to border control information. Functions and processes supported by most border control information are not time-critical. Also, disruption of access will have only a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Special Factors Affecting Availability Impact Determination: There may be time critical cases, for example, information regarding transport of illegal aliens or information about a physical threat posed by aliens that border control personnel have been assigned to interdict. In such cased, the availability impact will be high. The consequences of disruption of access to information or information systems associated with ensuring security of transportation and infrastructure networks, facilities, vehicles, and personnel within the United States may be severe. Also, anti-terrorism missions are not reliably tolerant of delays. The availability impact level for information systems that ensure the security of transportation and infrastructure networks, facilities, vehicles, and personnel within the United States is high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "Except for such time-critical cases, cases where impact is driven by information shared with associated missions (e.g., anti-terrorism), the provisional availability impact level recommended for border control information is normally moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. The consequences of unauthorized modification or destruction of information can be very serious if the information is critical to tactical operations. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information associated with ensuring security of transportation and infrastructure networks, facilities, vehicles, and personnel within the United States may seriously affect mission operations or result in the loss of human life. Unauthorized modification or destruction of information affecting anti-terrorism information may adversely affect mission operations in a manner that results in unacceptable damage to critical infrastructures and/or key national assets or loss of key national assets and/or human life. Consequently, the integrity impact level associated with information that ensures the security of transportation and infrastructure networks, facilities, vehicles, and personnel within the United States is high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for border control information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.2.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Homeland Security",
+                "title": "Key Asset and Critical Infrastructure Protection",
+                "description": "Key Asset and Critical Infrastructure Protection involves assessing key asset and critical infrastructure vulnerabilities and taking direct action to mitigate vulnerabilities, enhance security, and ensure continuity and necessary redundancy in government operations and personnel. The Critical Infrastructure Information Protection Act of 2002 (6 U.S.C. 131-134) places specific controls on the dissemination of critical infrastructure information (see Volume I, 3.5.2.3). Under the provisions of Executive Order 13292, some anti-terrorism information is subject to security classification. National security information is outside the scope of this guideline. The recommended categorization for unclassified anti-terrorism information follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-high"
+                },
+                "availability-impact": {
+                    "base": "fips-199-high"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-high"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of critical infrastructure protection information on the ability of responsible agencies to monitor and assess the leadership, motivations, plans, and intentions of foreign and domestic terrorist groups and their state and non-state sponsors. The effects of unauthorized disclosure of this information can reasonably be expected to jeopardize fulfillment of critical infrastructure protection missions. The consequent threat to critical infrastructures, key national assets, and human life can be catastrophic."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for critical infrastructure protection information is high."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to critical infrastructure protection information. Generally, critical infrastructure protection missions are not reliably tolerant of delays. Significant degradation in mission capability and resultant catastrophic consequences for critical infrastructures, key national assets, and/or human life may occur from disruption of access to critical infrastructure protection information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for critical infrastructure protection information is high."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting critical infrastructure protection operations may adversely affect mission operations and result in unacceptable damage to critical infrastructures, damage to key national assets, or loss of human life."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for critical infrastructure protection information is high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.2.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Homeland Security",
+                "title": "Catastrophic Defense",
+                "description": "Catastrophic Defense involves the development of technological countermeasures (chemical, biological, radiological and nuclear [CBRN]) to terrorist threats, conducting laboratory testing on new and promising devices, and conducting basic and applied science that can lead to the development of countermeasures. Under the provisions of Executive Order 13292, some anti-terrorism information is subject to security classification. National security information is outside the scope of this guideline. The recommended categorization for unclassified anti-terrorism information follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-high"
+                },
+                "availability-impact": {
+                    "base": "fips-199-high"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-high"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of catastrophic defense information on the ability of responsible agencies to monitor and assess the leadership, motivations, plans, and intentions of foreign and domestic terrorist groups and their state and non-state sponsors. The effects of unauthorized disclosure of this information can reasonably be expected to jeopardize fulfillment of catastrophic defense missions. The consequent threat to human life, critical infrastructures, and key national assets can be catastrophic."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for catastrophic defense information is normally high."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The effects of disruption of access to or use of catastrophic defense information or The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to catastrophic defense information. Generally, disruption of access will have a severe adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Also, catastrophic defense missions are not tolerant of delays, with consequences of significant degradation in mission capability and resultant catastrophic consequences for human life, critical infrastructures, and/or key national assets."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for catastrophic defense information is high."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting catastrophic defense activities may adversely affect mission operations in a manner that results in loss of human life, unacceptable damage to critical infrastructures, and/or damage to or loss of key national assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for catastrophic defense information is high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.2.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Homeland Security",
+                "title": "Executive Functions of the Executive Office of the President",
+                "description": "Executive Functions involve the Executive Office of the President (EOP). Subject to exception conditions described below, the recommended provisional security categorization for the executive information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-high"
+                },
+                "availability-impact": {
+                    "base": "fips-199-high"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level associated with the executive information type is associated with functions of the Executive Office of the President (EOP). The effects of loss of confidentiality of policies and guidance during the formative stage can result in attempts by affected entities and other interested parties to influence and/or impede the policy and guidance development process. Premature public release of formative policies and guidance before internal coordination and review can result in unnecessary damage to public confidence in the EOP. These consequences may occur when the release includes unedited internal commentary and discussion. Most of the information processed in and by the EOP is classified national security information and is outside the scope of this guideline. Other information processed by the EOP is extremely sensitive and applicable to homeland security and law enforcement. The unauthorized disclosure of this extremely sensitive information can seriously imperil human life, key national assets, and critical infrastructures."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Based on the catastrophic harm that can be suffered by the nation due to unauthorized disclosure of executive information the provisional confidentiality impact level recommended for executive functions information is high."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to the executive information. National defense and critical infrastructure protection aspects of EOP functions are not generally tolerant of delays. Excessive recovery delays can result in loss of coordination of critical defense and public welfare processes."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for executive functions information is high."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external communications that contain EOP information (e.g., web pages, electronic mail) may adversely affect public confidence in the government. In the case of the EOP, the impact of such a loss of public confidence may be at least moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for executive information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.3.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Intelligence Operations",
+                "title": "Domestic Intelligence",
+                "description": "Some agencies are charged with gathering domestic intelligence. Much domestic intelligence information is classified. Other domestic intelligence information may not be classified (e.g., some information obtained from state and local government sources). All classified information is treated under separate rules established for national security information. The recommended categorization for unclassified domestic intelligence information follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-high"
+                },
+                "availability-impact": {
+                    "base": "fips-199-high"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-high"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of domestic intelligence information on the ability of responsible agencies to develop and manage accurate, comprehensive, and timely domestic intelligence on homeland security topics and other national threats. The consequences of unauthorized disclosure of domestic intelligence information may include loss of the ability and/or authorization to collect information necessary to provide warning or to interdict from major threats (e.g., terrorist threats to critical infrastructures and/or key national assets)."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Given the criticality of much domestic intelligence information and the severe or catastrophic consequences to agencies that disclose domestic intelligence information without proper authorization (e.g., Privacy Act provisions, Fourth Amendment issues), the provisional confidentiality impact level recommended for the domestic intelligence information is high."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to domestic intelligence information. Generally, missions supported by domestic intelligence information are not reliably tolerant of delays. Significant degradation in mission capability and resultant catastrophic consequences for critical infrastructures, key national assets, and/or human life may result from disruption of access to domestic intelligence information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for domestic intelligence information is high."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Domestic intelligence information is generally associated with other mission-related information (e.g., anti-terrorism, firearms and explosive protection, narcotics interdiction). The consequences of unauthorized modification or destruction of domestic intelligence information is determined to a large extent on the missions being supported by the intelligence information and on whether the intelligence information is time-critical. Unauthorized modification or destruction of intelligence information may adversely affect mission operations in a manner that results in unacceptable damage to critical infrastructures, damage to or loss of key national assets, or loss of human life."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for domestic intelligence information is high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.4.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Disaster Management",
+                "title": "Disaster Monitoring and Prediction",
+                "description": "Disaster monitoring and prediction involves the actions taken to predict when and where a disaster may take place and communicate that information to affected parties. [Some disaster management information occurs in humanitarian aid systems under the International Affairs and Commerce line of business (e.g., State Department disaster preparedness and planning).] The recommended provisional categorization of the disaster monitoring and protection information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-high"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-high"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of disaster monitoring and prediction information on the ability of responsible agencies to predict when and where a disaster may take place and communicate that information to affected parties. The purpose of disaster monitoring and prediction activities is generally to disseminate information. Sharing of raw information by a diverse group of analysts often improves the quality of predictive analysis. Special Factors Affecting Confidentiality Impact Determination: The consequences of unauthorized disclosure of some disaster monitoring and prediction information may include public panic or other responses that jeopardize public safety, disaster prevention, emergency response, disaster repair, or restoration missions. For example, attempts of large populations to evacuate in an endangered area before necessary preparations are made for evacuation routes can result in a clogging of the routes and failure to evacuate large parts of the population in time to save them from a life-threatening event. Most of the disaster monitoring and prediction information is critical in terms of potential loss of human life and major property damage. The unauthorized release of this information may interfere with disaster prevention or emergency response missions. The confidentiality impact level recommended for the information cited in the example can be moderate or high. The unauthorized disclosure of disaster monitoring and prediction information to terrorists may reveal weak or sensitive points to target, the most effective technique(s use in attacking a target, and information regarding the status, intent, and plans of our adversaries. Where unauthorized disclosure of disaster monitoring and prediction information is expected to be of direct use to terrorists, the confidentiality impact level is recommended to be high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact recommended for most disaster monitoring and prediction information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to disaster monitoring and prediction information. Generally, missions supported by disaster monitoring and prediction information are not reliably tolerant of delays. Delays may cost lives and irreplaceable property, e.g., degradation in mission capability and resultant catastrophic consequences for critical infrastructures, key national assets, and/or human life. For example, a loss of availability of information that prevents timely and accurate dissemination of tsunami and earthquake predictions can have life-threatening consequences."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for disaster monitoring and prediction information is high."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of disaster monitoring and prediction information usually depends on whether the information is time-critical. Unauthorized modification or destruction of information affecting disaster monitoring and prediction information may jeopardize public safety, disaster prevention, and/or emergency response missions in a manner that results in unacceptable damage to critical infrastructures, damage to key national assets, or loss of human life. For example, an integrity compromise that prevents timely and accurate dissemination of tsunami and earthquake predictions can have life-threatening consequences."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for disaster monitoring and prediction information is high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.4.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Disaster Management",
+                "title": "Disaster Preparedness and Planning",
+                "description": "Disaster preparedness and planning involves the development of response programs to be used in case of a disaster. This involves the development of emergency management programs and activities as well as staffing and equipping regional response centers. The recommended provisional categorization of the disaster preparedness and planning information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of disaster preparedness and planning information on the ability of responsible agencies to develop response programs to be used in case of a disaster. This involves the development of emergency management programs and activities as well as staffing and equipping regional response centers. The consequences of unauthorized disclosure of most disaster preparedness and planning information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: The consequences of unauthorized disclosure of some disaster preparedness and planning information may include revealing weak or sensitive critical infrastructure characteristics or inadequate security of U.S. targets to terrorists or other adversaries. Such information may reveal to an enemy the most effective technique(s) to use in attacking a target, and/or information regarding the capabilities, intent, and plans of our adversaries. Where unauthorized disclosure of disaster preparedness and planning information associated with critical infrastructures, large groups of people, or key national assets is expected to be of direct use to terrorists, the confidentiality impact level is recommended to be high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most disaster preparedness and planning information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to disaster preparedness and planning information. Generally, missions supported by disaster preparedness and planning information are not reliably tolerant of delays. Special Factors Affecting Availability Impact Determination: If emergency responders and those responsible for repair and restoration activities are unable to access preparedness and planning information in the event of an actual emergency the consequences may include confusion and delays. In such cases, the availability impact level can be moderate or high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for disaster preparedness and planning information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of disaster preparedness and planning information depend on whether the information is time-critical. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission will usually be limited. The consequences of unauthorized modification or destruction of information can be very serious or catastrophic if the data is time-critical operational information. In such cases, the impact level assigned would be moderate or high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most disaster preparedness and planning information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.4.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Disaster Management",
+                "title": "Disaster Repair and Restoration",
+                "description": "Disaster repair and restoration involves the cleanup and restoration activities that take place after a disaster. This involves the cleanup and rebuilding of any homes, buildings, roads, environmental resources, or infrastructure that may be damaged due to a disaster. The recommended provisional categorization of the disaster repair and restoration information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of disaster repair and restoration information on the ability of responsible agencies to conduct cleanup and restoration activities that take place after a disaster. This involves the cleanup and rebuilding of any homes, buildings, roads, environmental resources, or infrastructure that may be damaged due to a disaster. The consequences of unauthorized disclosure of most disaster repair and restoration information would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disaster repair and restoration information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to disaster repair and restoration information. Generally, missions supported by disaster repair and restoration information are tolerant of delay."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for disaster repair and restoration information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of disaster repair and restoration information depends on whether the information is time-critical. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most disaster repair and restoration information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.4.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Disaster Management",
+                "title": "Emergency Response",
+                "description": "Emergency Response involves the immediate actions taken to respond to a disaster (e.g., wildfire management). These actions include providing mobile telecommunications, operational support, power generation, search and rescue, and medical life saving actions. Impacts to emergency response information and the information systems that process and store emergency response information could result in negative impacts on cross-jurisdictional coordination within the critical emergency services infrastructure and the general effectiveness of organizations tasked with emergency response missions. The recommended provisional categorization of the emergency response information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-high"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-high"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of emergency response information on the ability of responsible agencies to respond to a disaster. These actions include providing mobile telecommunications, operational support, power generation, search and rescue, and medical life saving actions. The consequences of unauthorized disclosure of emergency response information will usually have little or no adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In cases where an attack is underway, unauthorized disclosure of emergency response information can provide information that might permit terrorists or other adversaries to target emergency response assets, thus jeopardizing emergency response resources and missions and public safety. Given the criticality that much emergency response information has in terms of potential loss of human life and major property damage, where unauthorized release of information can reasonably be expected to facilitate interference with emergency response missions, the confidentiality impact level may be moderate or high. The unauthorized disclosure of one agency\u2019s emergency response by another agency could result in negative impacts on cross-jurisdictional coordination within the critical emergency services infrastructure and the general effectiveness of organizations tasked with emergency response missions."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for emergency response information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to emergency response information. Generally, missions supported by emergency response information are not tolerant of delays. Delays may cost lives and result in major property damage. Denial of access to emergency response information may result in significant degradation in mission capability and resultant catastrophic consequences for critical infrastructures, key national assets, and/or human life."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for emergency response information is high."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The provisional confidentiality impact level recommended for emergency response information is low."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for emergency response information is normally high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.5.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "International Affairs and Commerce",
+                "title": "Foreign Affairs",
+                "description": "Foreign Affairs refers to those activities associated with the implementation of foreign policy and diplomatic relations, including the operation of embassies, consulates, and other posts; ongoing membership in international organizations; the development of cooperative frameworks to improve relations with other Nations; and the development of treaties and agreements. Conflict resolution involves the mitigation and prevention of disputes stemming from inter and intra-state disagreements. Some conflict resolution information is subject to security classification. This classified information is treated under separate rules established for national security information and is outside the scope of this guideline. Treaties and agreements involves the negotiation and implementation of accords with foreign governments and organizations in efforts related to arms reduction and regulation, trade matters, criminal investigations and extraditions, and other various types of foreign policy. When treaties and agreements information affects intelligence gathering and/or law enforcement cooperation, impacts to such information and the information systems that process and store the information could result in negative impacts on protection of a broad range of critical infrastructures and key national assets. Some information associated with treaties and agreements is subject to security classification. This classified information is treated under separate rules established for national security information. The recommended categorization for unclassified foreign affairs information follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-high"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-high"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of conflict resolution information on the ability of responsible agencies to mitigate and prevent disputes stemming from inter and intra-state disagreements. Unauthorized disclosure of conflict resolution information can reasonably be expected to jeopardize fulfillment of conflict resolution missions. This is particularly true of premature release of resolution factors, personnel profiles, and proposed solutions to adversaries. Some information that has supported a conflict resolution process may undo the results of successful conflict resolution processes. The loss of public confidence in the agency may cause a catastrophic adverse effect on an agency\u2019s mission capability. Where information includes candid opinions of agency personnel, or involvement of agency personnel in specific prior activities, the effectiveness of those personnel for many future agency missions may be permanently impaired. The consequences of failed conflict resolution activities may pose threats to human life and major property assets The level of confidentiality impact assigned to treaties and agreements information is determined by the ability of responsible agencies to negotiate and implement accords with foreign governments and organizations in efforts related to arms reduction and regulation, trade matters, criminal investigations and extraditions, and other types of foreign policy. Unauthorized disclosure of information associated with treaties and agreements can reasonably be expected to prevent successful negotiation and/or ratification of treaties and agreements. This is particularly true of prematurely released resolution factors, personality assessments, and proposed solutions to adversaries. Some information that has supported a treaty or other international agreement process may undo the results of a successfully completed treaty or agreement. The subsequent threat to public confidence in the agency can cause a catastrophic adverse effect on an agency\u2019s mission capability. When the disclosed information includes candid opinions of agency personnel, or background information on agency personnel, the effectiveness of those personnel for future agency missions may be permanently impaired. The consequences of failure to successfully conclude treaties and other international agreements often pose threats to human life and major property assets."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for foreign affairs information is high."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to foreign affairs information. Special Factors Affecting Availability Impact Determination: Diplomatic missions are often tolerant of delays. Therefore, the availability impact level assigned to information associated with treaties and agreements that are associated with diplomatic missions is low. Where this is not the case, the availability impact for foreign affairs information associated with treaties and agreements may be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for foreign affairs information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of conflict resolution information depend on whether the information is time-critical. The consequences of unauthorized modification or destruction of information associated with treaties and agreements also depend on the time-critical nature of the information. The unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. The unauthorized modification or destruction of information affecting conflict resolution information may adversely affect mission operations in a manner that results in unacceptable consequences such as loss of human life and/or major property assets. The consequences of unauthorized modification or destruction of information can be very serious if the modification is to time-critical operational information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for foreign affairs information is high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.5.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "International Affairs and Commerce",
+                "title": "International Development and Humanitarian Aid",
+                "description": "International Development and Humanitarian Aid refers to those activities related to the implementation of development and humanitarian assistance programs to developing and transitioning countries throughout the world. Development and aid may include technical assistance (the transfer of knowledge and expertise), and the delivery of equipment, commodities and humanitarian assistance including food aid. In some cases, international development and humanitarian aid information is subject to security classification. This classified information is treated under separate rules established for national security information. The recommended categorization for unclassified international development and humanitarian aid information follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of international development and humanitarian aid information on the ability of responsible agencies to execute programs relating to debt relief, foreign investments, poverty alleviation and food relief, foreign market expansion, and donations, as well as the establishment of policies and procedures to facilitate economic development. Special Factors Affecting Confidentiality Impact Determination: The unauthorized disclosure of international development and humanitarian aid information may not directly jeopardize foreign socio-economic and political development missions. However, the premature disclosure of this information may adversely affect agency credibility or give unfair competitive advantages to some candidates for mission support activities. These secondary effects may have a negative effect on the intended beneficiaries and can result, in extreme cases, in threats to human life, major assets, or the ability of the agency to perform future missions. Some information that has supported an international development and humanitarian aid process can even undo the results of previously completed foreign socio-economic and political development processes. Where there is a possibility of catastrophic consequences such as threats to human life and major property assets, a high confidentiality impact level must be assigned."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for international development and humanitarian aid information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to international development and humanitarian aid information. Special Factors Affecting Availability Impact Determination: Generally, international development and humanitarian aid missions are tolerant of delays. Where this is not the case, the availability impact associated with international development and humanitarian aid information may be moderate or high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for international development and humanitarian aid information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of international development and humanitarian aid information depend on whether the information is time-critical. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Integrity Impact Determination: The consequences of unauthorized modification or destruction of information can be very serious or catastrophic if the modification is to time-critical operational information. In such cases, the impact level assigned would be moderate or high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most international development and humanitarian aid information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.5.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "International Affairs and Commerce",
+                "title": "Global Trade",
+                "description": "Global Trade refers to those activities the Federal Government undertakes to advance worldwide economic prosperity by increasing trade through the opening of overseas markets and freeing the flow of goods, services, and capital. Trade encompasses all activities associated with the importing and exporting of goods to and from the United States. This includes goods declaration, fee payments, and delivery/shipment authorization. Export promotion involves the development of opportunities for the expansion of U.S. exports. Merchandise inspection includes the verification of goods and merchandise as well as the surveillance, interdiction, and investigation of imports/exports in violation of various Customs laws. Tariffs/quotas monitoring refers to the monitoring and modification of the schedules of items imported and exported to and from the United States. The recommended categorization for the global trade information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-high"
+                },
+                "availability-impact": {
+                    "base": "fips-199-high"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-high"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of export promotion information on the ability of responsible agencies to advance worldwide economic prosperity by increasing trade through the opening of overseas markets and freeing the flow of goods, services, and capital. Also, the confidentiality impact level is the effect of unauthorized disclosure of merchandise inspection information on the ability of responsible agencies to accurately determine, report, and record the discovered status of imported or exported merchandise as it bears on violations of various Customs laws. Generally, the unauthorized disclosure of merchandise inspection information will not jeopardize the completion of other merchandise inspection missions, as shipment status is generally information of public record. The confidentiality impact level is also the effect of unauthorized disclosure of tariffs/quotas monitoring information on the ability of responsible agencies to enforce various Customs laws, and preserve statistical data concerning the historical compliance with such laws. Typically, the unauthorized disclosure of tariffs/quotas monitoring information will not jeopardize the completion of other tariffs/quotas monitoring missions because the information is publicly available. Unauthorized disclosure of information that has supported an export promotion process may undo the results of successful export promotion processes. The consequent threat to agency image or reputations can cause a catastrophic adverse effect on an agency\u2019s mission capability. Consequently, the general confidentiality impact level associated with export promotion information is high. Some information that has supported a tariffs/quotas monitoring process might be of higher sensitivity, such as intelligence information36 that might point to a dumping situation. The unauthorized disclosure of this information might jeopardize the success of future tariffs/quotas monitoring processes. Consequently, the confidentiality impact level associated with tariffs/quotas monitoring information is high. Intelligence information is included in national security systems. National security information and national security systems are outside the scope of this guideline. Some information that has supported a merchandise inspection process might be of higher sensitivity. The unauthorized disclosure of this information might jeopardize the success of future merchandise inspection processes. The consequent threat to agency image or reputations may cause a serious adverse effect on an agency\u2019s mission capability. Consequently, the general confidentiality impact level associated with merchandise inspection information is high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for global trade information is high."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to global trade information. Export promotion and merchandise inspection missions are generally tolerant of significant delays. If the export promotion and merchandise inspection information are time-critical, the availability impact may be high. This would be the case where such an occurrence could result in significant financial consequences as a result of uncertainty regarding the status of an imported or exported shipment. Tariffs/quotas monitoring missions are also tolerant of significant delays. Typically, this information is used in high level policy and strategic analysis, and denial of access might cause an inconvenience but no significant mission impact. However, the availability impact associated with tariffs/quotas monitoring information may be high, if denial of access could result in serious damage to the image or reputation of an agency resulting from uncertainty regarding the compliance statistics of a major sovereign trade partner."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "he provisional availability impact level recommended for global trade information is high."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of global trade information depends on whether the information is time-critical. Unauthorized modification or destruction of information affecting export promotion information may adversely affect mission operations and result in potentially serious economic repercussions. Trade agreements that have been implemented are generally matters of public record. Therefore, the specific negotiated terms, etc., must be accurately recorded. The modification of merchandise inspection information may result in significant financial consequences to an importer or exporter whose shipment is in question and may adversely affect mission operations and result in potentially serious economic repercussions. The results of completed inspections are matters of public record and must be accurately recorded. For tariffs/quotas monitoring information, the requirement for adequate means to detect data corruption is high. This information is used in policy and strategic analysis, and the accuracy of this statistical information is critical. Unauthorized modification or destruction of information affecting tariffs/quotas monitoring information may adversely affect mission operations and result in potentially catastrophic economic repercussions."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for global trade information is high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.6.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Natural Resources",
+                "title": "Water Resource Management",
+                "description": "Water Resource Management includes all activities that promote the effective use and management of the nation\u2019s water resources. Notes: Environmental protection of water resources is included in the Environmental Management Line of Business. Hydroelectric energy production is included under the Energy Production mission. The recommended provisional categorization of the water resource management information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of water resource management information on the ability of responsible agencies to promote the effective use and management of the nation\u2019s water resources. The consequences of unauthorized disclosure of most water resource management information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: There may be some cases for which moderate confidentiality impact is associated with unauthorized disclosure of business/industry development. For example, unauthorized disclosure of details of current agency water resource management activities and plans may focus opposition and/or give an unfair advantage to competing interests. Consistent premature disclosure of agency plans may cause significant degradation in mission capability."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for water resource management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to water resource management information. Generally, missions supported by water resource management information are tolerant of delay."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for water resource management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of water resource management information depends on whether the information is time-critical. Unauthorized modification or destruction of information affecting external communications associated with water resource management information (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most water resource management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.6.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Natural Resources",
+                "title": "Conservation, Marine and Land Management",
+                "description": "Conservation, Marine and Land Management involves the responsibilities of surveying, maintaining, and operating public lands and monuments, as well as activities devoted to ensuring the preservation of land, water, wildlife, and natural resources, both domestically and internationally. It also includes the sustainable stewardship of natural resources on federally owned/controlled lands for commercial use (mineral mining, grazing, forestry, fishing, etc.). The recommended provisional categorization of the conservation, marine, and land management information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of conservation, marine, and land management information on the ability of responsible agencies to survey, maintain, and operate public lands and monuments, as well as to ensure the preservation of land, water, wildlife, and natural resources, both domestically and internationally. The consequences of unauthorized disclosure of most conservation, marine, and land management information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: There may be some cases for which moderate confidentiality impact is associated with unauthorized disclosure of private or proprietary information associated with use of federally owned/controlled lands for commercial use (mineral mining, grazing, forestry, fishing, etc.). Additionally, unauthorized disclosure of details of current agency conservation, marine, and land management activities and plans may focus opposition and/or give an unfair advantage to competing interests. Consistent premature disclosure of agency plans may cause significant degradation in mission capability. Also, conservation, marine, and land management include enforcement functions (e.g., the policing of marine fisheries). Confidentiality impacts associated with criminal apprehension, criminal investigation and surveillance, citizen protection, and property protection may cause the confidentiality impact of enforcement-related information to be moderate or high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact recommended for most conservation, marine, and land management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to conservation, marine, and land management information. Typically, missions supported by conservation, marine, and land management information are tolerant of delay. Special Factors Affecting Availability Impact Determination: Conservation, marine, and land management include enforcement functions (e.g., the policing of marine fisheries). Availability impacts associated with criminal apprehension, criminal investigation and surveillance, citizen protection, and property protection may cause the availability impact of enforcement-related information to be moderate or high. Particularly during fire season, the availability of land management information critical to fire-fighting operations can affect the safety of human life and large-scale property damage. Such information can have a high availability impact level."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for most conservation, marine, and land management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of conservation, marine, and land management information depend on whether the information is time-critical. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications associated with conservation, marine, and land management information (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Conservation, marine, and land management include enforcement functions (e.g., the policing of marine fisheries). Integrity impacts associated with criminal apprehension, criminal investigation and surveillance, citizen protection, and property protection may cause the integrity impact of enforcement-related information to be moderate. Particularly during fire season, the integrity of land management information critical to fire-fighting operations can affect the safety of human life and large-scale property damage. Such information can have a high integrity impact level."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most conservation, marine, and land management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.6.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Natural Resources",
+                "title": "Recreational Resource Management and Tourism",
+                "description": "Recreational Resource Management and Tourism involves the management of national parks, monuments, and tourist attractions as well as visitor centers, campsites, and park service facilities. Impacts to some information and information systems associated with tourism management may affect the security of some key national assets (e.g., some national monuments and icons). The recommended provisional categorization of the recreational resource management and tourism information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of recreational resource management and tourism information on the ability of responsible agencies to manage national parks, monuments, and tourist attractions as well as visitor centers, campsites, and park service facilities. The consequences of unauthorized disclosure of most recreational resource management and tourism information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Recreational resource management and tourism include enforcement functions (e.g., protective and enforcement functions of the National Park Service). Confidentiality impacts associated with criminal apprehension, criminal investigation and surveillance, citizen protection, and property protection may cause the confidentiality impact of enforcement-related information to be moderate or high. The consequences of unauthorized disclosure of property and tourist protection information can be particularly severe in the case of protection of national monuments and icons."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most recreational resource management and tourism information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to recreational resource management and tourism information. Generally, missions supported by recreational resource management and tourism information are tolerant of delays. Special Factors Affecting Availability Impact Determination: Recreational resource management and tourism include enforcement functions (e.g., protective and enforcement functions of the National Park Service). Availability impacts associated with criminal apprehension, criminal investigation and surveillance, citizen protection, and property protection may cause the confidentiality impact of enforcement-related information to be moderate or high. There may also be time-critical cases associated with protection of people and key national assets from natural disasters (such as fires, unexpected blizzards, or volcanic eruptions). In such cased, the availability impact may be high. Except for time-critical information, the availability impact level recommended for protection-related information is typically moderate."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "Most recreational resource management and tourism information is routine in nature (not time-critical). Consequently, the provisional availability impact level recommended for most recreational resource management and tourism information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of recreational resource management and tourism information depends on whether the information is time-critical. Unauthorized modification or destruction of information affecting external communications associated with recreational resource management and tourism information (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Integrity Impact Determination: Recreational resource management and tourism include enforcement functions (e.g., protective and enforcement functions of the National Park Service). Integrity impacts associated with criminal apprehension, criminal investigation and surveillance, citizen protection, and property protection may cause the integrity impact of enforcement-related information to be moderate or high. These types of enforcement-related information are time-critical. Where terrorists or other criminals pose a threat to key national assets, or pose a threat to human life, the integrity impact level recommended for recreational resource management and tourism enforcement information is high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most recreational resource management and tourism information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.6.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Natural Resources",
+                "title": "Agricultural Innovation and Services",
+                "description": "Agricultural Innovation and Services involves the creation and dissemination of better methods for farming and the development of better and healthier crops. The recommended security categorization for the agricultural innovation and service information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of agricultural innovation and service information on the ability of responsible agencies to create and disseminate of better methods for farming and the development of better and healthier crops. In most cases, unauthorized disclosure of agricultural innovation and service information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In some cases, unauthorized disclosure of preliminary findings or policies under consideration regarding proposed agricultural products may result in domestic or international public relations problems for the Federal government. In such cases, serious damage can result for agricultural innovation and service operations. Here, the confidentiality impact level may be moderate. In other cases, unauthorized disclosure of information regarding creation, storage, and transportation of dangerous plant disease vectors, animal disease vectors, pesticides, and herbicides might facilitate malicious activities by terrorists or other criminals. Here, there is a potential for loss of human life, so the confidentiality impact level may be high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most agricultural innovation and service information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to agricultural innovation and service information. Loan assistance processes are generally tolerant of delay. In most cases, disruption of access to agricultural innovation and service information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for agricultural innovation and service information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Agricultural innovation and service activities are not generally time-critical. In most cases, the adverse effects of unauthorized modification to or destruction of agricultural innovation and service information on agency mission functions and public confidence in the agency can be expected to be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for agricultural innovation and service information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.7.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Energy",
+                "title": "Energy Supply",
+                "description": "Energy Supply involves all activities devoted to ensuring the availability of an adequate supply of energy for the United States and its citizens. Energy Supply includes the sale and transportation of commodity fuels such as coal, oil, natural gas, and radioactive materials. This function also includes distributing and transferring power, electric generation, and/or storage located near the point of use. Impacts to some information and information systems associated with energy supply may affect the security of critical infrastructures, particularly in the areas of energy transmission and transport. The following recommended provisional categorization of the energy supply information type is particularly subject to change where critical infrastructure elements or nuclear materials are involved:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of energy supply information on the ability of responsible agencies to conduct activities related to the sale and transportation of commodity fuels such as coal, oil, natural gas, and radioactive materials. This function also includes distributing and transferring power, electric generation, and/or storage located near the point of use. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Confidentiality Impact Determination: The consequences of unauthorized disclosure of energy supply information can have a serious economic impact with respect to competitive advantages and financial and commodity market dynamics. Also, the unauthorized disclosure of supply information may assist terrorists in the theft of energy products or disruption of energy distribution channels. Facilitation of theft of nuclear materials is a particularly catastrophic potential result of unauthorized disclosure of specific types of energy supply information. In these cases, the confidentiality impact must be considered to be high. [Some information regarding transportation and storage of nuclear materials is classified. The classified information is national security related and is outside the scope of this guideline. Other information, such as Nuclear Regulatory Commission \u201cSAFEGUARDS\u201d information is not national security information, but must be treated as having high confidentiality impact.] With respect to possible use by terrorists of energy distribution information regarding petroleum, natural gas, and other flammable or explosive products, a realistic impact assessment must include energy distribution information from private companies. This information is also susceptible to access by terrorists. Where distribution of hazardous energy products is involved, there is a potential unauthorized disclosure consequence of loss of human life and major property. In such cases the confidentiality impact level can be moderate or high. [Disclosure of transportation routes and storage facilities is often (i) both authorized and necessary to mission accomplishment and (ii) authorized, or even mandated, for public safety reasons.] Also, the unauthorized disclosure of one agency\u2019s energy supply information by another agency could result in negative impacts on cross-jurisdictional coordination within the energy distribution infrastructure and the general effectiveness of organizations tasked with energy supply."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most energy supply information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to energy supply information. Typically, disruption of access will have a limited adverse effect on agency operations (including mission, functions, or public confidence in the agency), agency assets, or individuals. Also, most energy supply information is not time-critical. Special Factors Affecting Availability Impact Determination: Mission-critical systems: Functions supported by mission-critical information or information systems (e.g., electrical power generation, transmission, and/or distribution; petroleum or gas pipelines) are often adversely impacted by lack of availability. Loss of availability of the information or information system can result in severe impacts to the environment, service, major assets and/or human safety. Consequently, the availability impact level associated with these types of mission-critical processes/systems may be high. Non mission-critical systems: For information or information systems that do not directly impact mission-critical functions, the availability impact level may be downgraded to low."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The availability impact level recommended for most energy supply information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data and systems supporting that mission, not on the time required to detect the modification to or destruction of information or information system. The consequences of unauthorized modification to or destruction of energy supply information or information systems, usually depends on whether the information is mission-critical. Special Factors Affecting Integrity Impact Determination: Mission-critical systems: Unauthorized modification of mission-critical information or information systems (e.g., electrical power distribution, petroleum or gas pipelines) can result in severe impacts to the environment, service, major assets and/or human safety. Consequently, the integrity impact level associated with these types of mission-critical processes/systems may be high. Non mission-critical systems: For information or information systems that do not directly impact mission-critical functions, the integrity impact level may be downgraded to low."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for energy supply information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.7.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Energy",
+                "title": "Energy Conservation and Preparedness",
+                "description": "Energy Conservation and Preparedness involves protection of energy resources from over-consumption to ensure the continued availability of fuel resources and to promote environmental protection. This mission also includes measures taken to ensure the provision of energy in the event of an emergency. The recommended security categorization for the energy conservation and preparedness information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of energy conservation and preparedness information on the ability of responsible agencies to protect energy resources from over-consumption to ensure the continued availability of fuel resources and to promote environmental protection. In most cases, unauthorized disclosure of energy conservation and preparedness information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In some cases, unauthorized disclosure of preliminary findings or policies under consideration regarding proposed conservation measures or the distribution of energy in the event of an emergency may result in mobilization of special interests. These groups may successfully oppose necessary conservation measures and be given an unfair advantage for specific commercial interests. Also, the unauthorized disclosure may cause domestic or international loss of confidence in the Federal government. In such cases, serious damage may result for energy conservation and preparedness operations. Therefore, the confidentiality impact level may be moderate. In other cases, unauthorized disclosure of information regarding measures taken to ensure the provision of energy in the event of an emergency may facilitate malicious activities of terrorists. Here, there is a potential for loss of human life resulting from extended outages, so the confidentiality impact level may be high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most energy conservation and preparedness information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to energy conservation and preparedness information. Loan assistance processes are generally tolerant of delay. In most cases disruption of access to energy conservation and preparedness information will have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Unavailability of information necessary to mission-critical procedures ensuring the provision of energy in the event of an emergency may result in extended outages. There is some potential for a consequent threat to critical energy infrastructure and to human life. In such cases, the availability impact level may be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for energy conservation and preparedness information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In most cases, the adverse effects of unauthorized modification or destruction of energy conservation and preparedness information on agency mission functions and public confidence in the agency will be limited Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information necessary to mission-critical procedures ensuring the provision of energy in the event of an emergency can result in extended outages. There is some potential for a consequent threat to critical energy infrastructure and to human life. In such cases, the integrity impact level may be high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for energy conservation and preparedness information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.7.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Energy",
+                "title": "Energy Resource Management",
+                "description": "Energy resource management involves the management of energy producing resources including facilities, land, and offshore resources. The recommended provisional categorization of the energy resource management information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of energy resource management information on the activities of responsible agencies with respect to management of energy producing resources including facilities, land, and offshore resources. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of much energy resource management information can result in major financial consequences and impact financial markets and have a severe adverse effect on public confidence in the agency. In some cases, the probable consequences of damage to public confidence in the agency can even be high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The consequences of unauthorized disclosure of some energy resource management information would have only a limited adverse effect on agency operations. However, the consequences that can be expected to result from unauthorized disclosure of most energy resource management information justify a moderate provisional confidentiality impact level."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to energy resource management information. Generally, missions supported by energy resource management information are tolerant of delay."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for energy resource management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of energy resource management information may depend on the urgency with which the information is typically needed. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited Special Factors Affecting Integrity Impact Determination: If the energy resource management information is mission-critical or very sensitive, the integrity impact level may be moderate or high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most energy resource management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.7.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Energy",
+                "title": "Energy Production",
+                "description": "Energy production involves the transformation of raw energy resources into useable, deliverable energy. Impacts to some information and information systems associated with energy production may affect the security of the critical energy infrastructure. The recommended provisional categorization of the energy production information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of energy production information on the activities of responsible agencies with respect to transformation of raw energy resources into useable, deliverable energy. The consequences of unauthorized disclosure of most energy production information would have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some energy production information can result in major financial consequences. In some cases, premature disclosure of this information can impact financial markets. Unauthorized disclosure to a single institution could damage faith in government institutions, result in adverse financial events, and have a serious adverse effect on public confidence in the agency. Therefore, the confidentiality impact should be at least moderate for this energy production information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most energy production information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to energy production information. Missions supported by energy production information are generally tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for energy production information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of energy production information may depend on the urgency with which the information is typically needed. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Integrity Impact Determination: If the energy production information is time-critical or very sensitive, the integrity impact level may be moderate or high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most energy production information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.8.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Environmental Management",
+                "title": "Environmental Monitoring and Forecasting",
+                "description": "Environmental Monitoring and Forecasting involves the observation and prediction of environmental conditions. This includes b the monitoring and forecasting of water quality, water levels, ice sheets, air quality, regulated and non-regulated emissions, as well as the observation and prediction of weather patterns and conditions. The following provisional security categorization is recommended for the environmental monitoring and forecasting information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of environmental monitoring and forecasting information on the ability of responsible agencies to observe and predict environmental conditions. The consequences of unauthorized disclosure of most environmental monitoring information are unlikely to have a serious adverse effect on agency operations. Special Factors Affecting Confidentiality Impact Determination: The most serious adverse effects are likely to involve exposure of information that is proprietary to an organization or result in damaging publicity for an organization. [Unauthorized disclosure of some information can have serious economic impact on both individual companies and the broader market place. The consequences of such unauthorized disclosures may have an adverse effect on public confidence in the agency.] In such cases, the potential confidentiality impacts may be at least moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most environmental monitoring and forecasting information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to environmental monitoring and forecasting information. Except for cases of emergency bulletins necessary to correct existing threats to public safety, the nature of environmental monitoring and forecasting processes is usually tolerant of reasonable delays"
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for environmental monitoring and forecasting information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of environmental monitoring information and forecasting can be serious if the public is exposed to harmful emissions, polluted water, etc. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and public confidence in the agency, but also the agency mission. In some cases, unauthorized modification or destruction of information can result in loss of human life - a high-impact potential."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for environmental monitoring and forecasting information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.8.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Environmental Management",
+                "title": "Environmental Remediation",
+                "description": "Environmental remediation supports the immediate and long-term activities associated with the correcting and offsetting of environmental deficiencies or imbalances, including restoration activities. The following security categorization is recommended for the environmental remediation information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of environmental remediation information on the immediate and long-term activities of responsible agencies with respect to correcting and offsetting environmental deficiencies or imbalances. Serious adverse effects are likely to result from 1) exposure of information that is premature and not fully checked for accuracy and that can damage public confidence in an organization targeted for remedial action, 2) unauthorized disclosure of information that is proprietary to an organization, 3) unauthorized disclosure of information concerning proposed remediation that may be used by organizations opposing particular remedial actions, and 4) disclosure of an agency\u2019s tactics for enforcing remediation that will have an adverse effect on the enforcement action. The consequences of such unauthorized disclosures may have a serious adverse effect on public confidence in the agency, have a serious adverse effect on agency operations, and place the agency at a significant disadvantage."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for environmental remediation information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to pollution prevention and control information. Except for cases of emergency bulletins necessary to correct existing threats to public safety, pollution prevention and control processes are usually tolerant of delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for pollution prevention and control information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of environmental remediation information may depend on the urgency with which the information is typically needed. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations, public confidence in the agency, and the agency mission."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for pollution prevention and control information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.9.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Economic Development",
+                "title": "Business and Industry Development",
+                "description": "Business and industry development supports activities related to the creation of economic and business opportunities and stimulus, and the promotion of financial and economic stability for corporations and citizens involved in different types of business. The recommended provisional categorization of the business and industry development information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of business and industry development information on the ability of responsible agencies to create economic and business opportunities and stimulus, and promote financial and economic stability for corporations and citizens involved in different types of business. The consequences of unauthorized disclosure of most business and industry development information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: There may be some cases for which moderate confidentiality impact is associated with unauthorized disclosure of business/industry development. For example, unauthorized disclosure of private information concerning individuals or businesses can result in legal expense and serious effects on public confidence in the agency. Similarly, unauthorized disclosure of details of current agency business and industry development activities and plans can serve to focus opposition and/or give an unfair advantage to competing interests. Additionally, there are legislative mandates prohibiting unauthorized disclosure of trade secrets. Trade secrets will generally be assigned a moderate confidentiality impact level."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for business/industry development information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to business and industry development information. Missions supported by business and industry development information are generally tolerant of delay."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for business and industry development information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of business and industry development information may depend on the urgency with which the information is typically needed. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most business and industry development information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.9.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Economic Development",
+                "title": "Intellectual Property Protection",
+                "description": "The provisional availability impact level recommended for business and industry development information is low.",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of intellectual property protection information on the abilities of responsible agencies to enforce intellectual property including inventions, literary and artistic works, and symbols, names, images, and designs used in commerce. The consequences of unauthorized disclosure of the majority of intellectual property protection information will result in, at most, a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: There are legislative mandates prohibiting unauthorized disclosure of trade secrets. Trade secrets will generally be assigned a moderate confidentiality impact level. In the case of patent activities, technical details of applications involving inventions with military applications and with deliberations concerning withholding patents as a result of national security considerations may be sensitive. (In some cases, the patent application information may be classified or to contain information concerning weapons or weapons systems. In such cases, the information would be national security information, and outside the scope of this guideline.)"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for intellectual property protection information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to intellectual property protection information. The nature of intellectual property protection processes is tolerant of reasonable delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for intellectual property protection information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of intellectual property protection information depends on the criticality of the information with respect to agency mission capability, protection of agency assets, and safety of individuals. The effects of modification or deletion of this information are generally limited with respect to agency mission capabilities or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for intellectual property protection information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.9.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Economic Development",
+                "title": "Financial Sector Oversight",
+                "description": "Financial Sector Oversight involves the regulation of private sector firms and markets (stock exchanges, corporations, etc.) to protect investors from fraud, monopolies, and illegal behavior. This also includes deposit protection. The recommended provisional categorization of the financial sector oversight information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of financial sector oversight information on the ability of responsible agencies to regulate private sector firms and markets (stock exchanges, corporations, etc.) to protect investors from fraud, monopolies, and illegal behavior. This also includes deposit protection, creation, regulation, and control of the nation\u2019s currency and coinage supply and demand. Special Factors Affecting Confidentiality Impact Determination: While the consequences of unauthorized disclosure of some financial sector oversight information would have only a limited adverse effect on agency operations, agency assets, or individuals, there are significant exceptions. Unauthorized disclosure of much financial sector oversight information can result in major financial consequences. This can result in assignment of a high impact level to such information. In some cases, premature disclosure of regulatory information can impact major financial markets and damage national banking and finance infrastructures. For example, unauthorized disclosure of a decision to increase the money supply or of an ongoing securities fraud investigation can have a dramatic effect on financial markets. This can result in assignment of a high impact level to such information. Unauthorized disclosure to a single institution (e.g., a major banking institution or brokerage house), could damage faith in regulatory institutions and result in even more market disruption and have a severe or catastrophic adverse effect on public confidence in the agency. This can result in assignment of a high impact level to such information. Even where the consequences are limited to giving an unfair market advantage to a single financial or commercial institution, unauthorized disclosure can have a serious adverse effect on public confidence in the agency and its staff. This can result in assignment of a high impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for financial sector oversight information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to financial sector oversight information. Missions supported by financial sector oversight information are generally tolerant of delay."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for financial sector oversight information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. T he consequences of unauthorized modification or destruction of financial sector oversight information depends on whether the information is time-critical. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Integrity Impact Determination: Where unauthorized modification or destruction of financial sector oversight information facilitates or enables catastrophic consequences, the integrity impact level may be high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most financial sector oversight information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.9.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Economic Development",
+                "title": "Industry Sector Income Stabilization",
+                "description": "Industry Sector Income Stabilization involves all programs and activities devoted to assisting adversely impacted industrial sectors (farming, commercial transportation, etc.) to ensure the continued availability of their services for the American public and the long-term economic stability of these sectors. The provisional recommended security categorization for the industry sector income stabilization information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of industry sector income stabilization information on the ability of responsible agencies to assist adversely impacted industrial sectors (farming, commercial transportation, etc.) to ensure the continued availability of their services for the American public and the long-term economic stability of these sectors. In most cases, unauthorized disclosure of industry sector income stabilization information will have only a limited adverse effect on agency operations, assets, or individuals. However, unauthorized premature disclosure of Federal government plans for industry sector income stabilization actions (e.g., grants or subsidies) as well as of government economic forecasts and commentary preliminary to formulation of plans may result in major financial consequences. Unauthorized and premature disclosure to a single institution (e.g., a major manufacturing institution, a major agribusiness institution, or a commodity brokerage house), could damage confidence in economic stabilization institutions and have a severe adverse effect on public confidence in the government."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for industry sector income stabilization information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to industry sector income stabilization information. Industry sector income stabilization processes are generally tolerant of delay. In most cases, disruption of access to industry sector income stabilization information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for industry sector income stabilization information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Industry sector income stabilization activities are not generally time-critical. In most cases, the adverse effects of unauthorized modification or destruction of industry sector income stabilization information on agency mission functions and public confidence in the agency will be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for industry sector income stabilization information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.10.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Community and Social Services",
+                "title": "Homeownership Promotion",
+                "description": "Homeownership Promotion includes activities devoted to assisting citizens interested in buying homes and educating the public as to the benefits of homeownership. Note: Activities devoted to the provision of housing to low-income members of the public are covered under the Housing Assistance mission. The recommended provisional categorization of the homeownership promotion information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of homeownership promotion information on the ability of responsible agencies to assist citizens interested in buying homes and educating the public as to the benefits of homeownership. The consequences of unauthorized disclosure of most homeownership promotion information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions that might have a potential for more serious consequences are based on privacy information processed in training and employment systems (e.g., information required by the Privacy Act of 1974 or other statutes and executive orders to receive special handling to protect the privacy of individuals). The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for homeownership promotion information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to homeownership promotion information. The effects of disruption of access to most homeownership promotion information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for homeownership promotion information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of homeownership promotion information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited"
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended most homeownership promotion information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.10.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Community and Social Services",
+                "title": "Community and Regional Development",
+                "description": "The Community and Regional Development mission involves activities designed to assist communities in preventing and eliminating blight and deterioration, assist economically distressed communities, and encourage and foster economic development through improved public facilities and resources. The recommended provisional categorization of the community and regional development information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of community and regional development information on the ability of responsible agencies to assist communities in preventing and eliminating blight and deterioration, assist economically distressed communities, and encourage and foster economic development through improved public facilities and resources. The consequences of unauthorized disclosure of most community and regional development information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions that might have a potential for more serious consequences are based on privacy information processed in training and employment systems (e.g., information required by the Privacy Act of 1974 or other statutes and executive orders to receive special handling to protect the privacy of individuals). The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Another exception might be unauthorized disclosure of information that gives an individual or corporate entity an unfair competitive advantage in obtaining contracts or other funding for development activities. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for community and regional development information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to community and regional development information. The effects of disruption of access to most community and regional development information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for community and regional development information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of community and regional development information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited"
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most community and regional development information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.10.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Community and Social Services",
+                "title": "Social Services",
+                "description": "Social Services are designed to provide meaningful opportunities for social and economic growth of the disadvantaged sector of the population in order to develop individuals into productive and self-reliant citizens and promote social equity. Included in this category are social welfare services extended to children and adults with special needs, such as the orphaned, neglected, abandoned, disabled, etc. Such services include family life education and counseling, adoption, guardianship, foster family care, rehabilitation services, etc. Note: This mission does not include services that are primarily for income support (Income Security) or are an integral part of some other mission area (e.g., Health, Workforce Management, etc.). The recommended provisional categorization of the social services information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of social services information on the ability of responsible agencies to provide meaningful opportunities for social and economic growth of the disadvantaged sector of the population in order to develop individuals into productive and self-reliant citizens and promote social equity. The consequences of unauthorized disclosure of most social services information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions that might have a potential for more serious consequences include privacy information processed in training and employment systems (e.g., information required by the Privacy Act of 1974 or other statutes and executive orders to receive special handling to protect the privacy of individuals). The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Other exceptions include unauthorized disclosure of information that might assist criminals to perpetrate fraud, particularly with respect to income security disbursements. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for social services information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to social services information. The effects of disruption of access to most social services information or information systems would have, at most, a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for social services information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of social services information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Another threat is that of unauthorized modification of information to support fraudulent activities. This might result in harm to individuals, but not to agency operations or missions."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most social services information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.10.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Community and Social Services",
+                "title": "Postal Services",
+                "description": "Postal Services provide for the timely and consistent exchange and delivery of mail and packages between businesses, organizations, and residents of the United States or between businesses, organizations, and residents of the United States and the rest of the world. It also includes the nation-wide retail infrastructure required to make Postal Services easily accessible to customers. (Note: The commercial function of mail is more closely aligned with the \u201cBusiness and Industry Development\u201d mission in the \u201cEconomic Development mission area.\u201d The international commercial function of mail is more closely aligned with the \u201cGlobal Trade\u201d mission in the \u201cInternational Affairs\u201d mission area). The recommended provisional categorization of thee postal services information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of postal services information on the ability of responsible agencies to provide for the timely and consistent exchange and delivery of mail and packages between businesses, organizations, and residents of the United States or between businesses, organizations, and residents of the United States and the rest of the world. The consequences of unauthorized disclosure of most postal services information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions that might have a potential for more serious consequences include privacy information (e.g., information required by the Privacy Act of 1974 or other statutes and executive orders to receive special handling to protect the privacy of individuals). The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Other exceptions include unauthorized disclosure of information that might assist criminals to perpetrate fraud, particularly with respect to income security disbursements. Because registered mail can be employed to transmit classified information, information regarding some registered mail can facilitate unauthorized access to national security information. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most postal services information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to postal services information. The effects of disruption of access to most postal services information or information systems would have an adverse effect on agency operations. Because most postal services information is time critical, extended widespread outages could seriously affect the commerce of the United States."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for postal services information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of postal services information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Integrity Impact Determination: The consequences of unauthorized modification or destruction of postal information might provide terrorists the tools to carry out an attack. The consequences in terms of critical infrastructure protection and risk to human life may be severe. In such cases, the integrity impact of compromise would be high. Another threat is that of unauthorized modification of information to support fraudulent activities (e.g., misdirection of monetary instruments, execution of fraudulent financial transactions). This might result in harm to individuals, but not to agency operations or missions."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most postal services information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.11.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Transportation",
+                "title": "Ground Transportation",
+                "description": "Ground Transportation involves the activities related to ensuring the availability of transit and the safe passage of passengers and goods over land. Water and fuel pipelines are included among ground transportation assets. Note: The protection of ground transportation from deliberate attack is included in the Transportation Security information type under the Homeland Security mission area. The recommended provisional security categorization for the ground transportation information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of ground transportation information on the ability of responsible agencies to ensure the availability of transit and the safe passage of passengers and goods over land. The protection of ground transportation from deliberate attack is included in the Transportation Security information type under the Homeland Security mission area. For most cases, unauthorized disclosure of ground transportation information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Some regulatory and tariff enforcement functions associated with the safe passage of passengers and goods over land involve relatively sensitive information. These are included in Law Enforcement. Unauthorized disclosure of accident investigation information that has not yet been adequately researched, coordinated, or edited can result in serious economic harm to individuals and to corporations. Loss in public confidence is a further potential consequence. Additionally, some information associated with ground transportation functions is proprietary to corporations or subject to privacy laws (e.g., the Privacy Act of 1974). (The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type.) In such cases, the confidentiality impact resulting from unauthorized disclosure may be moderate. Some military ground transportation information is national security information and is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for ground transportation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to ground transportation information. Most ground transportation processes are tolerant of reasonable delays. In most cases, disruption of access to ground transportation information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Some ground transportation functions are time-critical (e.g., track switching functions associated with rail travel). Loss of availability of time-critical information necessary to these functions can result in large-scale property loss and in loss of human lives. Such information will have a high integrity impact level."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for ground transportation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In most cases, the adverse effects of unauthorized modification or destruction of ground transportation information on agency mission functions and public confidence in the agency will be limited. Special Factors Affecting Integrity Impact Determination: Some ground transportation functions are time-critical (e.g., track switching functions associated with rail travel). Unauthorized modification or destruction of time-critical information necessary to these functions can result in large-scale property loss and in loss of human lives. Such information will have a high integrity impact level."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for ground transportation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.11.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Transportation",
+                "title": "Water Transportation",
+                "description": "Water Transportation involves the activities related to ensuring the availability of transit and the safe passage of passengers and goods over sea and water. Note: The protection of maritime transportation from deliberate attack is included in the Transportation Security information type under the Homeland Security mission area. The general recommended security categorization for the water transportation information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of water transportation information on the ability of responsible agencies to ensure the availability of transit and the safe passage of passengers and goods over sea and water. The protection of water transportation from deliberate attack is included in the Transportation Security information type under the Homeland Security mission area. Some regulatory and tariff enforcement functions associated with the safe passage of passengers and goods over sea and water involve relatively sensitive information. These are included in Law Enforcement. In most cases, unauthorized disclosure of water transportation information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of accident investigation information that has not been adequately researched, coordinated, or edited can result in serious economic harm to individuals and to corporations. Loss in public confidence is a further potential consequence. Additionally, some information associated with water transportation functions is proprietary to corporations or subject to privacy laws. In such cases, the confidentiality impact resulting from unauthorized disclosure can be moderate. Some military sea and water transportation information is national security information and is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for water transportation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to water transportation information. Most water transportation processes are tolerant of reasonable delays. In most cases, disruption of access to water transportation information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Some water and sea transportation functions are time-critical (e.g., distress signals, docking operations, collision avoidance, warnings of hazardous weather or sea conditions). Loss of availability of time-critical information necessary to these functions can result in large-scale property loss and in loss of human lives. Such information would have a high integrity impact level."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for water transportation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. In most cases, the adverse effects of unauthorized modification or destruction of water transportation information on agency mission functions and public confidence in the agency will be limited. Special Factors Affecting Integrity Impact Determination: Some water and sea transportation functions are time-critical (e.g., distress signals, docking operations, collision avoidance, warnings of hazardous weather or sea conditions). Unauthorized modification or destruction of time-critical information necessary to these functions can result in large-scale property loss and in loss of human lives. Such information would have a high integrity impact level. Communications management (e.g., frequency management) information also needs to be included in water transportation integrity impact considerations. There may be circumstances when errors in frequency assignment information can result in an inability for Federal government agencies to communicate with state or local government activities. The subsequent loss of communications capabilities can result in life-threatening situations. Such information would have a high integrity impact level."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for water transportation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.11.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Transportation",
+                "title": "Air Transportation",
+                "description": "Air Transportation involves the activities related to the safe passage of passengers or goods through the air. It also includes command and control activities related to the safe movement of aircraft through all phases of flight for commercial and military operations. Note: The protection of air transportation from deliberate attack is included in the Transportation Security information type under the Homeland Security mission area. The general recommended security categorization for the air transportation information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of air transportation information on the ability of responsible agencies to ensure the safe passage of passengers and goods through the air. The protection of air transportation from deliberate attack is included in the Transportation Security information type under the Homeland Security mission area. Some regulatory and tariff enforcement functions associated with the safe passage of passengers and goods over land involve sensitive information. These are treated under Law Enforcement. In most cases, unauthorized disclosure of air transportation information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of information (e.g., investigations, maintenance) that has not been adequately researched, coordinated, or edited can result in serious economic harm to individuals and to corporations. Loss in public confidence is a further potential consequence. Additionally, some information associated with air transportation functions is proprietary to corporations or subject to privacy laws. In such cases, the confidentiality impact resulting from unauthorized disclosure can be moderate. The sensitivity of air transportation information (e.g., aircraft positioning data)can be time or event-driven. For example, passenger lists are not releasable to the general public before a flight takes off, but are placed in the public domain in the event of a crash. In such cases, the confidentiality impact resulting from unauthorized disclosure can be moderate. Also, much military air transport information is national security information and is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for air transportation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to air transportation information. Special Factors Affecting Availability Impact Determination: Some air transportation functions are time-critical (e.g., air traffic control instructions, position reports, situational awareness, separation, weather reports for the terminal area, microburst tracking, maintenance trouble reports). Loss of availability of time-critical information necessary to these functions can result in large-scale property loss and in loss of human lives. Timing plays a large part in the availability impact of air transportation information. For example, the time criticality of weather information may be measured in minutes or hours in the case of pre-flight and mid-flight operations. However, on final landing approach, up to the second availability may be required (e.g., detection of microbursts in the terminal area). Air operations are not tolerant of information loss. The Wide Area Augmentation System (WAAS) supplements the availability of information available from the Department of Defense's Global Positioning Systems (GPS). Because of the potential system-wide impacts from a loss of availability of this system, it would be appropriately categorized as having a high availability impact. The following example illustrates the use of controls to address a high integrity impact level: The systems designed for command and control for air traffic control (e.g., the NAS systems) have been designed for robust operations. However, in general, loss of availability for the majority of systems does not cause derogation in safety. The impacts of a loss of availability (or the loss of availability due to the loss of integrity) include local or system-wide air traffic delays, diversion of traffic to alternate airports, etc., and the economic losses related to those delays, diversions, etc. Severe impacts are not the norm because the loss of availability is inevitable, and the systems have been designed to accommodate failures. In light of the above, the Recommended Availability Impact Level is moderate."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for most air transportation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Many air transportation functions do not process time-critical information. Special Factors Affecting Integrity Impact Determination: Some air transportation functions are time-critical (e.g., air traffic control instructions, position reports, situational awareness, separation, weather reports for the terminal area, microburst tracking, maintenance trouble reports). Communications management (e.g., frequency management) information also needs to be included in air transportation integrity impact considerations. There may be circumstances under which erroneous frequency assignment information can result in a loss of communications with aircraft that are affected by hazardous conditions (e.g., loss of communications with an aircraft in a crowded air space.) Unauthorized modification or destruction of time-critical information necessary to these functions can result in large-scale property loss and in loss of human lives. The Wide Area Augmentation System (WAAS) supplements the availability and integrity of position information available from the DoD's Global Positioning Systems (GPS). Because of the potential system-wide impacts from a loss of integrity of this system, a high integrity impact level is recommended. The following example illustrates the use of controls to address a high integrity impact level: Systems designed for command and control for air traffic control (e.g., the NAS systems) have been designed for robust operations. In the NAS, integrity and availability issues are closely linked. The loss of integrity in a system is monitored continuously, and the loss of integrity is treated as a loss of availability, and in general, loss of availability for the majority of systems does not cause derogation in safety. That is, if the operational parameters for an Instrument Landing System are detected to be out of established tolerances, the system is immediately removed from service - it is powered down and users are notified that the particular service is not available. In most cases, a loss of availability is preferred to continued availability with degraded integrity. The impacts of the loss of availability due to the loss of integrity include system-wide air traffic delays, diversion of traffic to alternate airports - and the economic losses related to those delays, diversions, etc. Severe impacts are not the norm because the loss of availability is assumed to be inevitable, and the systems have been designed to accommodate failures. In light of the above, the Recommended Integrity Impact Level is moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most air transportation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.11.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Transportation",
+                "title": "Space Operations",
+                "description": "Space Operations involves the activities related to the safe launches/missions of passengers or goods into aerospace and includes commercial, scientific, and military operations. The recommended provisional security categorization for the space operations information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-high"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-high"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of space operations information on the ability of responsible agencies to conduct safe launches/missions of passengers or goods into space and includes commercial, scientific, and military operations. The protection of space operations from deliberate attack involves military operations (D.1), homeland security operations (D.2), and law enforcement operations (D.16). In most cases, unauthorized disclosure of space operations information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Civilian space operations are intended to be conducted in the open. Administrative and business functions associated with space operations may involve proprietary, procurement-sensitive, and Privacy Act information. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. In such cases, the confidentiality impact resulting from unauthorized disclosure can be moderate. Some information regarding space operations (particularly military operations) is classified national security information and is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for space operations information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to space operations information. Space operations are typically characterized by critical operational timing and safety parameters and low tolerance for error. Loss of availability of time-critical information necessary to these functions can result in large-scale property loss and in loss of human lives. Also, air operations are not tolerant of information loss."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for space operations information is high."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Space operations are typically characterized by critical operational timing and safety parameters, and low tolerance for error. Unauthorized modification or destruction of time-critical information necessary to these functions may result in significant property loss and loss of human lives. Communications management (e.g., frequency management) information also needs to be included in integrity impact determination for space operations. Erroneous frequency assignment information can result in loss of communications with spacecraft that can endanger mission operations and human safety."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for space operations information is high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.12.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Education",
+                "title": "Elementary, Secondary, and Vocational Education",
+                "description": "Elementary, secondary, and vocational education refers to the provision of education in elementary subjects (reading and writing and arithmetic); education provided by a high school or college preparatory school; and vocational and technical education and training. The recommended provisional categorization of the elementary, secondary, and vocational education information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of elementary, secondary, and vocational education information on the ability of responsible agencies to provide guidance and consultative services. The consequences of unauthorized disclosure of most elementary, secondary, and vocational education information would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for elementary, secondary, and vocational education information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The effects of disruption of access to most elementary, secondary, and vocational education information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for elementary, secondary, and vocational education information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of elementary, secondary, and vocational education information would have a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for elementary, secondary, and vocational education information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.12.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Education",
+                "title": "Higher Education",
+                "description": "Higher Education refers to education beyond the secondary level; specifically, education provided by a college or university. It includes external higher educational activities performed by the government (e.g., Military Academies, ROTC, and USDA Graduate School). The recommended provisional categorization of the higher education information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of higher education information on the ability of responsible agencies to support education beyond the secondary level (e.g., Military Academies, ROTC, USDA Graduate School, and other public and private universities and colleges). The consequences of unauthorized disclosure of most higher education information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions are based on the mission supported by the external training and education activity. In such cases, the impact on the system is defined by the information associated with the supported mission. This can result in assignment of a moderate or high impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for higher education information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to higher education information. The effects of disruption of access to most higher education information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for higher education information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of higher education information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Integrity Impact Determination: Exceptions that might result in more serious consequences are based on the mission supported by the higher education activity (e.g., undetected modification of weapons training information at a service academy where the modification could result in harm to the student or other individuals). In such cases, the impact is determined by the information associated with the supported mission. This can result in assignment of a moderate or high impact level to such information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for higher education information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.12.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Education",
+                "title": "Cultural and Historic Preservation",
+                "description": "Cultural and Historic Preservation involves all activities performed by the Federal Government to collect and preserve information and artifacts important to the culture and history of the United States and its citizenry and the education of U.S. citizens and the world. The recommended provisional categorization of the cultural and historic preservation information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of cultural and historic preservation information on the ability of responsible agencies to collect and preserve information and artifacts important to the culture and history of the United States and its citizenry and the education of U.S. citizens and the world. The consequences of unauthorized disclosure of most cultural and historic preservation information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In cases where disclosure of information might be useful to an individual or organization intent on destruction of historical materials, the potential consequences to key national assets could be serious to severe. In such cases, the confidentiality impact could be moderate to high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for cultural and historic preservation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to cultural and historic preservation information. The effects of disruption of access to most cultural and historic preservation information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for cultural and historic preservation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of cultural and historic preservation information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Integrity Impact Determination: In cases where undetected modification of information might be useful to an individual or organization intent on destruction of historical materials, the potential consequences to key national assets could be serious to severe. Consequently, the integrity impact could be moderate to high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for cultural and historic preservation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.12.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Education",
+                "title": "Cultural and Historic Exhibition",
+                "description": "Cultural and Historic Exhibition includes all activities undertaken by the U.S. government to promote education through the exhibition of cultural, historical, and other information, archives, art, etc. The recommended provisional categorization of the cultural and historic exhibition information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of cultural and historic exhibition information on the ability of responsible agencies to promote education through the exhibition of cultural, historical, and other information, archives, art, etc. The consequences of unauthorized disclosure of most cultural and historic exhibition information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In cases where disclosure of information might be useful to an individual or organization intent on destruction of historical materials or archives, the potential consequences to key national assets could be serious to severe. Consequently, the confidentiality impact could be moderate to high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for cultural and historic exhibition information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to cultural and historic exhibition information. The effects of disruption of access to most cultural and historic exhibition information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for cultural and historic exhibition information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of cultural and historic exhibition information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Integrity Impact Determination: In cases where undetected modification of information might be useful to an individual or organization intent on the destruction of historical materials or archives, the potential consequences to key national assets could be serious to severe. Consequently, the integrity impact could be moderate to high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for cultural and historic exhibition information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.13.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Workforce Management",
+                "title": "Training and Employment",
+                "description": "Training and Employment includes programs of job or skill training, employment services and placement, and programs to promote the hiring of marginal, unemployed, or low-income workers. Additionally, training information can include special training for personnel involved in Federal government operations (e.g., astronaut training). The recommended provisional categorization of the training and employment information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of training and employment information on the ability of responsible agencies to provide job or skill training, employment services and placement, and programs to promote the hiring of marginal, unemployed, or low-income workers. The consequences of unauthorized disclosure of most training and employment information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions that might have a potential for more serious consequences are based on privacy information processed in training and employment systems (e.g., information required by the Privacy Act of 1974 or other statutes and executive orders to receive special handling to protect the privacy of individuals). The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for training and employment information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to training and employment information. The effects of disruption of access to most training and employment information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for training and employment information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of training and employment information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Confidentiality Impact Determination: In the case of training aimed at achieving or improving proficiency in specialty occupations (e.g., astronaut training), the consequences of integrity compromises can threaten missions, or even human safety. In such cases, the integrity impact level can range from moderate to high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for training and employment information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.13.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Workforce Management",
+                "title": "Labor Rights Management",
+                "description": "Labor Rights Management refers to those activities undertaken to ensure that employees and employers are aware of and comply with all statutes and regulations concerning labor rights, including those pertaining to wages, benefits, safety and health, whistleblower, and nondiscrimination policies. The recommended provisional categorization of the labor rights management information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of labor rights management information on the ability of responsible agencies to ensure that employees and employers are aware of and comply with all statutes and regulations concerning labor rights, including those pertaining to wages, benefits, safety and health, whistleblower, and nondiscrimination policies. In some cases, premature release of draft labor rights bulletins might adversely affect the effectiveness of agency operations. In general, the consequences of unauthorized disclosure of most labor rights management information would have, a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for labor rights management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to labor rights management information. The effects of disruption of access to most labor rights management information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for labor rights management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. The consequences of unauthorized modification or destruction of labor rights management information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for labor rights management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.13.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Workforce Management",
+                "title": "Worker Safety",
+                "description": "Worker Safety refers to those activities undertaken to save lives, prevent injuries, and protect the health of America's workers. The recommended provisional categorization of the worker safety information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of worker safety information on the ability of responsible agencies to protect the health and safety of America\u2019s workers. In some cases, premature release of draft worker safety bulletins might adversely affect the effectiveness of agency operations. In general, the consequences of unauthorized disclosure of worker safety information would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for worker safety information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to worker safety information. The effects of disruption of access to most worker safety information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for worker safety information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of worker safety information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for worker safety information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.14.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Health",
+                "title": "Access to Care",
+                "description": "Access to Care focuses on the access to appropriate care. This includes streamlining efforts to receive care; ensuring care is appropriate in terms of type, care, intensity, location and availability; providing seamless access to health knowledge, enrolling providers; performing eligibility determination, and managing patient movement. The recommended provisional security categorization for access to care information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of access to care information on the ability of responsible agencies to focus on the access to appropriate care. This includes streamlining efforts to receive care; ensuring care is appropriate in terms of type, care, intensity, location and availability; providing seamless access to health knowledge, enrolling providers; performing eligibility determination, and managing patient movement will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Some information associated with health care involves confidential patient information subject to the Privacy Act and to HIPAA. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Other information (e.g., information proprietary to hospitals, pharmaceutical companies, insurers, and care givers) must be protected under rules governing proprietary information and procurement management. In some cases, unauthorized disclosure of this information such as privacy-protected medical records can have serious consequences for agency operations. In such cases, the confidentiality impact level may be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of access to care information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to care. Access to care is generally tolerant of delay. Typically, disruption of access to care information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Some access to care information could be deemed time-critical and is dependent on the severity of the health issue requiring immediate access to care, patient movements, etc.. Delays in the communication of specific situations may cause serious impacts to the patient or care provide. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for access to care information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Many activities associated with access to care information are not time critical and the adverse effects of unauthorized modification or destruction of health care information on agency mission functions and/or public confidence in the agency will be limited. However, the consequences of unauthorized modification or destruction of health care information may result in incorrect, inappropriate, or excessively delayed treatment of patients. In these cases, serious adverse effects can include legal actions and danger to human life. Unauthorized modification or destruction of information affecting external communications that contain health care information (e.g., web pages, electronic mail) may adversely affect operations and public confidence in the agency and the agency mission."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for access to care information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.14.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Health",
+                "title": "Population Health Management and Consumer Safety",
+                "description": "Population Health Management and Consumer Safety assesses health indicators and consumer products as a means to protect and promote the health of the general population. This includes monitoring of health, health planning, and health management of humans, animals, animal products, and plants, as well as tracking the spread of diseases and pests. It also includes evaluation of consumer products, drug, and foods to assess the potential risks and dangers; education of the consumer and the general population; and facilitation of health promotion and disease and injury prevention. The recommended provisional security categorization for population health management and consumer safety information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of population health management and consumer safety information on the ability of responsible agencies to assess health indicators and consumer products as a means to protect and promote the health of the general population that will have only a limited adverse effect on agency operations, assets, or individuals. The basic nature of this information type is to support the public and consumer market with information and supporting education. Special Factors Affecting Confidentiality Impact Determination: The most serious adverse effects are likely to involve premature release of health planning and management information, disclosure of sensitive mission support information [agencies\u2019 means to combat spread of diseases or reacting to terrorist attacks on food, water, and other public consumables], or the exposure of information that is proprietary to an organization being evaluated by the agency [Unauthorized disclosure of some information can have serious economic impact on both individual companies and the broader market place. The consequences of such unauthorized disclosures may have an adverse effect on public confidence in the agency.] This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of Health Management and Consumer Safety information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish population health management and consumer safety. Population health management and consumer safety are generally tolerant of delay. Typically, disruption of population health management and consumer safety information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Delays in the communication of product deficiencies or issues associated with food, plant and animal sources may be life threatening. Delays in agency response to public health issues involving humans, animals, animal products, and plants, as well as tracking the spread of diseases and pests may also be life threatening or significantly degrade public safety. This can result in assignment of a high impact level to such information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for population health management and consumer safety information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of population health management and consumer safety information can be serious if the public is exposed to mislabeled, tainted, or otherwise harmful food, drugs, or consumer products. Special Factors Affecting Integrity Impact Determination: Impacts to some population health management and consumer safety information and supporting information systems associated with quality assurance of food, animal, plant and pharmaceuticals may affect the security of critical agriculture and food and public health infrastructures. Additionally, unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and public confidence in the agency and the agency mission. In such cases, unauthorized modification or destruction of information can result in loss of human life. This can result in assignment of a high impact level to such information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for population health management and consumer safety information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.14.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Health",
+                "title": "Health Care Administration",
+                "description": "Health Care Administration assures that federal health care resources are expended effectively to ensure quality, safety, and efficiency. This includes managing health care quality, cost, workload, utilization, and fraud/abuse efforts.",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of Health Care Administration on the ability of responsible agencies to assure that federal health care resources are expended effectively to ensure quality, safety, and efficiency will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Much information associated with public health monitoring involves confidential patient information subject to the Privacy Act and to HIPAA. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. In some cases, unauthorized disclosure of this information such as privacy-protected medical records can have serious consequences for agency operations. In such cases, the confidentiality impact level may be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of Health Care Administration information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish Health Care Administration information. Health Care Administration information is generally tolerant of delay. Typically, disruption of Health Care Administration information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for Health Care Administration information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external communications that contain Health Care Administration information (e.g., web pages, electronic mail) may adversely affect operations and public confidence in the agency and also the agency mission. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of Health Care Administration information can result in inappropriate allocation or deployment of health care services and possible loss of human life. This can result in assignment of a high impact level to such information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for Health Care Administration information is Moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.14.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Health",
+                "title": "Health Care Delivery Services",
+                "description": "Health Care Delivery Services provides and supports the delivery of health care to its beneficiaries. This includes assessing health status; planning health services; ensuring quality of services and continuity of care; and managing clinical information and documentation. The recommended provisional security categorization for health care delivery services information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-high"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of health care delivery services on the ability of responsible agencies to provide and support the delivery of health care to its beneficiaries will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Some information associated with health care involves confidential patient information subject to the Privacy Act and to HIPAA. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Other information (e.g., information proprietary to hospitals, pharmaceutical companies, insurers, and care givers) must be protected under rules governing proprietary information and procurement management. In some cases, unauthorized disclosure of this information such as privacy-protected medical records can have serious consequences for agency operations. In such cases, the confidentiality impact level may be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of health care delivery services information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish Health Care Administration information. Except for cases of emergency actions necessary to correct urgent threats to patient health, health care processes are usually tolerant of reasonable delays. Special Factors Affecting Availability Impact Determination: Some health care delivery services information is time-critical and is dependent on the severity of the health threat(s) and the rapidity with which the threat is spreading/ growing. Delays in the communication of specific situations may be life threatening. This can result in assignment of a moderate or high impact level to such information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for health care delivery services information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Many activities associated with health care delivery services are not time critical and the adverse effects of unauthorized modification or destruction of health care information on agency mission functions and/or public confidence in the agency will be limited. However, the consequences of unauthorized modification or destruction of health care information may result in incorrect, inappropriate, or excessively delayed treatment of patients. In these cases, serious adverse effects can include legal actions and danger to human life. Unauthorized modification or destruction of information affecting external communications that contain health care information (e.g., web pages, electronic mail) may adversely affect operations and public confidence in the agency and the agency mission."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "Because of the potential for the loss of human life, the provisional integrity impact level recommended for health care delivery services information is high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.14.5"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Health",
+                "title": "Health Care Research and Practitioner Education",
+                "description": "Health Care Research and Practitioner Education fosters advancement in health discovery and knowledge. This includes developing new strategies to handle diseases; promoting health knowledge advancement; identifying new means for delivery of services, methods, decision models and practices; making strides in quality improvement; managing clinical trials and research quality; and providing for practitioner education. The recommended provisional security categorization for health care research and practitioner education information is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of health care research and practitioner education on the ability of responsible agencies to fosters advancement in health discovery and knowledge will have only a limited adverse effect on agency operations, assets, or individuals."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for disclosure of health care research and practitioner education information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish health care research and practitioner education. Health care research and practitioner education information are generally tolerant of delay. Typically, disruption of health care research and practitioner education information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for health care research and practitioner education information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external communications that contain health care research and practitioner education information (e.g., web pages, electronic mail) may adversely affect operations and public confidence in the agency and also the agency mission."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for health care research and practitioner education information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.15.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Income Security",
+                "title": "General Retirement and Disability",
+                "description": "General Retirement and Disability involves the development and management of retirement benefits, pensions, and income security for those who are retired or disabled. Related information types affecting qualification and disbursement of benefits are discussed in Appendix C\u2019s Sections C.2.8.8, C.2.8.9, C.2.8.10, C.2.8.11, and C.3.2.5. The recommended provisional categorization of the general retirement and disability information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of general retirement and disability information on the ability of responsible agencies to develop and manage retirement benefits, pensions, and income security for those who are retired or disabled. The consequences of limited unauthorized disclosure of retirement and disability information would have a limited adverse effect on agency operations, agency assets, or individuals. The disclosure of privacy information (e.g., information required by the Privacy Act of 1974 or other statutes and executive orders to receive special handling to protect the privacy of individuals) may have serious consequences. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. Unauthorized disclosure of large amounts of general retirement and disability information may result in significant damage to an agency\u2019s image or operation."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The confidentiality impact recommended for general retirement and disability information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to general retirement and disability information. The effects of disruption of access to general retirement and disability information or information systems would have, in many cases, a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Where provision of retirement and/or disability benefits is a primary agency service delivery mission, the consequences can be more severe. Availability compromises may result in reduction of benefits \u2013 and in extreme cases can be life threatening. This can result in assignment of a high impact level to such information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for general retirement and disability information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Generally, the consequences of unauthorized modification or destruction of general retirement and disability information would have a limited adverse effect on agency operations, agency assets, or individuals. However, where provision of retirement and/or disability benefits is a primary agency service delivery mission, the consequences can be more severe. Special Factors Affecting Integrity Impact Determination: Integrity compromises may result in reduction of benefits\u2013 and in extreme cases can be life threatening. This can result in assignment of a high impact level to such information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for general retirement and disability information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.15.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Income Security",
+                "title": "Unemployment Compensation",
+                "description": "Unemployment Compensation provides income security to those who are no longer employed, while they seek new employment. The recommended provisional categorization of the unemployment compensation information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of unemployment compensation information on the ability of responsible agencies to provide income security to those who are no longer employed, while they seek new employment. The consequences of unauthorized disclosure of most unemployment compensation information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions that might have a potential for more serious consequences are based on privacy information (e.g., information required by the Privacy Act of 1974 or other statutes and executive orders to receive special handling to protect the privacy of individuals). The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for unemployment compensation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to unemployment compensation information. The effects of disruption of access to unemployment compensation information or information systems would have, at most, a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for unemployment compensation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of unemployment compensation information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for unemployment compensation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.15.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Income Security",
+                "title": "Housing Assistance",
+                "description": "Housing Assistance involves the development and management programs that provide housing to those who are unable to provide housing for themselves including the rental of single-family or multifamily properties, and the management and operation of federally supported housing properties. The recommended provisional categorization of the housing assistance information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of housing assistance information on the ability of responsible agencies to develop and manage programs that provide housing to those who are unable to provide housing for themselves including the rental of single-family or multifamily properties, and the management and operation of federally supported housing properties. The consequences of unauthorized disclosure of most housing assistance information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions that might have a potential for more serious consequences are based on privacy information (e.g., information required by the Privacy Act of 1974 or other statutes and executive orders to receive special handling to protect the privacy of individuals). The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for housing assistance information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to housing assistance information. The effects of disruption of access to most housing assistance information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for housing assistance information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of housing assistance information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for housing assistance information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.15.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Income Security",
+                "title": "Food and Nutrition Assistance",
+                "description": "Food and Nutrition Assistance involves the development and management of programs that provide food and nutrition assistance to those members of the public who are unable to provide for these needs themselves. The recommended provisional categorization of the food and nutrition assistance information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of food and nutrition assistance information on the ability of responsible agencies to develop and manage of programs that provide food and nutrition assistance to those members of the public who are unable to provide for these needs themselves. The consequences of unauthorized disclosure of most food and nutrition assistance information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions that might have a potential for more serious consequences are based on privacy information (e.g., information required by the Privacy Act of 1974 or other statutes and executive orders to receive special handling to protect the privacy of individuals). The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact recommended for food and nutrition assistance information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to food and nutrition assistance information. The effects of disruption of access to most food and nutrition assistance information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for food and nutrition assistance information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of food and nutrition assistance information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for food and nutrition assistance information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.15.5"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Income Security",
+                "title": "Survivor Compensation",
+                "description": "Survivor Compensation provides compensation to the survivors of individuals currently receiving or eligible to receive benefits from the Federal Government. This includes survivors such as spouses or children of veterans or wage earners eligible for social security payments. The recommended provisional categorization of the survivor compensation information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of survivor compensation information on the ability of responsible agencies to provide compensation to the survivors of individuals currently receiving or eligible to receive benefits from the Federal Government. The consequences of unauthorized disclosure of most survivor compensation information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions that might have a potential for more serious consequences are based on privacy information (e.g., information required by the Privacy Act of 1974 or other statutes and executive orders to receive special handling to protect the privacy of individuals). The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for survivor compensation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to survivor compensation information. The effects of disruption of access to most survivor compensation information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for survivor compensation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of survivor compensation information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for survivor compensation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.16.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Law Enforcement",
+                "title": "Criminal Apprehension",
+                "description": "Criminal apprehension supports activities associated with the tracking and capture of groups or individuals believed to be responsible for committing Federal crimes. The recommended provisional categorization of the criminal apprehension information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of criminal apprehension information on the ability of responsible agencies to track and capture groups or individuals believed to be responsible for committing Federal crimes, on public safety, and on the safety of law enforcement officers. The consequences of unauthorized disclosure of criminal apprehension information depend 1) on the seriousness of the crime involved, 2) on the capability and predisposition of the criminal to injure or kill civilians or law enforcement officials, 3) timing (e.g., the ability of the criminal to access the information and use it to facilitate a crime or evade capture), and 4) statutory and regulatory requirements which vary by violation. Special Factors Affecting Confidentiality Impact Determination: In cases where 1) the crimes are not violent and do not involve large property losses, and 2) there is no history of violence on the part of the criminal, the confidentiality impact may be low or moderate. For many crimes that are the responsibility of Federal law enforcement agencies, the consequences associated with unauthorized disclosure of criminal apprehension information must often be assumed to pose a threat to human life or result in a loss of major assets. In such cases, confidentiality impact level is high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "For most Federal law enforcement systems that support criminal apprehension activities the harm that results from unauthorized disclosure will be limited. Therefore, the provisional confidentiality impact level recommended for criminal apprehension information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to criminal apprehension information. Missions supported by criminal apprehension information are not typically tolerant of delay. While there are many cases in which elements of criminal apprehension information are not urgent, there are many in which relatively short periods of unavailability can pose a threat to human life and/or result in a loss of major assets."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for most criminal apprehension information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of criminal apprehension information may depend on the urgency with which the information is needed and on the success of subsequent prosecution of the apprehended criminal(s). Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of criminal apprehension information may have an adverse effect on the subsequent prosecution of the apprehended criminal. Consequently, a serious adverse effect on agency operations can result. This can place the agency at a significant disadvantage. In such cases, the integrity impact level recommended for criminal apprehension information is at least moderate. When the criminal apprehension information is time-critical, the unauthorized modification or destruction of this information may have a severe or catastrophic effect on public confidence in the agency, pose a significant threat to major assets, and/or pose a threat to human life. This is applicable for many crimes that are the responsibility of Federal law enforcement agencies. For this criminal apprehension information, the Recommended Integrity Impact Level is high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "For most Federal law enforcement systems that support criminal apprehension activities the harm that results from unauthorized modification or destruction will be limited. Therefore, the provisional integrity impact level recommended for criminal apprehension information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.16.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Law Enforcement",
+                "title": "Criminal Investigation and Surveillance",
+                "description": "Criminal investigation and surveillance includes the collection of evidence required to determine responsibility for a crime and the monitoring and questioning of affected parties. The recommended provisional categorization of the criminal investigation and surveillance information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of criminal investigation and surveillance information on the ability of responsible agencies to collect evidence required to determine responsibility for a crime, to monitor and question affected parties, and to protect the safety of witnesses and law enforcement officers. The consequences of unauthorized disclosure of criminal investigation and surveillance information depend 1] on the seriousness of the crime involved, 2] timing (e.g., the ability of the criminal39 to access the information and use it to facilitate a crime, to evade detection or surveillance, or eliminate probable cause for searches and warrants), and 3] on the capability and predisposition of the criminal to injure witnesses or law enforcement officials. Special Factors Affecting Confidentiality Impact Determination: In cases where 1) the crimes are not violent and do not involve large property losses, and 2) there is no history of violence on the part of the criminal, the confidentiality impact may be low or moderate. Given the nature of many of the crimes that are the responsibility of Federal law enforcement agencies, the consequences associated with unauthorized disclosure of criminal investigation and surveillance information must often be assumed to pose a threat to human life or result in a loss of major assets. Information that reveals the identity and/or location of informants may be of particular concern. In such cases, the confidentiality impact level is high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for criminal investigation and surveillance information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to criminal investigation and surveillance information. Missions supported by criminal investigation and surveillance information are not always tolerant of delay. Special Factors Affecting Availability Impact Determination: There are some cases in which relatively short periods of unavailability of criminal investigation and surveillance information may result in lost surveillance opportunities or opportunities to make an arrest. Where the crimes involved pose a threat to human life and/or result in a loss of major assets, the availability impact level recommended for criminal investigation and surveillance information is high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for criminal investigation and surveillance information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of criminal investigation and surveillance information depends on the urgency with which the information is needed and on the success of subsequent prosecution of the apprehended criminal(s). Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Where unauthorized modification or destruction of criminal investigation and surveillance information can have an adverse effect on the granting or execution of a search or wiretap warrant or on the success of subsequent prosecution of the apprehended criminal a serious adverse effect on agency operations can result. This can place the agency at a significant disadvantage. Special Factors Affecting Integrity Impact Determination: In some cases, major investigations can be jeopardized when the time-critical criminal investigation and surveillance information is modified or destroyed. Where the criminal case under investigation involves major property losses, large-scale financial frauds that have serious implications for financial markets, poses a threat to key national assets or human life, the Recommended Integrity Impact Level is high. In international matters, such as trade enforcement, tariff agreements, etc., or where foreign nationals might be involved, the integrity impact level for criminal investigation and surveillance information will be high. Any compromise of such information could result in catastrophic adverse effects on future operations, individual and agency reputations, and on human life."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for criminal investigation and surveillance information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.16.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Law Enforcement",
+                "title": "Citizen Protection",
+                "description": "Citizen protection involves all activities performed to protect the general population of the United States from criminal activity. The following security categorization is recommended for the citizen protection information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of citizen protection information on the ability of responsible agencies to protect the general population of the United States from criminal activity. In some cases, the criminal activity is terrorist activity intended to cause mass casualties. While the results of unauthorized disclosure of most citizen protection information are unlikely to have a serious adverse effect on agency operations, the exceptions can have catastrophic consequences. Special Factors Affecting Confidentiality Impact Determination: The consequences of unauthorized disclosure of citizen protection information could be severe. If detailed intelligence information regarding a planned terrorist act was disclosed, the terrorists might succeed in countering the protection measures and carry out a devastating attack. The confidentiality impacts associated with information concerning defensive dispositions would be high. While the adverse effects of unauthorized disclosure of some citizen protection information on law enforcement operations, assets, and individuals are limited; the stakes are usually higher. Federal citizen protection activities often seek to protect the public against life-threatening situations or against loss of major assets."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most citizen protection information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to citizen protection information. Many citizen protection missions are usually tolerant of reasonable delays. Most criminal activity against citizen protection information is not life threatening but can result in serious property loss. Special Factors Affecting Availability Impact Determination: Emergency situations or elevated terrorist threat conditions are not tolerant of delays. Where systems support time-sensitive operations for life-threatening situations, the availability impact level for citizen protection information is high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "In the case of most systems that support delivery of citizen protection services, the provisional availability impact level recommended for citizen protection information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of citizen protection information may pose a potential threat to public safety particularly if the protective measures are compromised. Special Factors Affecting Integrity Impact Determination: In some cases (e.g., terrorist threats), unauthorized modification or destruction of citizen protection information can result in loss of human life - a high-impact potential."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for citizen protection information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.16.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Law Enforcement",
+                "title": "Leadership Protection",
+                "description": "Leadership protection involves all activities performed to protect the health and well being of the president, vice-president, their families, and other high-level government officials. Some leadership protection information may be classified. All classified information is treated under separate rules established for national security information and is outside the scope of this guideline. The recommended provisional categorization for unclassified leadership protection information follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of leadership protection information on the abilities of responsible agencies to protect the health and well being of the president, vice-president, their families, and other high-level government officials. The consequences of unauthorized disclosure of most leadership protection information are not directly life-threatening but can have serious consequences. Special Factors Affecting Confidentiality Impact Determination: For the unauthorized disclosure of information that can facilitate efforts to assassinate Federal leadership, the consequences not only pose a threat to human life, but can also have a disruptive effect on the continuity of Federal government operations. In such cases, the confidentiality impact level is high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Given the nature of most leadership protection information, the provisional confidentiality impact level recommended for the information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to leadership protection information. Special Factors Affecting Integrity Impact Determination: In the case of Secret Service operations, missions supported by leadership protection information are not tolerant of delays with resultant catastrophic consequences for mission capability and human life. In such cases, the availability impact level is high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for most leadership protection information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. That is, the consequences of unauthorized modification or destruction of leadership protection information may be determined by the specific operation(s) supported by the information. In addition, the consequences may depend on the urgency with which the intelligence information is needed. Special Factors Affecting Integrity Impact Determination: In the case of Secret Service operations, unauthorized modification or destruction of information affecting leadership protection information may adversely affect mission operations in a manner that results in loss of human life and disruption of government operations. In such cases, the integrity impact level is high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most leadership protection information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.16.5"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Law Enforcement",
+                "title": "Property Protection",
+                "description": "Property protection entails all activities performed to ensure the security of civilian and government property. The recommended provisional categorization of the property protection information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of property protection information on the ability of responsible agencies to ensure the security of civilian and government property. The consequences of unauthorized disclosure of property protection information are generally dependent on the nature of the property being protected. Where the property being protected is neither critical to agency operations nor of such value that its loss would degrade mission capability or place the agency at a significant disadvantage, unauthorized disclosure would have a limited adverse effect. Special Factors Affecting Confidentiality Impact Determination: Where critical infrastructure facilities or key national assets are being protected, the consequences of unauthorized disclosure of property protection information might reveal vulnerabilities in protection measures to terrorists or other adversaries. Where unauthorized disclosure of property protection information associated with critical infrastructures, large groups of people, or key national assets is expected to be of direct use to terrorists, the confidentiality impact level is high. Most protected facilities are not part of national security, the critical infrastructure, or key national asset categories. If unauthorized disclosure of property protection information resulted in damage to these facilities, serious adverse effects on agency operations and assets could reasonably be expected to result. This can result in assignment of a moderate or high impact level to such information. Where the property being protected involves classified information, the property protection information itself might be classified. Some examples include command and control and other military facilities, foreign intelligence collection or processing facilities, weapons or weapons facilities, and cryptographic activities. National security information is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of property protection information on the ability of responsible agencies to ensure the security of civilian and government property. The consequences of unauthorized disclosure of property protection information are generally dependent on the nature of the property being protected. Where the property being protected is neither critical to agency operations nor of such value that its loss would degrade mission capability or place the agency at a significant disadvantage, unauthorized disclosure would have a limited adverse effect. Special Factors Affecting Confidentiality Impact Determination: Where critical infrastructure facilities or key national assets are being protected, the consequences of unauthorized disclosure of property protection information might reveal vulnerabilities in protection measures to terrorists or other adversaries. Where unauthorized disclosure of property protection information associated with critical infrastructures, large groups of people, or key national assets is expected to be of direct use to terrorists, the confidentiality impact level is high. Most protected facilities are not part of national security, the critical infrastructure, or key national asset categories. If unauthorized disclosure of property protection information resulted in damage to these facilities, serious adverse effects on agency operations and assets could reasonably be expected to result. This can result in assignment of a moderate or high impact level to such information. Where the property being protected involves classified information, the property protection information itself might be classified. Some examples include command and control and other military facilities, foreign intelligence collection or processing facilities, weapons or weapons facilities, and cryptographic activities. National security information is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to property protection information. Missions supported by property protection information are not typically tolerant of delays, but the consequences of loss of availability of most property protection information are limited. Special Factors Affecting Availability Impact Determination: The consequences of inability of guard forces and other emergency responders to receive property protection information in a timely manner may result in catastrophic consequences for properties that could include critical infrastructures and key national assets. In general, the availability impact level assigned to property protection information is dependent on what is being protected. This can result in assignment of a moderate or high impact level to such information."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact recommended for most property protection information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of property protection information depends on the type of property being protected and on the immediacy with which the information is expected to be used. In most cases, unauthorized disclosure can be expected to have limited adverse consequences. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency. However, the potential damage to the protection mission will usually be of greater concern. If the modified or destroyed information is tactical i.e., time-critical, there is a greater potential for actions being taken based on incomplete or false information. This can have serious adverse effects on protection operation. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most property protection information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.16.6"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Law Enforcement",
+                "title": "Substance Control",
+                "description": "Substance control supports activities associated with the enforcement of legal substances (i.e., alcohol and tobacco) and illegal narcotics laws including trafficking, possession, sale, distribution, and other related activities. The provisional security categorization recommended for the substance control information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of substance control information on the ability of responsible agencies to enforce legal substances (i.e., alcohol and tobacco) and illegal narcotics laws including trafficking, possession, sale, distribution, and other related activities. Unauthorized disclosure of a significant proportion of substance control information can compromise investigations, cause apprehension operations to fail, and compromise prosecutions. This can have a serious adverse effect on agency operations and place the agency at a significant disadvantage. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some routine substance control information is unlikely to have more than a limited adverse effect on agency operations, agency assets, or individuals. The confidentiality impact associated with such information is low. Where the unauthorized disclosure of information exposes sensitive information sources or compromises investigative or interdiction operations, the consequences of unauthorized disclosure of substance control information may have a serious adverse effect on agency operations, significantly degrade mission capability, and/or pose a threat to human life. Where unauthorized disclosure endangers investigations in process, investigative or intelligence information sources, or information regarding witnesses or other critical case file elements, the danger to human life and key agency missions can be significant. Where unauthorized disclosure endangers witnesses or law enforcement officers, the impact level must be rated as high. Other factors affecting confidentiality impacts associated with substance control information are discussed under Section D.16.1 (Criminal Apprehension) and Section D.16.2 (Criminal Investigation and Surveillance). Some substance control information is classified (e.g., some intelligence-derived information). Classified information and other national security information are outside the scope of this guideline"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most substance control information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to substance control information. Most substance control processes are usually tolerant of reasonable delays. Special Factors Affecting Availability Impact Determination: The consequences of unavailability of information can be serious if the information is critical to tactical operations i.e., is time-critical. Failure of some processes during tactical operations can result in both threats to human life and severe harm to public confidence in the agency. The impact level assigned to information and information systems associated with these tactical processes is high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for most substance control information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The amount of money available to perpetrators significantly increases the insider threat. The consequences of unauthorized modification or destruction of information can be serious if the information is critical to tactical operations i.e., is time-critical. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to most missions would usually be limited Special Factors Affecting Confidentiality Impact Determination: Unauthorized modification or destruction of information (particularly time-critical information) affecting internal communications can jeopardize investigations, prosecutions, the lives of witnesses, and the safety of enforcement officers. In some cases, unauthorized modification or destruction of information can result in loss of human life. In such cased, the integrity impact level is high. Other factors affecting integrity impacts associated with substance control information are discussed under Section D.16.1 (Criminal Apprehension) and Section D.16.2 (Criminal Investigation and Surveillance)."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "Because the consequences of unauthorized modification or destruction of information can be serious if the information is critical to tactical operations (i.e., is time-critical), the provisional integrity impact level recommended for substance control information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.16.7"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Law Enforcement",
+                "title": "Crime Prevention",
+                "description": "Crime prevention entails all efforts designed to create safer communities through the control and reduction of crime by addressing the causes of crime and reducing the opportunities of crime. The recommended provisional security categorization for the crime prevention information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of crime prevention information on the ability of responsible agencies to create safer communities through the control and reduction of crime by addressing the causes of crime and reducing the opportunities of crime. Generally, the unauthorized disclosure of crime prevention information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In a few cases, details of crime prevention programs are sensitive (e.g., location of actively monitored surveillance cameras where only a fraction of camera feeds are monitored). In such cases, unauthorized disclosure of crime prevention information might have a serious adverse effect on crime prevention operations by eliminating uncertainty regarding surveillance patterns. Therefore, the confidentiality impact might be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for crime prevention information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to crime prevention information. Most crime prevention processes are tolerant of delay. In most cases, disruption of access to crime prevention information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: In exceptional cases (e.g., orders associated with deployment of officers to provide a crime-discouraging presence in developing threat situations), loss of availability of information can have a serious adverse effect on crime prevention operations. In such cases, the availability impact might be moderate."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for crime prevention information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Crime prevention activities are not generally time-critical. In most cases, the adverse effects of unauthorized modification or destruction of crime prevention information on agency mission functions and/or public confidence in the agency would be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for crime prevention information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.16.8"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Law Enforcement",
+                "title": "Trade Law Enforcement",
+                "description": "Trade law enforcement refers to the enforcement of anti-boycott, international loan, and general trade laws. The security categorization recommended for the trade law enforcement information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of trade law enforcement information on the ability of responsible agencies to enforce various Customs laws. Unauthorized disclosure of trade law enforcement information could potentially jeopardize fulfillment of other trade law enforcement missions. Some information that has supported a trade law enforcement process might be of higher sensitivity, and unauthorized disclosure of this information might jeopardize the success of future trade law enforcement processes. The subsequent threat to agency image or reputation can cause a serious adverse effect on an agency\u2019s mission capability. Where information includes names of informants, informant contacts, or agency personnel, the effectiveness of those personnel in future enforcement activities can be permanently impaired, or their lives threatened. Intelligence information falls under national security systems. National security information and national security systems are outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most trade law enforcement information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to trade law enforcement information. The effects of disruption of access to trade law enforcement information or information systems can be serious or, in some cases, catastrophic if the information is time-critical. Trade law enforcement missions are typically intolerant of significant time delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for most trade law enforcement information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of trade law enforcement information may depend on whether the information is time-critical. The compromise of trade law enforcement information can be serious or, in some cases, catastrophic if the information is time-critical. Also, the results of trade law enforcement activities may become matters of public record, and thus must be accurately recorded. Special Factors Affecting Integrity Impact Determination: Unauthorized modification or destruction of information affecting trade law enforcement information may adversely affect mission operations and result in unacceptable consequences such as loss of human life. The compromise of trade law enforcement information can be serious or catastrophic if the information is time-critical. This can result in assignment of a high impact level to such information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most trade law enforcement information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.17.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Litigation and Judicial Activities",
+                "title": "Judicial Hearings",
+                "description": "Judicial hearings include activities associated with conducting a hearing in a court of law to settle a dispute. The general recommended security categorization for the judicial hearings information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of judicial hearings information on the ability of responsible entities to conducting a hearing in a court of law to settle a dispute. While much information associated with judicial hearings is public, some information is sealed by the court and unauthorized disclosure is punishable by law, fine and/or imprisonment. In the vast majority of cases, unauthorized disclosure of judicial hearings information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where the life of a victim, witness, or informant may be endangered by unauthorized disclosure, the confidentiality impact is high. Also, where the consequences are likely to endanger public safety, the confidentiality impact is high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Given the consequences of unauthorized disclosure, the provisional confidentiality impact level recommended for judicial hearings information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to judicial hearings information. Most judicial hearings processes are tolerant of delay. In most cases, disruption of access to judicial hearings information can be expected to have only a limited adverse effect on government operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: In exceptional cases (e.g., orders associated with wiretap or search warrants), loss of availability of information can have a serious or severe adverse effect. In such cases, the availability impact might be moderate or high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for judicial hearings information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Judicial hearings activities are not typically time-critical. Modification or destruction of court records can result in disruption or jeopardy to legal proceedings. In most cases, the adverse effects of unauthorized modification or destruction of judicial hearings information on agency mission functions and/or public confidence in the agency will be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for judicial hearings information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.17.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Litigation and Judicial Activities",
+                "title": "Legal Defense",
+                "description": "Legal defense refers to the representation of a defendant in a criminal/civil court of law in an attempt to provide constitutional guarantees to legal representation. The sensitivity of much legal information is highly lifecycle-dependent. From a confidentiality perspective, most information associated with litigation and judicial activities is in the public record after the information has been presented in court. The recommended provisional security categorization for the legal defense information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-high"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of legal defense information on the representation of a defendant in a criminal/civil court of law and on the ability of the government to provide constitutional guarantees to legal representation. Dissemination of legal defense information is governed by privacy laws and by Rules of Criminal Procedure, Rules of Civil Procedure, and other laws governing adversarial legal proceedings. While much information associated with legal defense is public, some information is sealed by the court or is otherwise protected from disclosure. Violation of rules regarding unauthorized disclosure is punishable by law, disbarment, fine, and/or imprisonment. Generally, the unauthorized disclosure of legal defense information will have only a limited adverse effect on agency operations, assets, or individuals. Where unauthorized disclosure of information might have a serious adverse effect on legal defense, there is a presumption of a miscarriage of justice. If an unauthorized disclosure is discovered, the legal proceeding may be jeopardized (e.g., a mistrial may be declared). The cost to the government and others in terms of finance, time, and disruption to normal operations can be severe. If suspicion is raised concerning government complicity or negligence, serious loss of public confidence in government agencies or the legal process may result. Special Factors Affecting Confidentiality Impact Determination: Where the life of a victim, witness, or informant may be endangered by disclosure, the confidentiality impact will be high. Also, where the consequences of a miscarriage of justice are likely to endanger public safety (e.g., release of a terrorist or other murderer), the confidentiality impact will be high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Given legal consequences of unauthorized disclosure, the provisional confidentiality impact level recommended for legal defense information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to legal defense information. Most legal defense processes are tolerant of delay. Delays can impact court schedules, cause significant taxpayer expense, and potentially jeopardize legal proceedings (see C17.2.2). In most cases, disruption of access to legal defense information can be expected to have only a limited adverse effect on government operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: In exceptional cases (e.g., information affecting a ruling regarding an impending execution), loss of availability of information can have a severe adverse effect. The consequent availability impact level would be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for legal defense information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Legal defense activities are not typically time-critical. In most cases, unauthorized modification or destruction of legal defense information will have only a limited adverse effect on government operations, government assets, or individuals. Special Factors Affecting Integrity Impact Determination: For legal defense information, when evidence or other defense information has been compromised the legal proceedings can be jeopardized. As a consequence, the cost to the government and other entities in terms of finance, time, and disruption to normal operations may be severe. If suspicion is raised concerning government complicity or negligence, serious loss of public confidence in government agencies or the legal process may result. In this case, the integrity impact level will be moderate. When the modification or destruction of legal defense information endangers public safety (e.g., release of a terrorist or other murderer), the integrity impact will be high. Even if public safety is not endangered, the modification or destruction of legal defense information may result in expensive and disruptive civil or criminal proceedings."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "Given the legal consequences of unauthorized modification or destruction and potential consequences for human life, the provisional integrity impact level recommended for legal defense information is high."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.17.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Litigation and Judicial Activities",
+                "title": "Legal Investigation",
+                "description": "Legal investigation supports activities associated with gathering information about a given party (government agency, citizen, corporation) that would be admissible in a court of law, in an attempt to prove guilt or innocence. The",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of legal investigation information on the ability of responsible agencies to gather information about a given party (government agency, citizen, corporation) that would be admissible in a court of law, in an attempt to prove guilt or innocence. Special Factors Affecting Confidentiality Impact Determination: The consequences of unauthorized disclosure of legal investigation information depend 1] on the seriousness of the crime involved, 2] timing (e.g., the ability of the criminal40 to access the information and use it to commit a crime or to evade detection or surveillance), and 3] on the capability criminal to injure witnesses or law enforcement officials. In cases where 1) the crimes are not violent and do not inextraordinarily large property losses, and 2) there is no indication of a record of violence on the part of the criminal, the confidentiality impact may be low or moderate. Given the nature of many of the crimes that are the responsibility of Federal law enforcement agencies, the consequences associated with unauthorized disclosure of legal investigation information will pose a threat to human life or result in a loss of major assets. Additionally, when the disclosure concerns matters of multi-national interest, such as trade enforcement, tariff agreements, etc., or where foreign nationals might be involved, the confidentiality impact will be high. Information that reveals the identity and/or location of informants may be of particular concern."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Given potentially serious to severe legal consequences of unauthorized disclosure, the provisional confidentiality impact level recommended for legal investigation information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to legal investigation information. Missions supported by legal investigation information are not typically tolerant of delay with resultant serious consequences for ongoing investigations. Special Factors Affecting Availability Impact Determination: Where the crimes involved pose a threat to human life and/or result in a loss of major assets, the availability impact level recommended for legal investigation information is high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for legal investigation information is moderate."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of legal investigation information may depend on whether the information is time-critical. Unauthorized modification or destruction of information affecting external communications associated with legal investigative organizations (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. Where unauthorized modification or destruction of information has an adverse effect on the granting/executing of a search or wiretap warrant or on the success of the subsequent prosecution, a serious adverse effect on agency operations may result. This can place the agency at a significant disadvantage. Special Factors Affecting Integrity Impact Determination: Legal investigation mission requirements may include time-critical information. In such cases, major investigations can be jeopardized by the unauthorized modification or destruction of legal investigation information. Where the criminal case under investigation involves major property losses, large-scale financial frauds, poses a threat to key national assets or human life, the integrity impact level recommended for legal investigation information is high. When legal investigation information addresses international matters, such as trade enforcement or tariff agreements or when foreign nationals are involved, the integrity level is high. Any deliberate or inadvertent corruption of such information could result in catastrophic adverse effects on future operations, individual or agency reputations, and human life."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for legal investigation information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.17.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Litigation and Judicial Activities",
+                "title": "Legal Prosecution and Litigation",
+                "description": "Legal prosecution/litigation includes all activities involved with presenting a case in a legal proceeding both in a criminal or civil court of law in an attempt to prove guilt/responsibility. The recommended provisional security categorization for the legal prosecution/litigation information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of legal prosecution/litigation information on the ability of responsible agencies to present a case in a legal proceeding either in a criminal or civil court of law in an attempt to prove guilt/responsibility. Dissemination of legal prosecution/litigation information is governed by privacy laws and by Rules of Criminal Procedure, Rules of Civil Procedure, and other laws governing adversarial legal proceedings. While most information associated with legal prosecution/litigation is public, some information is sealed by the court or is otherwise protected from disclosure. Violation of rules regarding unauthorized disclosure is punishable by law, disbarment, fine, and/or imprisonment. Generally, the unauthorized disclosure of legal prosecution/litigation information will have only a limited adverse effect on agency operations, assets, or individuals. In criminal cases, the consequences of unauthorized disclosure of legal prosecution information are affected by 1] the seriousness of the crime involved, 2] timing (e.g., the ability of the criminal to access the information and use it to commit a crime or evade detection or surveillance), and 3] the capability of the criminal to injure witnesses or law enforcement officials. Special Factors Affecting Confidentiality Impact Determination: Where unauthorized disclosure of information might have a serious adverse effect on legal prosecution/ litigation, there is a presumption of a miscarriage of justice. If an unauthorized disclosure is discovered, the legal proceeding is jeopardized (e.g., a mistrial may be declared). The cost to the government and others in terms of finance, time, and disruption to normal operations can be severe. If suspicion is raised concerning government complicity or negligence, serious loss of public confidence in government agencies or the legal process may result. In this case, the confidentiality impact of unauthorized disclosure will be moderate. Where the life of a complainant, victim, witness, or informant may be endangered by disclosure, the confidentiality impact will be high. Also, where the consequences of a miscarriage of justice are likely to endanger public safety (e.g., release of a terrorist or other murderer), the confidentiality impact will be high. Given the nature of many of the crimes that are the responsibility of Federal law enforcement agencies, the consequences associated with unauthorized disclosure of legal prosecution information must be assumed to pose a threat to human life or result in a loss of major assets. Additionally, when a legal proceeding concerns matters of trans-national interest, such as trade enforcement, tariff agreements, etc., or where foreign nationals might be involved, the confidentiality impact will be high. Information that reveals the identity and/or location of informants may be of particular concern. [The impact of unauthorized disclosure of national security information is outside the scope of this guideline.]"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Given the public nature of and disclosure rules associated with most prosecution/litigation information, the provisional confidentiality impact level recommended is low. In cases where 1) the crimes are not violent and do not involve extraordinarily large property losses, and 2) there is no indication of a record of violence on the part of the criminal, the confidentiality impact may be low"
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to legal prosecution/litigation information. Most legal prosecution/litigation processes are tolerant of delay even though the delays can impact court schedules, cause significant taxpayer expense, and potentially jeopardize legal proceedings (see C17.4.2). Typically, the disruption of access to legal prosecution/litigation information can be expected to have only a limited adverse effect on government operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: In exceptional cases (e.g., information affecting a ruling regarding an impending execution), loss of availability of information can have a severe adverse effect. The availability impact level recommended for this legal prosecution/litigation information is high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for legal prosecution/litigation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Legal prosecution/litigation activities are not typically time-critical. Unauthorized modification or destruction of information affecting external communications associated with legal prosecution/litigation organizations (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited. In general, the unauthorized modification or destruction of legal prosecution/litigation information will have only a limited adverse effect on government operations, government assets, or individuals. However, if evidence or other defense information has been compromised, legal proceedings may be affected (e.g., a mistrial may be declared). The subsequent cost to the government in terms of finance, time, and disruption to normal operations may be severe. If suspicion is raised concerning government complicity or negligence, serious loss of public confidence in government agencies or the legal process may result. Special Factors Affecting Integrity Impact Determination: Where the life of a victim, witness, or informant may be endangered, the integrity impact will be high. Also, where the consequences of a miscarriage of justice are likely to endanger public safety (e.g., release of a terrorist or other murderer), the integrity impact will be high."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "Given the legal consequences of the unauthorized modification or destruction of legal prosecution/litigation information, the provisional integrity impact level recommended for legal prosecution/litigation information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.17.5"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Litigation and Judicial Activities",
+                "title": "Resolution Facilitation",
+                "description": "Resolution facilitation involves all activities outside of a court of law that may be used in an attempt to settle a dispute between two or more parties (government, citizen, corporation). The general recommended security categorization for the resolution facilitation information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of resolution facilitation information on the ability of responsible entities to settle a dispute between two or more parties (government, citizen, corporation) outside of a court of law. While some information associated with resolution facilitation is public, much of the information is private and/or proprietary. Unauthorized disclosure of such information can disrupt or defeat the dispute resolution process. The consequences typically depend on the nature of the dispute. Jeopardy to the resolution process will not usually involve threats to critical infrastructures, key national assets, or human life. Typically, the unauthorized disclosure of resolution facilitation information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where large monetary amounts and/or violent crimes are involved, the confidentiality impact of unauthorized disclosure of resolution facilitation information is at least moderate. In exceptional cases human lives may be jeopardized by failure of the resolution facilitation process. Additionally, when resolution facilitation concerns matters of trans-national interest, such as trade enforcement, tariff agreements, etc., or where foreign nationals might be involved, the confidentiality impact will be high."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Given the legal consequences of unauthorized disclosure, the provisional confidentiality impact level recommended for resolution facilitation information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to resolution facilitation information. Most resolution facilitation processes are tolerant of delay. In most cases, disruption of access to resolution facilitation information can be expected to have only a limited adverse effect on government operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for resolution facilitation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Resolution facilitation activities are not typically time-critical. The modification or destruction of court records may result in disruption or jeopardy of legal proceedings. In most cases, the adverse effects of unauthorized modification or destruction of resolution facilitation information on agency mission functions and/or public confidence in the agency can be expected to be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for resolution facilitation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.18.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Federal Correctional Activities",
+                "title": "Criminal Incarceration",
+                "description": "Criminal incarceration includes activities associated with the housing, custody and general care of criminals sentenced to serve time in penitentiaries. The following security categorization is recommended for the criminal incarceration information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of criminal incarceration information on the ability of responsible agencies to provide housing, custody, and general care for criminals sentenced to serve time in a Federal penitentiary. The consequences of unauthorized disclosure of most criminal incarceration information are unlikely to have a serious adverse effect on agency operations. The most serious adverse effects are likely to involve exposure of information that is proprietary to prisoners that can result in damaging publicity for an organization. (Unauthorized disclosure of some information can conceivably have serious impact on the status or resolution of appeal actions). The consequences of unauthorized disclosures may have an adverse effect on public confidence in the agency."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most criminal incarceration information is normally low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to criminal incarceration information. Criminal incarceration processes are usually tolerant of reasonable delays. Special Factors Affecting Availability Impact Determination: There may be cases (e.g. emergency bulletins affecting prisoner health and/or safety) in which emergency dissemination of information regarding life-threatening situations is delayed for excessive periods. Such cases can result in a high availability impact level."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for criminal incarceration information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of criminal incarceration information can be serious if the information is time-critical and results in the premature release of a criminal, unjust retention of an individual in the prison system, or harm to a citizen\u2019s reputation or public confidence in the government. Special Factors Affecting Integrity Impact Determination: In some cases (e.g., instructions regarding a need to isolate a prisoner from the general prison population for personal safety reasons), the unauthorized modification or destruction of criminal incarceration information can result in loss of human life a high impact potential."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for criminal incarceration information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.18.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Federal Correctional Activities",
+                "title": "Criminal Rehabilitation",
+                "description": "Criminal Rehabilitation includes all government activities devoted to providing convicted criminals with the educational resources and life skills necessary to rejoin society as responsible and contributing members. The recommended provisional categorization of the criminal rehabilitation information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of criminal rehabilitation information on the ability of responsible agencies to provide convicted criminals with the educational resources and life skills necessary to rejoin society as responsible and contributing members. The consequences of unauthorized disclosure of most criminal rehabilitation information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Exceptions that might have a potential for more serious consequences are based on privacy information processed in criminal rehabilitation systems (e.g., information required by the Privacy Act of 1974 (The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type) or other statutes and executive orders to receive special handling to protect the privacy of individuals). This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for criminal rehabilitation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to criminal rehabilitation information. The effects of disruption of access to most criminal rehabilitation information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for criminal rehabilitation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of criminal rehabilitation information would have a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for most criminal rehabilitation information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.19.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Sciences and Innovation",
+                "title": "Scientific and Technological Research and Innovation",
+                "description": "Scientific and Technological Research and Innovation includes all federal activities whose goal is the creation of new scientific and/or technological knowledge as a goal in itself, without a specific link to the other mission areas or information types identified in the BRM. Most sensitive information is developed under research and development programs that directly support another of the mission areas described in this Appendix and are not included here. Some information associated with scientific and technical research and innovation is national security information and is outside the scope of this guideline. The recommended provisional categorization for the scientific and technical research and innovation information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of scientific and technical research and innovation information on the ability of responsible agencies to create new scientific and/or technological knowledge as a goal in itself, without a specific link to other program areas or information types. Many scientific and technical research and innovation activities are conducted in association with public institutions of higher learning, and the findings resulting from those activities are intended for publication. Special Factors Affecting Confidentiality Impact Determination: The pre-publication disclosure or other unauthorized disclosure of information associated with competition for funding and recognition (e.g., grants, development contract, patent rights, and copyrights) can have a serious adverse effect on agency operations, agency assets, or individuals. In such cases, the confidentiality impact level associated for scientific and technical research and innovation information will be moderate. In some cases, the information associated with scientific and technical research and innovation is classified or otherwise qualified as national security information. Such information is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most scientific and technical research and innovation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to scientific and technical research and innovation information. Most research processes are tolerant of delay. In most cases, disruption of access to research and innovation information can be expected to have only a limited adverse effect on government operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for scientific and technical research and innovation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of most information associated with scientific and technical research and innovation can be seriously disruptive to the progress of research activities. The effects on future funding can be quite serious and can have a serious adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be more limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for scientific and technical research and innovation information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.19.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "General Science and Innovation",
+                "title": "Space Exploration and Innovation",
+                "description": "Space Exploration and Innovation includes all activities devoted to innovations directed at human and robotic space flight and the development and operation of space launch and transportation systems, and the general research and exploration of outer space. While some space exploration and innovation is national security information, most sensitive information is developed under research and development programs that directly support another of the mission areas described in this Appendix and are not included here. The recommended provisional categorization of the research and development information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of space exploration and innovation information on the ability of responsible agencies to conduct activities devoted to [1] innovations directed at human and robotic space flight and the development and operation of space launch and transportation systems, and [2] the general research and exploration of outer space. Many space exploration and innovation activities are conducted with public institutions of higher learning, and the findings resulting from those activities are intended for publication. Special Factors Affecting Confidentiality Impact Determination: The pre-publication disclosure or other unauthorized disclosure of information associated with competition for funding and recognition (e.g., grants, development contract, patent rights, and copyrights) can have a serious adverse effect on agency operations, agency assets, or individuals. In such cases, the confidentiality impact associated with space exploration and innovation is moderate. In some cases, the space exploration and innovation information is classified or otherwise qualifies as national security information. This information is outside the scope of this guideline"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most space exploration and innovation information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to space exploration and innovation information. Most research and innovation processes are tolerant of delay. In most cases, disruption of access to research and innovation information will have only a limited adverse effect on government operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for space exploration and innovation information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of most space exploration and innovation information can be seriously disruptive to the progress of research activities. The effects on future funding can be quite serious and can have a serious adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for space exploration and innovation information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.20.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Knowledge Creation and Management",
+                "title": "Research and Development",
+                "description": "Research and Development involves the gathering and analysis of data, dissemination of results, and development of new products, methodologies, and ideas. The sensitivity and criticality of most research and development information depends on the subject matter involved. The recommended provisional categorization of the research and development information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level depends on the effect of unauthorized disclosure of research and development information on the ability of responsible agencies to gather and analyze data, disseminate results, and develop new products, methodologies, and ideas, and on the degree to which unauthorized disclosure of the information can assist hostile institutions to do harm to the interests of the government of the United States. Many research and development activities are conducted in association with public institutions of higher learning, and the findings resulting from those activities are intended for publication. Unauthorized disclosure of most research and development information can be expected to have only limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Most research and development information is proprietary. Unauthorized disclosure of proprietary information violates several statures and Federal regulations (see Appendix E). Pre-publication disclosure or other unauthorized disclosure of research findings can have a serious adverse effect on agency operations, agency assets, or individuals. In such cases, the confidentiality impact level associated with research and development is moderate. Premature and/or partial release of preliminary research and development information can lead to misleading conclusions by policy makers, funding entities, news organizations, and/or the general public. Where the research and development activities are associated with security measures or law enforcement tools, potential adversaries may derive insights on countermeasures development. In extreme cases, the resulting confidentiality impact can be high. In some cases, the research and development information is classified or otherwise qualifies as national security information). Such information is outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most government research and development information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to research and development information. Most research and innovation processes are tolerant of delay. In most cases, disruption of access to research and innovation information will have only a limited adverse effect on government operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for research and development information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of most research and development information can be seriously disruptive to the progress of research activities. The effects on future funding can be serious and can have a serious adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be more limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for research and development information is moderate."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.20.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Knowledge Creation and Management",
+                "title": "General Purpose Data and Statistics",
+                "description": "General purpose data and statistics includes activities performed in providing empirical, numerical, and related data and information pertaining to the current state of the nation in areas such as the economy, labor, weather, international trade, etc. The recommended provisional categorization of the General Purpose Data and Statistics information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of general purpose data and statistics information on the ability of responsible agencies to provide empirical, numerical, and related data and information pertaining to the current state of the nation in areas such as the economy, labor, weather, international trade, etc. The consequences of unauthorized disclosure of most general-purpose data and statistics information would have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized premature disclosure of much economic (e.g., agricultural commodity, economic indicators) data and statistics information can result in major financial consequences. In some cases, premature disclosure of this information can impact major financial markets and damage national banking and finance infrastructures. Unauthorized and premature disclosure to a single institution (e.g., a major commodity brokerage house), could damage faith in general-purpose data and statistics gathering and development institutions, result in even more market disruption, and have a severe or catastrophic adverse effect on public confidence in the agency. Even when the consequences are limited to giving an unfair market advantage to a single financial or commercial institution, unauthorized disclosure can have a serious adverse effect on public confidence in the agency and its staff. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most general-purpose data and statistics information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to general-purpose data and statistics information. Missions supported by general-purpose data and statistics information are generally tolerant of delay."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for general-purpose data and statistics information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of general-purpose data and statistics information may depend on whether the information is time-critical. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for general-purpose data and statistics information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.20.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Knowledge Creation and Management",
+                "title": "Advising and Consulting",
+                "description": "Advising and Consulting activities involve the guidance and consultative services provided by the Federal Government to support the implementation of a specific service provided to citizens. The recommended provisional categorization of the advising and consulting information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of advising and consulting information on the ability of responsible agencies to provide guidance and consultative services to support the implementation of a specific service to citizens. The consequences of unauthorized disclosure of advising and consulting information depends on the nature of the service being provided and on the sensitivity of the information with which advisory or consulting entities are working. The consequences of unauthorized disclosure of most advising and consulting information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where consulting support involves classified or other national security information, the consequences of unauthorized disclosure can be severe but are outside the scope of this guideline. In other cases, such as consultative services provided to law enforcement institutions, the consequences of unauthorized disclosure can be serious or even life threatening. This can result in assignment of a moderate or high impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for advising and consulting information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to advising and consulting information. The effects of disruption of access to most advising and consulting information or information systems would have limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for advising and consulting information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of advising and consulting information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for advising and consulting information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.20.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Knowledge Creation and Management",
+                "title": "Knowledge Dissemination",
+                "description": "Knowledge Dissemination addresses those instances where the primary method used in delivering a service is through the publishing or broadcasting of information, such as the Voice of America or web-based museums maintained by the Smithsonian. Knowledge Dissemination is not intended to address circumstances where the publication of information is a by-product of a mission rather than the mission itself. The recommended provisional security categorization of the knowledge dissemination information type follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of knowledge dissemination information on the ability of responsible agencies to publish or broadcast information. Premature and unauthorized disclosure of information being considered for broadcast can be harmful if the information is subsequently determined to be false or counterproductive to the knowledge dissemination mission. However, the consequences of unauthorized disclosure of most knowledge dissemination information would have, at most, a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of some policies governing knowledge dissemination missions can be harmful to the agency mission (e.g., some internal Voice of America editorial policies). This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for knowledge dissemination information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to knowledge dissemination information. The effects of disruption of access to most knowledge dissemination information or information systems would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: An exception is the extended disruption of broadcast capabilities (e.g., Voice of America). Here, the agency mission is seriously harmed and the impact of the consequences will be moderate."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for most knowledge dissemination information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of knowledge dissemination information may depend on whether the information is time-critical. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) may adversely affect operations and/or public confidence in the agency, but the damage to the mission would usually be limited. In most cases, the consequences of unauthorized modification or destruction of knowledge dissemination information would have a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Integrity Impact Determination: In cases of dissemination of erroneous/defamatory information, an agency mission can be seriously harmed and the impact level will be moderate."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for knowledge dissemination information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.21.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Regulatory Compliance and Enforcement",
+                "title": "Inspections and Auditing",
+                "description": "Inspections and Auditing involves the methodical examination and review of regulated activities to ensure compliance with standards for regulated activity. The recommended security categorization for the inspections and auditing information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of inspections and auditing information on the ability of responsible agencies to methodically examine and review regulated activities to ensure compliance with standards for regulated activity. If the inspections and auditing data belongs to one of the information types described in this guideline, the confidentiality impact assigned the data and system is dependent on the nature of the regulated activity. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of inspections and auditing information can alert personnel associated with programs being monitored to the focus of inspection or auditing activities. With this information, program personnel may divert attention from questionable program attributes or hide unfavorable information. Where a major program or human safety is at stake, actions taken based on unauthorized disclosure of inspections and auditing information can pose a threat to human life or a loss of major assets. In such cases, the confidentiality impact is high. National security information and national security systems are outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Although there are many Federal environments in which unauthorized disclosure will have only a limited adverse effect, there are enough circumstances in which serious adverse effects on agency operations, agency assets, or individuals can result to justify recommendation of a moderate provisional confidentiality impact level for inspections and auditing information."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to inspections and auditing information. In most cases, disruption of access to inspections and auditing information is expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Not many inspection or auditing operations involve activities for which temporary loss of availability is likely to cause significant degradation in mission capability, place the agency at a significant disadvantage, result in major damage to major assets, or pose a threat to human life."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "For most inspection and audit functions, the recommended provisional availability impact level is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of inspections and auditing information can compromise the effectiveness of the program. The damage likely to be caused by unauthorized modification or destruction may affect inspection or audit results with subsequent serious adverse effects on agency operations or public confidence in the agency. The consequences can be particularly serious if the destruction or modification of information invalidates oversight of major programs or the information threatens human safety. The integrity impact level depends on the laws or policies with which compliance is being determined and on the criticality of the processes being monitored (e.g., correctness of contract expenditure reporting versus safety regulations affecting manned space flight)."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "Although there are regulatory environments in which a low impact level is appropriate, the circumstances associated with most inspections and auditing support information require at least a moderate provisional integrity impact level."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.21.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Regulatory Compliance and Enforcement",
+                "title": "Standards Setting/Reporting Guideline Development",
+                "description": "Standard Setting/Reporting Guideline Development involves the establishment of allowable limits associated with a regulated activity and the development of reporting requirements necessary to monitor and control compliance with allowable limits. This includes the development of requirements for product sampling and testing, emissions monitoring and control, incident reporting, financial filings, etc. The following provisional security categorization is recommended for the standards setting/reporting guideline development information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of standards setting/reporting guideline development information on the abilities of responsible agencies to establish allowable limits associated with a regulated activity and to develop reporting requirements necessary to monitor and control compliance with allowable limits. In a few cases, the unauthorized public dissemination of standards or guidelines information can harm the effectiveness of the function being supported (e.g., public dissemination of Internal Revenue Service audit thresholds for certain deductions). However, most Federal standards and guidelines are intended for public dissemination. The consequences of unauthorized disclosure of the majority of standards setting/reporting guideline development information will result in a limited adverse effect on agency operations, agency assets, or individuals. There are some cases for which standards or guidelines include classified or other national security information. Such cases are outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for standards setting/reporting guideline development information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to standards setting/reporting guideline development information. The nature of standards setting/reporting guideline development processes is tolerant of reasonable delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for standards setting/reporting guideline development information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of standards setting/reporting guideline development information depends primarily on the criticality of the information with respect to agency mission capability, protection of agency assets, and safety of individuals. In general, the effects of modifications or deletions of standards setting/reporting guideline development information are limited with respect to agency missions or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for standards setting/reporting guideline development information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.21.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Regulatory Compliance and Enforcement",
+                "title": "Permits and Licensing",
+                "description": "Permits and Licensing involves activities associated with granting, revoking, and the overall management of the documented authority necessary to perform a regulated task or function. The following security categorization is recommended for the permits and licensing information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of permits and licensing information on the abilities of responsible agencies to manage the documented authority necessary to perform a regulated task or function. The consequences of unauthorized disclosure of the majority of permits and licensing information will result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Where more sensitive information is involved, it will typically be personal information subject to the Privacy Act of 1974, the Health Insurance Portability and Accountability Act of 1996, or other laws and executive orders affecting the dissemination of information regarding individuals. The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. In such cases, the consequences of unauthorized disclosure of permits and licensing information could be serious. In such cases, the confidentiality impact level might be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most permits and licensing information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to permits and licensing information. The nature of permits and licensing processes is tolerant of reasonable delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for permits and licensing information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of permits and licensing information depends primarily on the criticality of the regulated activity with respect to protection of government assets, and safety of individuals. Typically, the effects of modification or deletion of permits and licensing information are limited with respect to agency missions or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for permits and licensing information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.22.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Public Goods Creation and Management",
+                "title": "Manufacturing",
+                "description": "Manufacturing involves all programs and activities in which the Federal Government produces both marketable and non-marketable goods. The following provisional security categorization is recommended for the manufacturing information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of manufacturing information on the abilities of responsible agencies to produce both marketable and non-marketable goods. In a few cases, unauthorized disclosure of details of the products or manufacturing processes can give adversaries opportunities (e.g., terrorism, industrial espionage). However, in most cases, the consequences of unauthorized disclosure of manufacturing information will result in a limited adverse effect on agency operations, agency assets, or individuals. There are some cases for which manufacturing or product information includes classified or other national security information. Such cases are outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for manufacturing information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to manufacturing information. The nature of most government manufacturing processes is tolerant of reasonable delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for manufacturing information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of manufacturing information depends primarily on the criticality of the information with respect to a manufacturing process and on the volume and use of the end product. Typically, the effects of modification or deletion of manufacturing information are generally limited with respect to agency missions or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for manufacturing information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.22.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Public Goods Creation and Management",
+                "title": "Construction",
+                "description": "Construction involves all programs and activities in which the Federal Government builds or constructs facilities, roads, dams, etc. The following security categorization is recommended for the construction information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of construction information on the abilities of responsible agencies to build or construct facilities, roads, dams, etc. In most cases, the consequences of unauthorized disclosure of construction information will result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In some cases, construction details can be of use to terrorists or other criminals who seek to penetrate or destroy government installations. Unauthorized disclosure of some construction details (e.g., alarm designs, points of vulnerability to the structural integrity of a dam or building) can result in danger to critical infrastructures, key national assets, or human life. In such cases, the confidentiality impact may be high. There are some cases for which construction information includes classified or other national security information. Such cases are outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for construction information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to construction information. The nature of most government construction processes is tolerant of reasonable delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for construction information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of construction information depends primarily on the criticality of the information. Typically, the effects of modification or deletion of construction information are limited with respect to agency missions or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for construction information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.22.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Public Goods Creation and Management",
+                "title": "Public Resources, Facility and Infrastructure Management",
+                "description": "Public Resources, Facility and Infrastructure Management involves the management and maintenance of government-owned capital goods and resources (natural or otherwise) on behalf of the public, usually with benefits to the community at large as well as to the direct user. Examples of facilities and infrastructure include schools, roads, bridges, dams, harbors, and public buildings. Examples of resources include parks, cultural artifacts and art, endangered species, oil reserves, etc. The following security categorization is recommended for the public resources, facilities, and infrastructure management information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of public resources, facilities, and infrastructure management information on the abilities of responsible agencies to manage and maintain government-owned capital goods and resources (natural or otherwise) on behalf of the public, usually with benefits to the community at large as well as to the direct user. In most cases, the consequences of unauthorized disclosure of public resources, facilities, and infrastructure management information will result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In some cases, premature unauthorized disclosure of management information can give an unfair competitive advantage to a commercial interest (e.g., proposed changes for management of petroleum reserves). The confidentiality impact of consequent loss of public confidence and/or serious economic disruption might be moderate. In other cases, public resources, facilities, and infrastructure management details can be of use to terrorists or other criminals who seek to penetrate the security of government property or to harm populations. Unauthorized disclosure of some public resources, facilities, and infrastructure management details to criminals (e.g., facilities security dispositions, building alarm designs), can result in danger to critical infrastructures, key national assets, or human life. In such cases, the confidentiality impact can be high"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most public resources, facilities, and infrastructure management information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to public resources, facilities, and infrastructure management information. The nature of most government public resources, facilities, and infrastructure management processes is tolerant of reasonable delays."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for public resources, facilities, and infrastructure management information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of public resources, facilities, and infrastructure management information depends primarily on the criticality of the information with respect to management of public resources, facilities, and infrastructures. Typically, the effects of modification or deletion of public resources, facilities, and infrastructure information are limited with respect to agency missions or assets."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for public resources, facilities, and infrastructure management information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.22.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Public Goods Creation and Management",
+                "title": "Information Infrastructure Management",
+                "description": "Information Infrastructure Management involves the management and stewardship of a type of information by the Federal Government and/or the creation of physical communication infrastructures on behalf of the public in order to facilitate communication. This includes the management of large amounts of information (e.g., environmental and weather data, criminal records, etc.), the creation of information and data standards relating to a specific type of information (patient records), and the creation and management of physical communication infrastructures (networks) on behalf of the public. Note: Information infrastructures for government use are not included in this information type because the impact levels associated with information infrastructure maintenance information are primarily a function of the information processed in that infrastructure. The recommended provisional security categorization for the information infrastructure maintenance information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of information infrastructure maintenance information on the ability of responsible agencies to manage a type of information and/or to create physical communication infrastructures on behalf of the public in order to facilitate communication. The disclosure of most information infrastructure maintenance information can be expected to result in a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In some cases, information infrastructure maintenance details can be of use to terrorists or other criminals who seek to destroy government data bases or communications infrastructures, or deny access to information needed by the public. Unauthorized disclosure of some information infrastructure maintenance details to criminals can result in danger to critical infrastructures, key national assets, or human life. In such cases, the confidentiality impact can be high. In other cases, premature unauthorized disclosure of management information can give an unfair competitive advantage to a commercial interest (e.g., proposed outsourcing of system administration or details of a proposed communications system acquisition). This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for information infrastructure maintenance information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to information infrastructure maintenance information. Disruption of access to information infrastructure maintenance information or information systems will typically result in denial of access to resources for all affected agencies. Typically, disruption of access will have a limited adverse effect on agency operations (including mission functions and public confidence in the agency), agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Exceptions may include emergency response aspects of disaster management or other time critical functions (e.g., some systems that support air traffic control functions). The availability impact level associated with unauthorized modification or destruction of information infrastructure maintenance information needed to respond to emergencies or critical to public safety may be high."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for information infrastructure maintenance information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. That is, the consequences of unauthorized modification or destruction of information infrastructure maintenance information typically depend on the criticality of the data processed by the infrastructure and whether this data is time-critical. In most cases, the data will not be urgently needed or acted upon immediately. Special Factors Affecting Integrity Impact Determination: In a relatively few cases, the consequences of unauthorized modification or destruction of information infrastructure maintenance information might result in serious damage to agency operations, assets, or human safety. This may require a moderate or high integrity impact level for information infrastructure maintenance information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for information infrastructure maintenance information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.23.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Federal Financial Assistance",
+                "title": "Federal Grants (Non-State)",
+                "description": "Federal Grants involve the disbursement of funds by the Federal Government to a non-Federal entity to help fund projects or activities. This includes the processes associated with grant administration, including the publication of funds availability notices, development of the grant application guidance, determination of grantee eligibility, coordination of the peer review/evaluation process for competitive grants, the transfer of funds, and the monitoring/oversight as appropriate. The recommended provisional security categorization for the federal grants information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of federal grants information on the ability of responsible agencies to disburse funds to non-Federal entities to fund projects or activities. Typically, unauthorized disclosure of federal grants information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In a few cases, records associated with grants may include information subject to privacy restrictions (e.g., the Privacy Act of 1974). The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type. In many cases, premature and unauthorized disclosure can affect the integrity of the grants process, giving an unfair competitive advantage to one or more applicants. In such cases, punitive consequences and/or loss of public confidence can have a seriously disruptive effect on an agency\u2019s operations and mission. In such cases, the confidentiality impact level would be moderate. In some cases, federal grants information might be moderate to high impact. Also, details of programs for which grants are awarded may be sensitive (e.g., research grants for weapons systems project activities). Some federal grants information and some grant program details may be classified and outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for federal grants information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to federal grants information. Federal grants processes are generally tolerant of delay. In most cases, disruption of access to federal grants information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for federal grants information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Federal grants activities are not generally time-critical and multiple individuals in multiple organizations are usually involved in the grants process. Therefore, the information maintained by all the individuals/agencies may be necessary to alter a grants decision. In most cases, the adverse effects of unauthorized modification or destruction of federal grants information on agency mission functions or public confidence in the agency is limited. Special Factors Affecting Integrity Impact Determination: There are significant differences between the ability to modify a document authorizing a payment and the modification of the payment itself. The unauthorized modification of a document authorizing a payment is less time critical than the modification of the payment itself while the payment is in transit. Modifications to payments in transit will result in immediate inaccurate payments. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for federal grants information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.23.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Federal Financial Assistance",
+                "title": "Direct Transfers to Individuals",
+                "description": "Direct Transfers to Individuals involves the disbursement of funds from the Federal Government directly to beneficiaries (individuals or organizations) who satisfy Federal eligibility requirements with no restrictions imposed on the recipient as to how the money is spent. Direct Transfers include both earned and unearned Federal Entitlement programs such as Medicare, Social Security, unemployment benefits, etc. The recommended provisional security categorization for the direct transfers to individuals information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of direct transfers to individuals information on the ability of responsible agencies to disburse funds from the Federal Government directly to beneficiaries (individuals or organizations) who satisfy Federal eligibility requirements with no restrictions imposed on the recipient as to how the money is spent. In the majority of cases, unauthorized disclosure of direct transfers to individuals will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Many of the records associated with the disbursements may include information subject to privacy restrictions (e.g., the Privacy Act of 1974, HIPAA of 1996). (The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type.) In such cases, punitive consequences and/or loss of public confidence can have a seriously disruptive effect on an agency\u2019s operations and mission. The consequent confidentiality impact level could be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "Therefore, the provisional confidentiality impact level recommended for direct transfers to individuals is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to direct transfers to individuals information. Federal disbursement processes are generally tolerant of delay. In most cases, disruption of access to information regarding direct transfers to individuals can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Availability Impact Determination: Disruption of disbursements to large populations can do serious harm to public confidence in the agency and have a harmful impact on the nation\u2019s economy (e.g., affect consumer confidence and retail sales for a month or quarter). In such cases, the availability impact would be moderate."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for direct transfers to individuals is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Federal disbursement activities are not generally time-critical. In most cases, the monetary amounts involved are not large (on a governmental budgetary scale). Also, the adverse effects of unauthorized modification or destruction of direct transfers to individuals on agency mission functions or public confidence in the agency will be limited. Special Factors Affecting Integrity Impact Determination: There are significant differences between the ability to modify a document authorizing a payment and the modification of the payment itself. The unauthorized modification of a document authorizing a payment is less time critical than the modification of the payment itself while the payment is in transit. Modifications to payments in transit will result in immediate inaccurate payments. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for direct transfers to individuals is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.23.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Federal Financial Assistance",
+                "title": "Subsidies Information",
+                "description": "Subsidies involve Federal Government financial transfers that reduce costs and/or increase revenues of producers. Subsidies include the payment of funds from the government to affect the production or prices of various goods to benefit the public. The recommended provisional security categorization for the subsidies information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of subsidies information on the ability of responsible agencies to pay government funds to affect the production or prices of various goods to benefit the public benefit. In many cases, unauthorized disclosure of subsidies information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Some information associated with applications for subsidies includes information covered by the provisions of the Privacy Act of 1974. (The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type.) Unauthorized disclosure of large volumes of information protected under the Privacy Act can be expected to have a serious effect on public confidence in the agency. Also, premature unauthorized disclosure of planned subsidies policies can affect financial/commodities markets, with associated potential adverse effects on the U.S. economy and serious adverse effects on public confidence in the agency. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most subsidies information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to subsidies information. Subsidies processes are generally tolerant of delay. In most cases, disruption of access to subsidies information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for subsidies information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Subsidies activities are not typically time-critical. In most cases, the adverse effects of unauthorized modification or destruction of subsidies information on agency mission functions, image or public confidence in the agency will be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for subsidies information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.23.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Federal Financial Assistance",
+                "title": "Tax Credits",
+                "description": "Tax Credits allow a special exclusion, exemption, or deduction from gross income or which provide a special credit, a preferential rate of tax, or a deferral of tax liability designed to encourage certain kinds of activities or to aid taxpayers in special circumstances. The recommended provisional security categorization for the tax credits information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-moderate"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of tax credit information on the ability of responsible agencies to allow special exclusions, exemptions, or deductions from gross income or which provide special credits, a preferential rate of tax, or a deferral of tax liability designed to encourage certain kinds of activities or to aid taxpayers in special circumstances. Many of the records associated with disbursements may include information subject to privacy restrictions (e.g., the Privacy Act of 1974, the Internal Revenue Code and Manual, or the Economic Espionage Act). (The provisional impact levels for personnel information are documented in the Personal Identity and Authentication, Income, Representative Payee, and Entitlement Event information types.) In such cases, punitive consequences and/or loss of public confidence can have a seriously disruptive effect on an agency\u2019s operations and mission. In many cases, unauthorized disclosure of tax credit information can have a serious adverse effect on agency operations, assets, or individuals."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for tax credit information is moderate."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to tax credits information. Taxation processes are generally tolerant of delay. In most cases, disruption of access to tax credit information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for tax credit information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Tax credits are not generally time-critical. In most cases, the adverse effects of unauthorized modification or destruction of tax credits on agency mission functions or public confidence in the agency will be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for tax credits is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.24.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Credit and Insurance",
+                "title": "Direct Loans",
+                "description": "Direct loans involve a disbursement of funds by the Government to a non-Federal borrower under a contract that requires the repayment of such funds with or without interest. The recommended provisional security categorization for the direct loan information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of direct loan information on the ability of responsible agencies to disburse Federal funds to non-Federal borrowers under contract terms that require the repayment of such funds with or without interest. Much direct loan information includes information covered by the provisions of the Privacy Act of 1974. (The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type.) In most cases, unauthorized disclosure of direct loan information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Unauthorized disclosure of large volumes of information protected under the Privacy Act can be expected to have a serious to severe effect on public confidence in the agency. In such cases, the confidentiality impact can be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for direct loan information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to direct loan information. Loan assistance processes are generally tolerant of delay. In most cases, disruption of access to direct loan information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for direct loan information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Loan assistance activities are not generally time-critical. In most cases, the adverse effects of unauthorized modification or destruction of direct loan information on agency mission functions and public confidence in the agency will be limited. Special Factors Affecting Integrity Impact Determination: There are significant differences between the ability to modify a document authorizing a payment and the modification of the payment itself. The unauthorized modification of a document authorizing a payment is less time critical than the modification of the payment itself while the payment is in transit. Modifications to payments in transit will result in immediate inaccurate payments. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for direct loan information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.24.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Credit and Insurance",
+                "title": "Loan Guarantees",
+                "description": "Loan guarantees involve any guarantee, insurance, or other pledge with respect to the payment of all or a part of the principal or interest on any debt obligation of a non-Federal borrower to a non-Federal lender, but does not include the insurance of deposits, shares, or other withdrawable accounts in financial institutions. The general recommended security categorization for the loan guarantees information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of loan guarantee information on the ability of responsible agencies to execute guarantees, insurance, or other pledges with respect to the payment of all or a part of the principal or interest on any debt obligation of a non-Federal borrower to a non-Federal lender. In most cases, unauthorized disclosure of loan guarantee information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: Much loan guarantee information includes information covered by the provisions of the Privacy Act of 1974. (The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type.) Unauthorized disclosure of large volumes of information protected under the Privacy Act can be expected to have a serious to severe effect on public confidence in the agency. In such cases, the confidentiality impact can be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for loan guarantee information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to loan guarantee information. Loan processes are generally tolerant of delay. In most cases, disruption of access to loan guarantee information will have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for loan guarantee information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Loan guarantee activities are not generally time-critical. In most cases, the adverse effects of unauthorized modification or destruction of loan guarantee information on agency mission functions and public confidence in the agency will be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for loan guarantee information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.24.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Credit and Insurance",
+                "title": "General Insurance",
+                "description": "General Insurance involves providing protection to individuals or entities against specified risks. The specified protection generally involves risks that private sector entities are unable or unwilling to assume or subsidize and where the provision of insurance is necessary to achieve social objectives. The following provisional security categorization is recommended for the general insurance information type:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of general insurance information on the abilities of responsible agencies to provide protection to individuals or entities against specified risks. General insurance activities include both insurance issuing and insurance servicing. Insurance issuing is any activity such as provider approval, underwriting, and endorsements. The consequences of unauthorized disclosure of insurance issuing information will generally result in a limited adverse effect on agency operations, agency assets, or individuals. Insurance servicing supports activities associated with administering and processing insurance include payment processing, initial and final closings, loss mitigation, claims management, and retiring insurance. The confidentiality impact level is the effect of unauthorized disclosure of insurance servicing information on the abilities of responsible agencies to administer and process insurance. The consequences of unauthorized disclosure of insurance servicing information will generally result in a limited adverse effect on agency operations, agency assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: The more serious consequences may result from 1) unauthorized disclosure of provider\u2019s proprietary information, or 2) premature disclosure of agency plans or changes under consideration for contracts, plans, or policies. Unauthorized disclosure of information that can affect contract arrangements to the detriment of the interests of the government, and of the public at large (e.g., planned or anticipated termination of a major contract insurer), can result in damaging increases in public expense and exposure to impact. In the case of unauthorized disclosure to an individual private sector organization, unfair competitive advantage may result \u2013 with major financial consequences. In the case of unauthorized disclosure of preliminary and unsubstantiated data that is both incorrect and pessimistic (e.g., Medicare budget projections,), the consequent unwarranted alarm of the public may have serious political and operational consequences for affected agencies. In the more serious cases, the confidentiality impact will be at least moderate. The more serious consequences of unauthorized disclosure of insurance servicing information may result from unauthorized disclosure of private information concerning the insured (e.g., Privacy Act information). (The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type.) In the more serious cases, the confidentiality impact will be at least moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for general insurance information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to general insurance information. The nature of general insurance processes is usually tolerant of reasonable delays. Special Factors Affecting Availability Impact Determination: Extensive delays in insurance servicing activities can result in financial harm for individuals and businesses and in public alarm and repercussions in the financial markets. In more serious cases, delays may have serious political and operational consequences for affected agencies. In such cases, the confidentiality impact may be at least moderate."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for general insurance information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. The consequences of unauthorized modification or destruction of general insurance information may depend on the urgency with which the information is typically needed. Unauthorized modification or destruction of information affecting external communications (e.g., web pages, electronic mail) typically has a limited adverse effect on agency operations and/or public confidence in the agency."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for general insurance information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.25.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Transfers to Local/State Government",
+                "title": "Formula Grants",
+                "description": "Formula Grants involves the allocation of money to States or their subdivisions in accordance with distribution formulas prescribed by law or administrative regulation, for activities of a continuing nature. The recommended provisional security categorization for the formula grants information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of formula grants information on the ability of responsible agencies to allocate money to States or their subdivisions in accordance with distribution formulas prescribed by law or administrative regulation, for activities of a continuing nature. Typically, unauthorized disclosure of most formula grants information will have only a limited adverse effect on agency operations, assets, or individuals. In most cases, information associated with formula grants is public knowledge. Special Factors Affecting Confidentiality Impact Determination: In a few cases, details of programs for which formula grants are awarded may be sensitive (e.g., some Federal/State cooperative programs intended to support Homeland Security operations). This can result in assignment of a moderate or high impact level to such information. Some formula grants information might be classified (hence outside the scope of this guideline)."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for formula grants information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to formula grants information. Formula grants processes are generally tolerant of delay. In most cases, disruption of access to formula grants information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for formula grants information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Formula grants activities are not generally time-critical and multiple individuals in multiple organizations are usually involved in the grants process. Therefore, the information maintained by all the individuals/agencies is probably necessary to alter a grants decision. In most cases, the adverse effects of unauthorized modification or destruction of formula grants information on agency mission functions or public confidence in the agency will be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for formula grants information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.25.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Transfers to Local/State Government",
+                "title": "Project/Competitive Grants",
+                "description": "Project/Competitive Grants involves the funding, for fixed or known periods, of projects. Project/Competitive grants can include fellowships, scholarships, research grants, training grants, traineeships, experimental and demonstration grants, evaluation grants, planning grants, technical assistance grants, survey grants, and construction grants. The general recommended security categorization for the project/competitive grants information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of project/competitive grants information on the ability of responsible agencies to award fellowships, scholarships, research grants, training grants, traineeships, experimental and demonstration grants, evaluation grants, planning grants, technical assistance grants, survey grants, and/or construction grants. In most cases, unauthorized disclosure of project/competitive grants information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In some cases, project/competitive grants information may be sensitive with moderate to high impact. In a few cases, details of programs for which grants are awarded may be classified and outside the scope of this guideline. In a few cases, records associated with the grants may include information subject to privacy restrictions (e.g., the Privacy Act of 1974). (The Privacy Act Information provisional impact levels are documented in the Personal Identity and Authentication information type.) In many cases, premature and unauthorized disclosure can affect the integrity of the grants process, giving an unfair competitive advantage to one or more applicants. In such cases, punitive consequences and/or loss of public confidence can have a seriously disruptive effect on an agency\u2019s operations and mission. In such cases, the confidentiality impact level would be moderate."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for most project/competitive grants information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to project/competitive grants information. Project/competitive grants processes are generally tolerant of delay. In most cases, disruption of access to project/competitive grants information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for project/competitive grants information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Project/competitive grants activities are not generally time-critical. In most cases, the adverse effects of unauthorized modification or destruction of project/competitive grants information on agency mission functions or public confidence in the agency will be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for project/competitive grants information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.25.3"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Transfers to Local/State Governments",
+                "title": "Earmarked Grants",
+                "description": "Earmarked Grants involves the distribution of money to State and Local Governments for a named purpose or service usually specifically noted by Congress in appropriations language, or other program authorizing language. The recommended provisional security categorization for the earmarked grants information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of earmarked grants information on the ability of responsible Federal government entities to distribute money to State and Local Governments for a named purpose or service usually specifically noted by Congress in appropriations language, or other program authorizing language. In the majority of cases, earmarked grants information is public knowledge. Typically, unauthorized disclosure of most earmarked grants information will have only a limited adverse effect on agency operations, assets, or individuals. Special Factors Affecting Confidentiality Impact Determination: In some cases, project/competitive grants information may be sensitive with moderate to high impact. In a few cases, details of programs for which grants are awarded may be classified and outside the scope of this guideline."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for earmarked grants information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to earmarked grants information. Earmarked grants processes are generally tolerant of delay. In most cases, disruption of access to earmarked grants information will have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for earmarked grants information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Earmarked grants activities are not generally time-critical and multiple individuals in multiple organizations are usually involved in the grants process. Therefore, the information maintained by all the individuals/agencies is probably necessary to alter a grants decision. In most cases, the adverse effects of unauthorized modification or destruction of earmarked grants information on agency mission functions or public confidence in the agency will be limited."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for earmarked grants information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.25.4"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Transfers to Local/State Governments",
+                "title": "State Loans",
+                "description": "State Loans involve all disbursement of funds by the Government to a State or Local Government (or Indian Tribe) entity under a contract that requires the repayment of such funds with or without interest. The recommended provisional security categorization for the state loan information type is as follows:",
+                "confidentiality-impact": {
+                    "base": "fips-199-low"
+                },
+                "availability-impact": {
+                    "base": "fips-199-low"
+                },
+                "integrity-impact": {
+                    "base": "fips-199-low"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "The confidentiality impact level is the effect of unauthorized disclosure of state loan information on the ability of responsible agencies to disburse Federal funds a State or Local Government (or Indian Tribe) entity under a contract that requires the repayment of such funds with or without interest. In most cases, unauthorized disclosure of state loan information will have only a limited adverse effect on agency operations, assets, or individuals."
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "The provisional confidentiality impact level recommended for state loan information is low."
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "The availability impact level is based on the specific mission and the data supporting that mission, not on the time required to re-establish access to state loan information. Loan assistance processes are generally tolerant of delay. In most cases, disruption of access to state loan information can be expected to have only a limited adverse effect on agency operations, agency assets, or individuals."
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "The provisional availability impact level recommended for state loan information is low."
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "The integrity impact level is based on the specific mission and the data supporting that mission, not on the time required to detect the modification or destruction of information. Loan assistance activities are not generally time-critical. In most cases, the adverse effects of unauthorized modification or destruction of state loan information on agency mission functions and public confidence in the agency will be limited. Special Factors Affecting Integrity Impact Determination: There are significant differences between the ability to modify a document authorizing a payment and the modification of the payment itself. The unauthorized modification of a document authorizing a payment is less time critical than the modification of the payment itself while the payment is in transit. Modifications to payments in transit will result in immediate inaccurate payments. This can result in assignment of a moderate impact level to such information."
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "The provisional integrity impact level recommended for state loan information is low."
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.26.1"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Direct Services for Citizens",
+                "title": "Military Operations",
+                "description": "The BRM provided in the FEA Consolidated Reference Model Document, Version 2.3, October 2007 does not define the Military Operations information type. For the purpose of this document, Military Operations describes the direct provision of military service for the citizens. Further, the BRM specifies Military Operations as a Mode of Delivery business area or a vehicle by which the federal government delivers it services to citizens. Therefore, agency personnel should consider the Military Operations information type as delivery mechanisms of the mission-based services information types [e.g., Catastrophic Defense, Emergency Response, Key Asset and Critical Infrastructure Protection] described heretofore.",
+                "confidentiality-impact": {
+                    "base": "na"
+                },
+                "availability-impact": {
+                    "base": "na"
+                },
+                "integrity-impact": {
+                    "base": "na"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "N/A"
+                    }
+                ]
+            },
+            {
+                "information-type-ids": {
+                    "https://doi.org/10.6028/NIST.SP.800-60v2r1": {
+                        "id": "D.26.2"
+                    }
+                },
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "category": "Direct Services for Citizens",
+                "title": "Civilian Operations",
+                "description": "The BRM provided in the FEA Consolidated Reference Model Document, Version 2.3, October 2007 specifies Civilian Operations as a Mode of Delivery business area or a vehicle by which the federal government delivers it services to citizens. Therefore, agency personnel should consider the Civilian Operations information type as delivery mechanisms of the mission-based services information types [e.g., Health Care, Emergency Response, and Environmental Remediation] described heretofore.",
+                "confidentiality-impact": {
+                    "base": "na"
+                },
+                "availability-impact": {
+                    "base": "na"
+                },
+                "integrity-impact": {
+                    "base": "na"
+                },
+                "properties": [
+                    {
+                        "name": "confidentiality_explanation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "confidentiality_recommendation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "availability_explanation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "availability_recommendation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "integrity_explanation",
+                        "value": "N/A"
+                    },
+                    {
+                        "name": "integrity_recommendation",
+                        "value": "N/A"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
Fedramp provided information types did not validate against the schema provided by OSCAL.
The information types have been transformed to pass Schema validation against the oscal information-type schema 
http://csrc.nist.gov/ns/oscal/1.0-schema.json#/definitions/information-type
