### PR TITLE
Fix failing dist/content generation

### DIFF
--- a/src/content/module.mk
+++ b/src/content/module.mk
@@ -21,4 +21,4 @@ test-content:  ## Test src/content
 
 build-content:  ## Build dist/content
 	@echo "Building content..."
-	$(OSCAL_DOCKER) run cli $(MNT)/$(CICD_DIR_PATH)/copy-and-convert-content.sh -v -o $(MNT)/$(OSCAL_DIR) -a $(MNT) -c $(MNT)/$(CONTENT_CONFIG_PATH)
+	$(OSCAL_DOCKER) run cli $(MNT)/$(CICD_DIR_PATH)/copy-and-convert-content.sh -v -o $(MNT)/$(OSCAL_DIR) -a $(MNT) -c $(MNT)/$(CONTENT_CONFIG_PATH) -w $(MNT)/dist --resolve-profiles


### PR DESCRIPTION
Fix bad working directory in copy-and-convert-content.sh invocation, and use --resolve-profiles parameter.

Context: This script invocation was moved out of a Github Action workflow and into the Makefile, utilizing an OSCAL Docker image as a runtime. These parameters were not copied over at that time.