### PR TITLE
location/country for data-center

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/validations/report
 src/validations/src/ssp.xsl
 src/validations/target
 utils
+src/validations/rules/ssp-compiled.xsl

--- a/src/validations/rules/ssp.sch
+++ b/src/validations/rules/ssp.sch
@@ -2452,6 +2452,22 @@
                 role="warning"
                 test="//oscal:responsible-party[oscal:party-uuid = current()/@uuid]">Each person should have a responsibility.</sch:assert>
         </sch:rule>
+        <sch:rule 
+            context="oscal:location[oscal:prop[@value eq 'data-center']]"
+            doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.23">
+            <sch:assert 
+                diagnostics="data-center-country-code-diagnostic"
+                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.23"
+                id="data-center-country-code"
+                role="warning"
+                test="oscal:address/oscal:country">Each data center address must contain a country.</sch:assert>    
+            <sch:assert 
+                diagnostics="data-center-US-diagnostic"
+                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.23"
+                id="data-center-US"
+                role="warning"
+                test="oscal:address/oscal:country eq 'US'">Each data center must have an address that is within the United States.</sch:assert>    
+        </sch:rule>
     </sch:pattern>
     <sch:pattern
         doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §5.2"
@@ -3467,6 +3483,16 @@
         </sch:rule>
     </sch:pattern>
     <sch:diagnostics>
+        <sch:diagnostic
+            doc:assertion="data-center-country-code"
+            doc:context="/o:location"
+            id="data-center-country-code-diagnostic">The data center address does not show a country.
+        </sch:diagnostic>
+        <sch:diagnostic
+            doc:assertion="data-center-US"
+            doc:context="/o:location"
+            id="data-center-US-diagnostic">The location address for a data center is not within the United States.  The country element must contain the string 'US'.
+        </sch:diagnostic>
         <sch:diagnostic
             doc:assertion="no-registry-values"
             doc:context="/o:system-security-plan"

--- a/src/validations/test/ssp.xspec
+++ b/src/validations/test/ssp.xspec
@@ -7416,6 +7416,62 @@
                         label="that is an anomaly." />
                 </x:scenario>
             </x:scenario>
+            
+            <x:scenario
+                label="Each location that is a data center must have a country">
+                <x:context>
+                    <location 
+                        xmlns="http://csrc.nist.gov/ns/oscal/1.0" 
+                        uuid="16adcc8d-65d8-4583-80d3-9cf007744fec">
+                        <title>Primary Data Center</title>
+                        <address>
+                            <addr-line>2222 Main Street</addr-line>
+                            <city>Anywhere</city>
+                            <state>--</state>
+                            <postal-code>00000-0000</postal-code>
+                        </address>
+                        <prop 
+                            name="type" 
+                            class="primary" 
+                            value="data-center" />
+                    </location>                    
+                </x:context>
+                <x:scenario
+                    label="When that is false">
+                    <x:expect-assert
+                        id="data-center-country-code"
+                        label="country is missing" />
+                </x:scenario>
+            </x:scenario>
+            
+            <x:scenario
+                label="The country in locations for data centers must be 'US'">
+                <x:context>
+                    <location 
+                        xmlns="http://csrc.nist.gov/ns/oscal/1.0" 
+                        uuid="16adcc8d-65d8-4583-80d3-9cf007744fec">
+                        <title>Primary Data Center</title>
+                        <address>
+                            <addr-line>2222 Main Street</addr-line>
+                            <city>Anywhere</city>
+                            <state>--</state>
+                            <postal-code>00000-0000</postal-code>
+                            <country>GB</country>
+                        </address>
+                        <prop 
+                            name="type" 
+                            class="primary" 
+                            value="data-center" />
+                    </location>                    
+                </x:context>
+                <x:scenario
+                    label="When that is false">
+                    <x:expect-assert
+                        id="data-center-US"
+                        label="country is not US" />
+                </x:scenario>
+            </x:scenario>
+            
             <x:scenario
                 label="Each implemented-requirement must have one or more responsible-role definitions.">
                 <x:context>


### PR DESCRIPTION
ssp.sch - Added rule for handling oscal:country on data center locations.

ssp.xpec - Added tests for expect-assert on oscal:country on data center locations.

realized the .gitignore is in here too.  That was an error I made when testing out things.  I'll fix it on the next PR.