### PR TITLE
doc-available adjusted for internal and external references for ssp

### DIFF
--- a/src/validations/rules/rev4/poam.sch
+++ b/src/validations/rules/rev4/poam.sch
@@ -537,12 +537,6 @@
             identify a target within the document.</sch:diagnostic>
 
         <sch:diagnostic
-            doc:assert="has-import-ssp-external-href"
-            doc:context="oscal:import-ssp"
-            id="has-import-ssp-external-href-diagnostic">This OSCAL POA&amp;M import-ssp element href attribute which is an external reference does
-            not identify an available target.</sch:diagnostic>
-
-        <sch:diagnostic
             doc:assertion="import-ssp-has-available-document"
             doc:context="oscal:import-ssp"
             id="import-ssp-has-available-document-diagnostic">The import-ssp element has an href attribute that does not reference an available

--- a/src/validations/rules/rev4/poam.sch
+++ b/src/validations/rules/rev4/poam.sch
@@ -44,13 +44,7 @@
                 resolve-uri(/oscal:plan-of-action-and-milestones/oscal:import-ssp/@href, base-uri())" />
     <sch:let
         name="ssp-available"
-        value="
-            if (: this is not a relative reference :) (not(starts-with($ssp-import-url, '#')))
-            then
-                (: the referenced document must be available :)
-                doc-available($ssp-import-url)
-            else
-                true()" />
+        value="doc-available($ssp-import-url)" />
     <sch:let
         name="ssp-doc"
         value="
@@ -144,26 +138,6 @@
                         true()">An OSCAL POA&amp;M import-ssp element href attribute which is document-relative must identify a target
                 within the document. <sch:value-of
                     select="@href" />.</sch:assert>
-
-            <sch:let
-                name="import-ssp-url"
-                value="resolve-uri(@href, base-uri())" />
-
-            <sch:assert
-                diagnostics="has-import-ssp-external-href-diagnostic"
-                doc:guide-reference="Guide to OSCAL-based FedRAMP Plan of Action and Milestones (POA&amp;M) §3.5"
-                id="has-import-ssp-external-href"
-                role="error"
-                test="
-                    if (: this is not a relative reference :) (not(starts-with(@href, '#')))
-                    then
-                        (: the referenced document must be available :)
-                        doc-available($import-ssp-url)
-                    else
-                        (: the assertion succeeds :)
-                        true()"
-                unit:override-xspec="both">An OSCAL POA&amp;M import-ssp element href attribute which is an external reference must identify an
-                available target.</sch:assert>
 
             <sch:assert
                 diagnostics="import-ssp-has-available-document-diagnostic"

--- a/src/validations/test/rules/rev4/poam.xspec
+++ b/src/validations/test/rules/rev4/poam.xspec
@@ -159,37 +159,6 @@
         </x:scenario>
 
         <x:scenario
-            label="when the import-ssp has an external href">
-            <x:scenario
-                label="which is available"
-                pending="XSpec problem resolution">
-                <x:context>
-                    <plan-of-action-and-milestones
-                        xmlns="http://csrc.nist.gov/ns/oscal/1.0">
-                        <import-ssp
-                            href="../../../../dist/content/rev4/templates/ssp/xml/FedRAMP-SSP-OSCAL-Template.xml" />
-                    </plan-of-action-and-milestones>
-                </x:context>
-                <x:expect-not-assert
-                    id="has-import-ssp-external-href"
-                    label="that is correct" />
-            </x:scenario>
-            <x:scenario
-                label="which is not available">
-                <x:context>
-                    <plan-of-action-and-milestones
-                        xmlns="http://csrc.nist.gov/ns/oscal/1.0">
-                        <import-ssp
-                            href="file:x" />
-                    </plan-of-action-and-milestones>
-                </x:context>
-                <x:expect-assert
-                    id="has-import-ssp-external-href"
-                    label="that is an error" />
-            </x:scenario>
-        </x:scenario>
-
-        <x:scenario
             label="when the import-ssp has a relative href">
             <x:scenario
                 label="and the SSP is declared as a back-matter resource">


### PR DESCRIPTION
Removed the if statement in ssp-available variable

removed the assertion 'has-import-ssp-external-href-diagnostic'