### PR TITLE
Fix incorrect objective IDs in FedRAMP rev 4 baselines

### DIFF
--- a/dist/content/rev4/baselines/xml/FedRAMP_rev4_HIGH-baseline_profile.xml
+++ b/dist/content/rev4/baselines/xml/FedRAMP_rev4_HIGH-baseline_profile.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/release-1.0/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
+<?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
          uuid="a96528f4-ced6-4711-b394-509b7042dfa5">
    <metadata>
       <title>FedRAMP Rev 4 High Baseline</title>
       <published>2021-02-05T00:00:00.000-04:00</published>
       <last-modified>2022-08-19T00:00:00.000-04:00</last-modified>
-      <version>fedramp1.1.0-oscal1.0.4</version>
+      <version>fedramp1.1.1-oscal1.0.4</version>
       <oscal-version>1.0.4</oscal-version>
       <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">
          <title>The FedRAMP Program Management Office (PMO)</title>
-         <short-name>CSP</short-name>
+         <short-name>PMO</short-name>
       </role>
       <role id="fedramp-jab">
          <title>The FedRAMP Joint Authorization Board (JAB)</title>
-         <short-name>CSP</short-name>
+         <short-name>JAB</short-name>
       </role>
       <party uuid="8cc0b8e5-9650-4d5f-9796-316f05fa9a2d" type="organization">
          <name>Federal Risk and Authorization Management Program: Program Management Office</name>
@@ -25,7 +25,6 @@
          <link href="https://fedramp.gov" rel="homepage"/>
          <link href="#a2381e87-3d04-4108-a30b-b4d2f36d001f" rel="logo"/>
          <link href="#985475ee-d4d6-4581-8fdf-d84d3d8caa48" rel="reference"/>
-         <link href="#1a23a771-d481-4594-9a1a-71d584fa4123" rel="reference"/>
          <email-address>info@fedramp.gov</email-address>
          <address type="work">
             <addr-line>1800 F St. NW</addr-line>
@@ -13032,18 +13031,16 @@
    <back-matter>
       <resource uuid="985475ee-d4d6-4581-8fdf-d84d3d8caa48">
          <title>FedRAMP Applicable Laws and Regulations</title>
-         <rlink href="https://www.fedramp.gov/assets/resources/templates/SSP-A12-FedRAMP-Laws-and-Regulations-Template.xlsx"/>
-      </resource>
-      <resource uuid="1a23a771-d481-4594-9a1a-71d584fa4123">
-         <title>FedRAMP Master Acronym and Glossary</title>
-         <rlink href="https://www.fedramp.gov/assets/resources/documents/FedRAMP_Master_Acronym_and_Glossary.pdf"/>
+         <rlink media-type="application/vnd.ms-excel" 
+                href="https://www.fedramp.gov/assets/resources/templates/SSP-A12-FedRAMP-Laws-and-Regulations-Template.xlsx"/>
       </resource>
       <resource uuid="a2381e87-3d04-4108-a30b-b4d2f36d001f">
          <description>
             <p>FedRAMP Logo</p>
          </description>
          <prop name="type" value="logo"/>
-         <rlink href="https://www.fedramp.gov/assets/img/logo-main-fedramp.png"/>
+         <rlink media-type="image/png" 
+                href="https://www.fedramp.gov/assets/img/logo-main-fedramp.png"/>
       </resource>
       <resource uuid="ad005eae-cc63-4e64-9109-3905a9a825e4">
          <title>NIST Special Publication (SP) 800-53</title>

--- a/dist/content/rev4/baselines/xml/FedRAMP_rev4_HIGH-baseline_profile.xml
+++ b/dist/content/rev4/baselines/xml/FedRAMP_rev4_HIGH-baseline_profile.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/release-1.0/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<!-- Modified by the OSCAL 1.0.0 RC2 to OSCAL 1.0.0 conversion XSLT on 2021-06-09T14:27:59.366-04:00 -->
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
          uuid="a96528f4-ced6-4711-b394-509b7042dfa5">
    <metadata>
       <title>FedRAMP Rev 4 High Baseline</title>
       <published>2021-02-05T00:00:00.000-04:00</published>
-      <last-modified>2021-06-09T14:27:59.366-04:00</last-modified>
-      <version>fedramp1.1.0-oscal1.0.0</version>
-      <oscal-version>1.0.0</oscal-version>
+      <last-modified>2022-08-19T00:00:00.000-04:00</last-modified>
+      <version>fedramp1.1.0-oscal1.0.4</version>
+      <oscal-version>1.0.4</oscal-version>
       <role id="prepared-by">
          <title>Document creator</title>
       </role>
@@ -2290,7 +2289,7 @@
          <add position="starting" by-id="ac-12">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="ac-12.1_obj">
+         <add position="starting" by-id="ac-12_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -3050,11 +3049,11 @@
          <add position="starting" by-id="ac-4">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="ac-4.1_obj">
+         <add position="starting" by-id="ac-4_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="ac-4.2_obj">
+         <add position="starting" by-id="ac-4_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -3668,11 +3667,11 @@
          </add>
       </alter>
       <alter control-id="au-10">
-         <add position="starting" by-id="au-10.1_obj">
+         <add position="starting" by-id="au-10_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="au-10.2_obj">
+         <add position="starting" by-id="au-10_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -3696,7 +3695,7 @@
          <add position="starting" by-id="au-11">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="au-11.1_obj">
+         <add position="starting" by-id="au-11_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -3934,7 +3933,7 @@
          </add>
       </alter>
       <alter control-id="au-4">
-         <add position="starting" by-id="au-4.1_obj">
+         <add position="starting" by-id="au-4_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -4277,13 +4276,13 @@
          </add>
       </alter>
       <alter control-id="au-9">
-         <add position="starting" by-id="au-9.1_obj">
+         <add position="starting" by-id="au-9_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="au-9.2_obj">
+         <add position="starting" by-id="au-9_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -4873,11 +4872,11 @@
          <add position="starting" by-id="ca-8">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="ca-8.1_obj">
+         <add position="starting" by-id="ca-8_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="ca-8.2_obj">
+         <add position="starting" by-id="ca-8_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -5405,7 +5404,7 @@
          </add>
       </alter>
       <alter control-id="cm-4">
-         <add position="starting" by-id="cm-4.1_obj">
+         <add position="starting" by-id="cm-4_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -5446,28 +5445,28 @@
          </add>
       </alter>
       <alter control-id="cm-5">
-         <add position="starting" by-id="cm-5.1_obj">
+         <add position="starting" by-id="cm-5_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="cm-5.2_obj">
+         <add position="starting" by-id="cm-5_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="cm-5.3_obj">
+         <add position="starting" by-id="cm-5_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="cm-5.4_obj">
+         <add position="starting" by-id="cm-5_obj.4">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
          </add>
-         <add position="starting" by-id="cm-5.5_obj">
+         <add position="starting" by-id="cm-5_obj.5">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="cm-5.6_obj">
+         <add position="starting" by-id="cm-5_obj.6">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -6037,7 +6036,7 @@
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="cp-10.2_obj">
+         <add position="starting" by-id="cp-10_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -6372,12 +6371,12 @@
          </add>
       </alter>
       <alter control-id="cp-6">
-         <add position="starting" by-id="cp-6.1_obj">
+         <add position="starting" by-id="cp-6_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
          </add>
-         <add position="starting" by-id="cp-6.2_obj">
+         <add position="starting" by-id="cp-6_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -6544,15 +6543,15 @@
                </part>
             </part>
          </add>
-         <add position="starting" by-id="cp-8.1_obj">
+         <add position="starting" by-id="cp-8_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="cp-8.2_obj">
+         <add position="starting" by-id="cp-8_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="cp-8.3_obj">
+         <add position="starting" by-id="cp-8_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -6827,7 +6826,7 @@
          </add>
       </alter>
       <alter control-id="ia-2">
-         <add position="starting" by-id="ia-2.1_obj">
+         <add position="starting" by-id="ia-2_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -6985,7 +6984,7 @@
          </add>
       </alter>
       <alter control-id="ia-3">
-         <add position="starting" by-id="ia-3.1_obj">
+         <add position="starting" by-id="ia-3_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -7483,7 +7482,7 @@
          </add>
       </alter>
       <alter control-id="ia-8">
-         <add position="starting" by-id="ia-8.1_obj">
+         <add position="starting" by-id="ia-8_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -7679,11 +7678,11 @@
          <add position="starting" by-id="ir-3">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="ir-3.1_obj">
+         <add position="starting" by-id="ir-3_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="ir-3.2_obj">
+         <add position="starting" by-id="ir-3_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -7830,7 +7829,7 @@
          </add>
       </alter>
       <alter control-id="ir-5">
-         <add position="starting" by-id="ir-5.1_obj">
+         <add position="starting" by-id="ir-5_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -7906,13 +7905,13 @@
          </add>
       </alter>
       <alter control-id="ir-7">
-         <add position="starting" by-id="ir-7.1_obj">
+         <add position="starting" by-id="ir-7_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="ir-7.2_obj">
+         <add position="starting" by-id="ir-7_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -8334,17 +8333,17 @@
          </add>
       </alter>
       <alter control-id="ma-3">
-         <add position="starting" by-id="ma-3.1_obj">
+         <add position="starting" by-id="ma-3_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
          </add>
-         <add position="starting" by-id="ma-3.2_obj">
+         <add position="starting" by-id="ma-3_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
          </add>
-         <add position="starting" by-id="ma-3.3_obj">
+         <add position="starting" by-id="ma-3_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -8541,15 +8540,15 @@
          </add>
       </alter>
       <alter control-id="ma-6">
-         <add position="starting" by-id="ma-6.1_obj">
+         <add position="starting" by-id="ma-6_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="ma-6.2_obj">
+         <add position="starting" by-id="ma-6_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="ma-6.3_obj">
+         <add position="starting" by-id="ma-6_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -8865,11 +8864,11 @@
          </add>
       </alter>
       <alter control-id="mp-7">
-         <add position="starting" by-id="mp-7.1_obj">
+         <add position="starting" by-id="mp-7_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="mp-7.2_obj">
+         <add position="starting" by-id="mp-7_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -9005,7 +9004,7 @@
          </add>
       </alter>
       <alter control-id="pe-12">
-         <add position="starting" by-id="pe-12.1_obj">
+         <add position="starting" by-id="pe-12_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -9022,13 +9021,13 @@
          </add>
       </alter>
       <alter control-id="pe-13">
-         <add position="starting" by-id="pe-13.1_obj">
+         <add position="starting" by-id="pe-13_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="pe-13.2_obj">
+         <add position="starting" by-id="pe-13_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -9266,7 +9265,7 @@
          </add>
       </alter>
       <alter control-id="pe-18">
-         <add position="starting" by-id="pe-18.1_obj">
+         <add position="starting" by-id="pe-18_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -10887,11 +10886,11 @@
          </add>
       </alter>
       <alter control-id="sa-12">
-         <add position="starting" by-id="sa-12.1_obj">
+         <add position="starting" by-id="sa-12_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sa-12.2_obj">
+         <add position="starting" by-id="sa-12_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -11060,7 +11059,7 @@
                </part>
             </part>
          </add>
-         <add position="starting" by-id="sa-4.1_obj">
+         <add position="starting" by-id="sa-4_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -11419,11 +11418,11 @@
                </part>
             </part>
          </add>
-         <add position="starting" by-id="sc-12.1_obj">
+         <add position="starting" by-id="sc-12_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-12.2_obj">
+         <add position="starting" by-id="sc-12_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -11733,11 +11732,11 @@
                </part>
             </part>
          </add>
-         <add position="starting" by-id="sc-28.1_obj">
+         <add position="starting" by-id="sc-28_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-28.2_obj">
+         <add position="starting" by-id="sc-28_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -11798,15 +11797,15 @@
          </add>
       </alter>
       <alter control-id="sc-5">
-         <add position="starting" by-id="sc-5.1_obj">
+         <add position="starting" by-id="sc-5_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-5.2_obj">
+         <add position="starting" by-id="sc-5_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-5.3_obj">
+         <add position="starting" by-id="sc-5_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -12882,7 +12881,7 @@
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="si-7.2_obj">
+         <add position="starting" by-id="si-7_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>

--- a/dist/content/rev4/baselines/xml/FedRAMP_rev4_LI-SaaS-baseline_profile.xml
+++ b/dist/content/rev4/baselines/xml/FedRAMP_rev4_LI-SaaS-baseline_profile.xml
@@ -5,10 +5,10 @@
          uuid="145f590d-2443-4c34-9ce9-37ccbe88abf9">
    <metadata>
       <title>FedRAMP Rev 4 Tailored Low Impact Software as a Service (LI-SaaS) Baseline</title>
-      <published>2021-02-17T00:00:00.000-04:00</published>
-      <last-modified>2021-06-09T14:28:03.343-04:00</last-modified>
-      <version>fedramp1.1.0-oscal1.0.0</version>
-      <oscal-version>1.0.0</oscal-version>
+      <published>2021-02-05T00:00:00.000-04:00</published>
+      <last-modified>2022-08-19T00:00:00.000-04:00</last-modified>
+      <version>fedramp1.1.0-oscal1.0.4</version>
+      <oscal-version>1.0.4</oscal-version>
       <role id="prepared-by">
          <title>Document creator</title>
       </role>
@@ -3212,7 +3212,7 @@
                </part>
             </part>
          </add>
-         <add by-id="ra-_smt" position="ending">
+         <add by-id="ra-3_smt" position="ending">
             <part id="ra-3_fr" name="item">
                <title>RA-3 Additional FedRAMP Requirements and Guidance</title>
                <part id="ra-3_fr_gdn.1" name="guidance">

--- a/dist/content/rev4/baselines/xml/FedRAMP_rev4_LI-SaaS-baseline_profile.xml
+++ b/dist/content/rev4/baselines/xml/FedRAMP_rev4_LI-SaaS-baseline_profile.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/release-1.0/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<!-- Modified by the OSCAL 1.0.0 RC2 to OSCAL 1.0.0 conversion XSLT on 2021-06-09T14:28:03.343-04:00 -->
+<?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
          uuid="145f590d-2443-4c34-9ce9-37ccbe88abf9">
    <metadata>
       <title>FedRAMP Rev 4 Tailored Low Impact Software as a Service (LI-SaaS) Baseline</title>
       <published>2021-02-05T00:00:00.000-04:00</published>
       <last-modified>2022-08-19T00:00:00.000-04:00</last-modified>
-      <version>fedramp1.1.0-oscal1.0.4</version>
+      <version>fedramp1.1.1-oscal1.0.4</version>
       <oscal-version>1.0.4</oscal-version>
       <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">
          <title>The FedRAMP Program Management Office (PMO)</title>
-         <short-name>CSP</short-name>
+         <short-name>PMO</short-name>
       </role>
       <role id="fedramp-jab">
          <title>The FedRAMP Joint Authorization Board (JAB)</title>
-         <short-name>CSP</short-name>
+         <short-name>JAB</short-name>
       </role>
       <party uuid="8cc0b8e5-9650-4d5f-9796-316f05fa9a2d" type="organization">
          <name>Federal Risk and Authorization Management Program: Program Management Office</name>
@@ -26,7 +25,6 @@
          <link href="https://fedramp.gov" rel="homepage"/>
          <link href="#a2381e87-3d04-4108-a30b-b4d2f36d001f" rel="logo"/>
          <link href="#985475ee-d4d6-4581-8fdf-d84d3d8caa48" rel="reference"/>
-         <link href="#1a23a771-d481-4594-9a1a-71d584fa4123" rel="reference"/>
          <email-address>info@fedramp.gov</email-address>
          <address type="work">
             <addr-line>1800 F St. NW</addr-line>
@@ -3902,18 +3900,16 @@
    <back-matter>
       <resource uuid="985475ee-d4d6-4581-8fdf-d84d3d8caa48">
          <title>FedRAMP Applicable Laws and Regulations</title>
-         <rlink href="https://www.fedramp.gov/assets/resources/templates/SSP-A12-FedRAMP-Laws-and-Regulations-Template.xlsx"/>
-      </resource>
-      <resource uuid="1a23a771-d481-4594-9a1a-71d584fa4123">
-         <title>FedRAMP Master Acronym and Glossary</title>
-         <rlink href="https://www.fedramp.gov/assets/resources/documents/FedRAMP_Master_Acronym_and_Glossary.pdf"/>
+         <rlink media-type="application/vnd.ms-excel" 
+                href="https://www.fedramp.gov/assets/resources/templates/SSP-A12-FedRAMP-Laws-and-Regulations-Template.xlsx"/>
       </resource>
       <resource uuid="a2381e87-3d04-4108-a30b-b4d2f36d001f">
          <description>
             <p>FedRAMP Logo</p>
          </description>
          <prop name="type" value="logo"/>
-         <rlink href="https://www.fedramp.gov/assets/img/logo-main-fedramp.png"/>
+         <rlink media-type="image/png" 
+                href="https://www.fedramp.gov/assets/img/logo-main-fedramp.png"/>
       </resource>
       <resource uuid="ad005eae-cc63-4e64-9109-3905a9a825e4">
          <title>NIST Special Publication (SP) 800-53</title>

--- a/dist/content/rev4/baselines/xml/FedRAMP_rev4_LOW-baseline_profile.xml
+++ b/dist/content/rev4/baselines/xml/FedRAMP_rev4_LOW-baseline_profile.xml
@@ -6,9 +6,9 @@
    <metadata>
       <title>FedRAMP Rev 4 Low Baseline</title>
       <published>2021-02-05T00:00:00.000-04:00</published>
-      <last-modified>2021-06-09T14:27:40.706-04:00</last-modified>
-      <version>fedramp1.1.0-oscal1.0.0</version>
-      <oscal-version>1.0.0</oscal-version>
+      <last-modified>2022-08-19T00:00:00.000-04:00</last-modified>
+      <version>fedramp1.1.0-oscal1.0.4</version>
+      <oscal-version>1.0.4</oscal-version>
       <role id="prepared-by">
          <title>Document creator</title>
       </role>
@@ -1644,7 +1644,7 @@
          <add position="starting" by-id="au-11">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="au-11.1_obj">
+         <add position="starting" by-id="au-11_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -1761,7 +1761,7 @@
          </add>
       </alter>
       <alter control-id="au-4">
-         <add position="starting" by-id="au-4.1_obj">
+         <add position="starting" by-id="au-4_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -1873,13 +1873,13 @@
          </add>
       </alter>
       <alter control-id="au-9">
-         <add position="starting" by-id="au-9.1_obj">
+         <add position="starting" by-id="au-9_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="au-9.2_obj">
+         <add position="starting" by-id="au-9_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -2428,7 +2428,7 @@
          </add>
       </alter>
       <alter control-id="cm-4">
-         <add position="starting" by-id="cm-4.1_obj">
+         <add position="starting" by-id="cm-4_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -2675,7 +2675,7 @@
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="cp-10.2_obj">
+         <add position="starting" by-id="cp-10_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -3006,7 +3006,7 @@
          </add>
       </alter>
       <alter control-id="ia-2">
-         <add position="starting" by-id="ia-2.1_obj">
+         <add position="starting" by-id="ia-2_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -3380,7 +3380,7 @@
          </add>
       </alter>
       <alter control-id="ia-8">
-         <add position="starting" by-id="ia-8.1_obj">
+         <add position="starting" by-id="ia-8_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -3577,7 +3577,7 @@
          </add>
       </alter>
       <alter control-id="ir-5">
-         <add position="starting" by-id="ir-5.1_obj">
+         <add position="starting" by-id="ir-5_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -3631,13 +3631,13 @@
          </add>
       </alter>
       <alter control-id="ir-7">
-         <add position="starting" by-id="ir-7.1_obj">
+         <add position="starting" by-id="ir-7_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="ir-7.2_obj">
+         <add position="starting" by-id="ir-7_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -4076,11 +4076,11 @@
          </add>
       </alter>
       <alter control-id="mp-7">
-         <add position="starting" by-id="mp-7.1_obj">
+         <add position="starting" by-id="mp-7_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="mp-7.2_obj">
+         <add position="starting" by-id="mp-7_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -4154,7 +4154,7 @@
          </add>
       </alter>
       <alter control-id="pe-12">
-         <add position="starting" by-id="pe-12.1_obj">
+         <add position="starting" by-id="pe-12_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -4171,13 +4171,13 @@
          </add>
       </alter>
       <alter control-id="pe-13">
-         <add position="starting" by-id="pe-13.1_obj">
+         <add position="starting" by-id="pe-13_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="pe-13.2_obj">
+         <add position="starting" by-id="pe-13_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -5455,7 +5455,7 @@
                </part>
             </part>
          </add>
-         <add position="starting" by-id="sa-4.1_obj">
+         <add position="starting" by-id="sa-4_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -5483,14 +5483,7 @@
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
          </add>
       </alter>
-      <alter control-id="sa-4.10">
-         <add position="starting" by-id="sa-4.10_obj">
-            <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
-            <prop name="method" class="fedramp" value="EXAMINE"/>
-            <prop name="method" class="fedramp" value="INTERVIEW"/>
-            <prop name="method" class="fedramp" value="TEST"/>
-         </add>
-      </alter>
+      
       <alter control-id="sa-5">
          <add position="starting" by-id="sa-5.a_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
@@ -5667,11 +5660,11 @@
                </part>
             </part>
          </add>
-         <add position="starting" by-id="sc-12.1_obj">
+         <add position="starting" by-id="sc-12_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-12.2_obj">
+         <add position="starting" by-id="sc-12_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -5806,15 +5799,15 @@
          </add>
       </alter>
       <alter control-id="sc-5">
-         <add position="starting" by-id="sc-5.1_obj">
+         <add position="starting" by-id="sc-5_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-5.2_obj">
+         <add position="starting" by-id="sc-5_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-5.3_obj">
+         <add position="starting" by-id="sc-5_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>

--- a/dist/content/rev4/baselines/xml/FedRAMP_rev4_LOW-baseline_profile.xml
+++ b/dist/content/rev4/baselines/xml/FedRAMP_rev4_LOW-baseline_profile.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/release-1.0/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<!-- Modified by the OSCAL 1.0.0 RC2 to OSCAL 1.0.0 conversion XSLT on 2021-06-09T14:27:40.706-04:00 -->
+<?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
          uuid="0c98192d-af11-4486-ab9a-d97ff36ff2ad">
    <metadata>
       <title>FedRAMP Rev 4 Low Baseline</title>
       <published>2021-02-05T00:00:00.000-04:00</published>
       <last-modified>2022-08-19T00:00:00.000-04:00</last-modified>
-      <version>fedramp1.1.0-oscal1.0.4</version>
+      <version>fedramp1.1.1-oscal1.0.4</version>
       <oscal-version>1.0.4</oscal-version>
       <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">
          <title>The FedRAMP Program Management Office (PMO)</title>
-         <short-name>CSP</short-name>
+         <short-name>PMO</short-name>
       </role>
       <role id="fedramp-jab">
          <title>The FedRAMP Joint Authorization Board (JAB)</title>
-         <short-name>CSP</short-name>
+         <short-name>JAB</short-name>
       </role>
       <party uuid="8cc0b8e5-9650-4d5f-9796-316f05fa9a2d" type="organization">
          <name>Federal Risk and Authorization Management Program: Program Management Office</name>
@@ -26,7 +25,6 @@
          <link href="https://fedramp.gov" rel="homepage"/>
          <link href="#a2381e87-3d04-4108-a30b-b4d2f36d001f" rel="logo"/>
          <link href="#985475ee-d4d6-4581-8fdf-d84d3d8caa48" rel="reference"/>
-         <link href="#1a23a771-d481-4594-9a1a-71d584fa4123" rel="reference"/>
          <email-address>info@fedramp.gov</email-address>
          <address type="work">
             <addr-line>1800 F St. NW</addr-line>
@@ -6203,18 +6201,16 @@
    <back-matter>
       <resource uuid="985475ee-d4d6-4581-8fdf-d84d3d8caa48">
          <title>FedRAMP Applicable Laws and Regulations</title>
-         <rlink href="https://www.fedramp.gov/assets/resources/templates/SSP-A12-FedRAMP-Laws-and-Regulations-Template.xlsx"/>
-      </resource>
-      <resource uuid="1a23a771-d481-4594-9a1a-71d584fa4123">
-         <title>FedRAMP Master Acronym and Glossary</title>
-         <rlink href="https://www.fedramp.gov/assets/resources/documents/FedRAMP_Master_Acronym_and_Glossary.pdf"/>
+         <rlink media-type="application/vnd.ms-excel" 
+                href="https://www.fedramp.gov/assets/resources/templates/SSP-A12-FedRAMP-Laws-and-Regulations-Template.xlsx"/>
       </resource>
       <resource uuid="a2381e87-3d04-4108-a30b-b4d2f36d001f">
          <description>
             <p>FedRAMP Logo</p>
          </description>
          <prop name="type" value="logo"/>
-         <rlink href="https://www.fedramp.gov/assets/img/logo-main-fedramp.png"/>
+         <rlink media-type="image/png" 
+                href="https://www.fedramp.gov/assets/img/logo-main-fedramp.png"/>
       </resource>
       <resource uuid="ad005eae-cc63-4e64-9109-3905a9a825e4">
          <title>NIST Special Publication (SP) 800-53</title>

--- a/dist/content/rev4/baselines/xml/FedRAMP_rev4_MODERATE-baseline_profile.xml
+++ b/dist/content/rev4/baselines/xml/FedRAMP_rev4_MODERATE-baseline_profile.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/release-1.0/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
+<?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
          uuid="a8aadf50-d5ea-46d2-bdf3-3d49947ce761">
    <metadata>
       <title>FedRAMP Rev 4 Moderate Baseline</title>
       <published>2021-02-05T00:00:00.000-04:00</published>
       <last-modified>2022-08-19T00:00:00.000-04:00</last-modified>
-      <version>fedramp1.1.0-oscal1.0.4</version>
+      <version>fedramp1.1.1-oscal1.0.4</version>
       <oscal-version>1.0.4</oscal-version>
       <role id="prepared-by">
          <title>Document creator</title>
       </role>
       <role id="fedramp-pmo">
          <title>The FedRAMP Program Management Office (PMO)</title>
-         <short-name>CSP</short-name>
+         <short-name>PMO</short-name>
       </role>
       <role id="fedramp-jab">
          <title>The FedRAMP Joint Authorization Board (JAB)</title>
-         <short-name>CSP</short-name>
+         <short-name>JAB</short-name>
       </role>
       <party uuid="8cc0b8e5-9650-4d5f-9796-316f05fa9a2d" type="organization">
          <name>Federal Risk and Authorization Management Program: Program Management Office</name>
@@ -25,7 +25,6 @@
          <link href="https://fedramp.gov" rel="homepage"/>
          <link href="#a2381e87-3d04-4108-a30b-b4d2f36d001f" rel="logo"/>
          <link href="#985475ee-d4d6-4581-8fdf-d84d3d8caa48" rel="reference"/>
-         <link href="#1a23a771-d481-4594-9a1a-71d584fa4123" rel="reference"/>
          <email-address>info@fedramp.gov</email-address>
          <address type="work">
             <addr-line>1800 F St. NW</addr-line>
@@ -10875,18 +10874,16 @@
    <back-matter>
       <resource uuid="985475ee-d4d6-4581-8fdf-d84d3d8caa48">
          <title>FedRAMP Applicable Laws and Regulations</title>
-         <rlink href="https://www.fedramp.gov/assets/resources/templates/SSP-A12-FedRAMP-Laws-and-Regulations-Template.xlsx"/>
-      </resource>
-      <resource uuid="1a23a771-d481-4594-9a1a-71d584fa4123">
-         <title>FedRAMP Master Acronym and Glossary</title>
-         <rlink href="https://www.fedramp.gov/assets/resources/documents/FedRAMP_Master_Acronym_and_Glossary.pdf"/>
+         <rlink media-type="application/vnd.ms-excel" 
+                href="https://www.fedramp.gov/assets/resources/templates/SSP-A12-FedRAMP-Laws-and-Regulations-Template.xlsx"/>
       </resource>
       <resource uuid="a2381e87-3d04-4108-a30b-b4d2f36d001f">
          <description>
             <p>FedRAMP Logo</p>
          </description>
          <prop name="type" value="logo"/>
-         <rlink href="https://www.fedramp.gov/assets/img/logo-main-fedramp.png"/>
+         <rlink media-type="image/png" 
+                href="https://www.fedramp.gov/assets/img/logo-main-fedramp.png"/>
       </resource>
       <resource uuid="ad005eae-cc63-4e64-9109-3905a9a825e4">
          <title>NIST Special Publication (SP) 800-53</title>

--- a/dist/content/rev4/baselines/xml/FedRAMP_rev4_MODERATE-baseline_profile.xml
+++ b/dist/content/rev4/baselines/xml/FedRAMP_rev4_MODERATE-baseline_profile.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/release-1.0/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<!-- Modified by the OSCAL 1.0.0 RC2 to OSCAL 1.0.0 conversion XSLT on 2021-06-09T14:27:27.561-04:00 -->
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
          uuid="a8aadf50-d5ea-46d2-bdf3-3d49947ce761">
    <metadata>
       <title>FedRAMP Rev 4 Moderate Baseline</title>
       <published>2021-02-05T00:00:00.000-04:00</published>
-      <last-modified>2021-06-09T14:27:27.561-04:00</last-modified>
-      <version>fedramp1.1.0-oscal1.0.0</version>
-      <oscal-version>1.0.0</oscal-version>
+      <last-modified>2022-08-19T00:00:00.000-04:00</last-modified>
+      <version>fedramp1.1.0-oscal1.0.4</version>
+      <oscal-version>1.0.4</oscal-version>
       <role id="prepared-by">
          <title>Document creator</title>
       </role>
@@ -1739,7 +1738,7 @@
          <add position="starting" by-id="ac-12">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="ac-12.1_obj">
+         <add position="starting" by-id="ac-12_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -2384,11 +2383,11 @@
          <add position="starting" by-id="ac-4">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="ac-4.1_obj">
+         <add position="starting" by-id="ac-4_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="ac-4.2_obj">
+         <add position="starting" by-id="ac-4_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -2889,7 +2888,7 @@
          <add position="starting" by-id="au-11">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="au-11.1_obj">
+         <add position="starting" by-id="au-11_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -3069,7 +3068,7 @@
          </add>
       </alter>
       <alter control-id="au-4">
-         <add position="starting" by-id="au-4.1_obj">
+         <add position="starting" by-id="au-4_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -3295,13 +3294,13 @@
          </add>
       </alter>
       <alter control-id="au-9">
-         <add position="starting" by-id="au-9.1_obj">
+         <add position="starting" by-id="au-9_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="au-9.2_obj">
+         <add position="starting" by-id="au-9_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -3864,11 +3863,11 @@
          <add position="starting" by-id="ca-8">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="ca-8.1_obj">
+         <add position="starting" by-id="ca-8_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="ca-8.2_obj">
+         <add position="starting" by-id="ca-8_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -4263,7 +4262,7 @@
          </add>
       </alter>
       <alter control-id="cm-4">
-         <add position="starting" by-id="cm-4.1_obj">
+         <add position="starting" by-id="cm-4_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -4274,28 +4273,28 @@
          </add>
       </alter>
       <alter control-id="cm-5">
-         <add position="starting" by-id="cm-5.1_obj">
+         <add position="starting" by-id="cm-5_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="cm-5.2_obj">
+         <add position="starting" by-id="cm-5_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="cm-5.3_obj">
+         <add position="starting" by-id="cm-5_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="cm-5.4_obj">
+         <add position="starting" by-id="cm-5_obj.4">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
          </add>
-         <add position="starting" by-id="cm-5.5_obj">
+         <add position="starting" by-id="cm-5_obj.5">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="cm-5.6_obj">
+         <add position="starting" by-id="cm-5_obj.6">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -4804,7 +4803,7 @@
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="cp-10.2_obj">
+         <add position="starting" by-id="cp-10_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -5069,12 +5068,12 @@
          </add>
       </alter>
       <alter control-id="cp-6">
-         <add position="starting" by-id="cp-6.1_obj">
+         <add position="starting" by-id="cp-6_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
          </add>
-         <add position="starting" by-id="cp-6.2_obj">
+         <add position="starting" by-id="cp-6_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -5220,15 +5219,15 @@
                </part>
             </part>
          </add>
-         <add position="starting" by-id="cp-8.1_obj">
+         <add position="starting" by-id="cp-8_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="cp-8.2_obj">
+         <add position="starting" by-id="cp-8_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="cp-8.3_obj">
+         <add position="starting" by-id="cp-8_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -5430,7 +5429,7 @@
          </add>
       </alter>
       <alter control-id="ia-2">
-         <add position="starting" by-id="ia-2.1_obj">
+         <add position="starting" by-id="ia-2_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -5566,7 +5565,7 @@
          </add>
       </alter>
       <alter control-id="ia-3">
-         <add position="starting" by-id="ia-3.1_obj">
+         <add position="starting" by-id="ia-3_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -6036,7 +6035,7 @@
          </add>
       </alter>
       <alter control-id="ia-8">
-         <add position="starting" by-id="ia-8.1_obj">
+         <add position="starting" by-id="ia-8_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -6210,11 +6209,11 @@
          <add position="starting" by-id="ir-3">
             <prop ns="https://fedramp.gov/ns/oscal" name="CORE" value="true"/>
          </add>
-         <add position="starting" by-id="ir-3.1_obj">
+         <add position="starting" by-id="ir-3_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="ir-3.2_obj">
+         <add position="starting" by-id="ir-3_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -6289,7 +6288,7 @@
          </add>
       </alter>
       <alter control-id="ir-5">
-         <add position="starting" by-id="ir-5.1_obj">
+         <add position="starting" by-id="ir-5_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -6354,13 +6353,13 @@
          </add>
       </alter>
       <alter control-id="ir-7">
-         <add position="starting" by-id="ir-7.1_obj">
+         <add position="starting" by-id="ir-7_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="ir-7.2_obj">
+         <add position="starting" by-id="ir-7_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -6765,17 +6764,17 @@
          </add>
       </alter>
       <alter control-id="ma-3">
-         <add position="starting" by-id="ma-3.1_obj">
+         <add position="starting" by-id="ma-3_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
          </add>
-         <add position="starting" by-id="ma-3.2_obj">
+         <add position="starting" by-id="ma-3_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
          </add>
-         <add position="starting" by-id="ma-3.3_obj">
+         <add position="starting" by-id="ma-3_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -6953,15 +6952,15 @@
          </add>
       </alter>
       <alter control-id="ma-6">
-         <add position="starting" by-id="ma-6.1_obj">
+         <add position="starting" by-id="ma-6_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="ma-6.2_obj">
+         <add position="starting" by-id="ma-6_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="ma-6.3_obj">
+         <add position="starting" by-id="ma-6_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -7237,11 +7236,11 @@
          </add>
       </alter>
       <alter control-id="mp-7">
-         <add position="starting" by-id="mp-7.1_obj">
+         <add position="starting" by-id="mp-7_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="mp-7.2_obj">
+         <add position="starting" by-id="mp-7_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
@@ -7366,7 +7365,7 @@
          </add>
       </alter>
       <alter control-id="pe-12">
-         <add position="starting" by-id="pe-12.1_obj">
+         <add position="starting" by-id="pe-12_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -7383,13 +7382,13 @@
          </add>
       </alter>
       <alter control-id="pe-13">
-         <add position="starting" by-id="pe-13.1_obj">
+         <add position="starting" by-id="pe-13_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
          </add>
-         <add position="starting" by-id="pe-13.2_obj">
+         <add position="starting" by-id="pe-13_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -9179,7 +9178,7 @@
                </part>
             </part>
          </add>
-         <add position="starting" by-id="sa-4.1_obj">
+         <add position="starting" by-id="sa-4_obj">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
@@ -9538,11 +9537,11 @@
                </part>
             </part>
          </add>
-         <add position="starting" by-id="sc-12.1_obj">
+         <add position="starting" by-id="sc-12_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-12.2_obj">
+         <add position="starting" by-id="sc-12_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -9803,11 +9802,11 @@
                </part>
             </part>
          </add>
-         <add position="starting" by-id="sc-28.1_obj">
+         <add position="starting" by-id="sc-28_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-28.2_obj">
+         <add position="starting" by-id="sc-28_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -9857,15 +9856,15 @@
          </add>
       </alter>
       <alter control-id="sc-5">
-         <add position="starting" by-id="sc-5.1_obj">
+         <add position="starting" by-id="sc-5_obj.1">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-5.2_obj">
+         <add position="starting" by-id="sc-5_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="sc-5.3_obj">
+         <add position="starting" by-id="sc-5_obj.3">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>
@@ -10779,7 +10778,7 @@
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
-         <add position="starting" by-id="si-7.2_obj">
+         <add position="starting" by-id="si-7_obj.2">
             <prop ns="https://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
             <prop name="method" class="fedramp" value="INTERVIEW"/>
             <prop name="method" class="fedramp" value="TEST"/>


### PR DESCRIPTION
Several of the objective IDs specified in the (high, moderate, and low) baseline response points have errors.   There erroneous objective IDs that are specified incorrectly within a control causes them to clash with control enhancements.  