### PR TITLE
Update issue auto-assignment for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feedback.md
+++ b/.github/ISSUE_TEMPLATE/1-feedback.md
@@ -3,7 +3,7 @@ name: OSCAL-based FedRAMP Resources Feedback
 about: Provide feedback, ask a question, or request an enhancement related to any of the OSCAL-based FedRAMP resources published for public comment
 title: ''
 labels: ''
-assignees: ohsh6o
+assignees: volpet2014
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/2-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: ohsh6o
+assignees: volpet2014
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/3-action-item.md
+++ b/.github/ISSUE_TEMPLATE/3-action-item.md
@@ -3,7 +3,7 @@ name: PMO Action Item (FedRAMP PMO Use Only)
 about: Capture an action item intended for follow-up by the FedRAMP PMO.
 title: ''
 labels: ''
-assignees: ohsh6o
+assignees: volpet2014
 
 ---
 


### PR DESCRIPTION
Since I am ohsh6o and I know I am no longer GSA, switch the auto-assigned GitHub user
to the current developer within the FedRAMP program who can handle those issues.

@volpet2014, I can use groups for permissions, but GitHub does not allow  anything but a specific named user to pick up issues and get them auto-assigned. I noticed this today because I follow with email notifications and checked out the newly drafted GSA/fedramp-automation#191 request. Sorry I did not do this before rolling off.