### PR TITLE
Adjust AC-8 requirements and guidance.

### DIFF
--- a/src/baselines/rev4/xml/FedRAMP_rev4_HIGH-baseline_profile.xml
+++ b/src/baselines/rev4/xml/FedRAMP_rev4_HIGH-baseline_profile.xml
@@ -3356,7 +3356,11 @@
                   <p>The service provider shall determine how System Use Notification is going
 							to be verified and provide appropriate periodicity of the check. The
 							System Use Notification verification and periodicity are approved and
-							accepted by the JAB/AO. If performed as part of a Configuration Baseline
+							accepted by the JAB/AO.</p>
+               </part>
+               <part id="ac-8_fr_gdn.1" name="guidance">
+                  <prop name="label" value="Guidance:"/>
+                  <p>If performed as part of a Configuration Baseline
 							check, then the % of items requiring setting that are checked and that
 							pass (or fail) check can be provided.</p>
                </part>

--- a/src/baselines/rev4/xml/FedRAMP_rev4_LOW-baseline_profile.xml
+++ b/src/baselines/rev4/xml/FedRAMP_rev4_LOW-baseline_profile.xml
@@ -1359,7 +1359,11 @@
                   <p>The service provider shall determine how System Use Notification is going
 							to be verified and provide appropriate periodicity of the check. The
 							System Use Notification verification and periodicity are approved and
-							accepted by the JAB/AO. If performed as part of a Configuration Baseline
+							accepted by the JAB/AO.</p>
+               </part>
+               <part id="ac-8_fr_gdn.1" name="guidance">
+                  <prop name="label" value="Guidance:"/>
+                  <p>If performed as part of a Configuration Baseline
 							check, then the % of items requiring setting that are checked and that
 							pass (or fail) check can be provided.</p>
                </part>

--- a/src/baselines/rev4/xml/FedRAMP_rev4_MODERATE-baseline_profile.xml
+++ b/src/baselines/rev4/xml/FedRAMP_rev4_MODERATE-baseline_profile.xml
@@ -2594,7 +2594,11 @@
                   <p>The service provider shall determine how System Use Notification is going
 							to be verified and provide appropriate periodicity of the check. The
 							System Use Notification verification and periodicity are approved and
-							accepted by the JAB/AO. If performed as part of a Configuration Baseline
+							accepted by the JAB/AO.</p>
+               </part>
+               <part id="ac-8_fr_gdn.1" name="guidance">
+                  <prop name="label" value="Guidance:"/>
+                  <p>If performed as part of a Configuration Baseline
 							check, then the % of items requiring setting that are checked and that
 							pass (or fail) check can be provided.</p>
                </part>


### PR DESCRIPTION
Adjust AC-8 requirements and guidance sections to match canonical FedRAMP SSP Templates in Microsoft Word DOCX format. Fixes issues GSA/fedramp-automation#92 and usnistgov/oscal-content#73  as reported by @grosven.