### PR TITLE
Feature rev5 hotfix 08312023

### DIFF
--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
@@ -3,8 +3,8 @@
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="9af0a7d3-252c-4f18-9baf-4f10e82bfac8">
 	<metadata>
 		<title>FedRAMP Rev 5 High Baseline</title>
-		<published>2023-06-15T00:00:00Z</published>
-		<last-modified>2023-06-15T00:00:00Z</last-modified>
+		<published>2023-08-31T00:00:00Z</published>
+		<last-modified>2023-08-31T00:00:00Z</last-modified>
 		<version>fedramp-2.0.0-oscal1.0.4</version>
 		<oscal-version>1.0.4</oscal-version>
 		<role id="prepared-by">
@@ -477,7 +477,7 @@
 		<set-parameter param-id="ac-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -519,7 +519,7 @@
 		<set-parameter param-id="ac-02.02_odp.01">
 			<constraint>
 				<description>
-					<p>Selection: disables </p>
+					<p>Selection: disables</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -666,14 +666,14 @@
 		<set-parameter param-id="at-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="at-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -722,14 +722,14 @@
 		<set-parameter param-id="au-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="au-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -883,14 +883,14 @@
 		<set-parameter param-id="ca-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="ca-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -904,7 +904,7 @@
 		<set-parameter param-id="ca-02_odp.01">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -981,14 +981,14 @@
 		<set-parameter param-id="cm-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="cm-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1023,7 +1023,7 @@
 		<set-parameter param-id="cm-03.01_odp.03">
 			<constraint>
 				<description>
-					<p>organization agreed upon time period </p>
+					<p>organization agreed upon time period</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1121,7 +1121,7 @@
 		<set-parameter param-id="cp-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1254,14 +1254,14 @@
 		<set-parameter param-id="ia-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="ia-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1303,7 +1303,7 @@
 		<set-parameter param-id="ia-04_odp.01">
 			<constraint>
 				<description>
-					<p>at a minimum, the ISSO (or similar role within the organization) </p>
+					<p>at a minimum, the ISSO (or similar role within the organization)</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1331,14 +1331,14 @@
 		<set-parameter param-id="ir-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="ir-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1429,7 +1429,7 @@
 		<set-parameter param-id="ma-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1464,14 +1464,14 @@
 		<set-parameter param-id="mp-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="mp-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1520,7 +1520,7 @@
 		<set-parameter param-id="mp-05_odp.01">
 			<constraint>
 				<description>
-					<p>all media with sensitive information </p>
+					<p>all media with sensitive information</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1548,14 +1548,14 @@
 		<set-parameter param-id="pe-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="pe-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1688,14 +1688,14 @@
 		<set-parameter param-id="pl-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="pl-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1751,14 +1751,14 @@
 		<set-parameter param-id="ps-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="ps-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1808,7 +1808,7 @@
 		<set-parameter param-id="ps-05_odp.02">
 			<constraint>
 				<description>
-					<p>twenty-four (24) hours </p>
+					<p>twenty-four (24) hours</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1871,14 +1871,14 @@
 		<set-parameter param-id="ra-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="ra-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1955,14 +1955,14 @@
 		<set-parameter param-id="sa-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="sa-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1976,7 +1976,7 @@
 		<set-parameter param-id="sa-04.02_odp.01">
 			<constraint>
 				<description>
-					<p>at a minimum to include security-relevant external system interfaces; high-level design; low-level design; source code or network and data flow diagram; </p>
+					<p>at a minimum to include security-relevant external system interfaces; high-level design; low-level design; source code or network and data flow diagram;</p>
 					<p>organization-defined design/implementation information</p>
 				</description>
 			</constraint>
@@ -2061,14 +2061,14 @@
 		<set-parameter param-id="sc-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="sc-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -2201,14 +2201,14 @@
 		<set-parameter param-id="si-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="si-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -2229,7 +2229,7 @@
 		<set-parameter param-id="si-02.02_odp.02">
 			<constraint>
 				<description>
-					<p>at least monthly </p>
+					<p>at least monthly</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -2355,14 +2355,14 @@
 		<set-parameter param-id="sr-01_odp.05">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="sr-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -2520,7 +2520,7 @@
 					</part>
 					<part id="ac-8_fr_gdn.1" name="guidance">
 						<prop name="label" value="Guidance:"/>
-						<p>If performed as part of a Configuration Baseline check, then the % of items requiring setting that are checked and that pass (or fail) check can be provided. </p>
+						<p>If performed as part of a Configuration Baseline check, then the % of items requiring setting that are checked and that pass (or fail) check can be provided.</p>
 					</part>
 				</part>
 			</add>
@@ -2712,7 +2712,7 @@
 					<title>CM-2 Additional FedRAMP Requirements and Guidance</title>
 					<part id="ca-8.2_fr_gdn.1" name="guidance">
 						<prop name="label" value="Guidance:"/>
-						<p>See the FedRAMP Documents page&gt; Penetration Test Guidance </p>
+						<p>See the FedRAMP Documents page&gt; Penetration Test Guidance</p>
 						<p>https://www.FedRAMP.gov/documents/</p>
 					</part>
 				</part>
@@ -3425,9 +3425,9 @@
 						</ul>
 						<p> </p>
 						<p>The following applies only when choosing SC-8 (5) in lieu of SC-8 (1).</p>
-						<p>FedRAMP-Defined Assignment / Selection Parameters </p>
+						<p>FedRAMP-Defined Assignment / Selection Parameters</p>
 						<p>SC-8 (5)-1 [a hardened or alarmed carrier Protective Distribution System (PDS) when outside of Controlled Access Area (CAA)]</p>
-						<p>SC-8 (5)-2 [prevent unauthorized disclosure of information AND detect changes to information] </p>
+						<p>SC-8 (5)-2 [prevent unauthorized disclosure of information AND detect changes to information]</p>
 					</part>
 					<part id="sc-8_fr_gdn.2" name="guidance">
 						<prop name="label" value="Guidance:"/>
@@ -3443,7 +3443,7 @@
 						<p>https://www.dcsa.mil/Portals/91/documents/ctp/nao/CNSSI_7003_PDS_September_2015.pdf</p>
 						<p> </p>
 						<p>DHS Recommended Practice: Improving Industrial Control System Cybersecurity with Defense-in-Depth Strategies can be accessed here:</p>
-						<p>https://us-cert.cisa.gov/sites/default/files/FactSheets/NCCIC%20ICS_FactSheet_Defense_in_Depth_Strategies_S508C.pdf </p>
+						<p>https://us-cert.cisa.gov/sites/default/files/FactSheets/NCCIC%20ICS_FactSheet_Defense_in_Depth_Strategies_S508C.pdf</p>
 					</part>
 				</part>
 			</add>
@@ -3707,7 +3707,7 @@
 					<part id="si-8_fr_gdn.1" name="guidance">
 						<prop name="label" value="Guidance:"/>
 						<p>When CSO sends email on behalf of the government as part of the business offering, Control Description should include implementation of Domain-based Message Authentication, Reporting &amp; Conformance (DMARC) on the sending domain for outgoing messages as described in DHS Binding Operational Directive (BOD) 18-01.</p>
-						<p>https://cyber.dhs.gov/bod/18-01/ </p>
+						<p>https://cyber.dhs.gov/bod/18-01/</p>
 					</part>
 					<part id="si-8_fr_gdn.2" name="guidance">
 						<prop name="label" value="Guidance:"/>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
@@ -2,9 +2,9 @@
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="2b515da9-8a5e-4b7c-9cce-6451e70ca75d">
     <metadata>
-        <title>FedRAMP Rev 5 Tailored Low Impact Software as a Service (LI-SaaS) Baseline</title>
-        <published>2023-06-15T00:00:00Z</published>
-        <last-modified>2023-06-15T00:00:00Z</last-modified>
+        <title>FedRAMP Rev 5 Tailored Low Impact Software as a Service (LI-SaaS) Baseline</title>     
+        <published>2023-08-31T00:00:00Z</published>
+        <last-modified>2023-08-31T00:00:00Z</last-modified>
         <version>fedramp-2.0.0-oscal1.0.4</version>
         <oscal-version>1.0.4</oscal-version>
         <role id="prepared-by">
@@ -216,14 +216,14 @@
         <set-parameter param-id="ac-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ac-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -286,14 +286,14 @@
         <set-parameter param-id="at-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="at-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -342,14 +342,14 @@
         <set-parameter param-id="au-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="au-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -419,14 +419,14 @@
         <set-parameter param-id="ca-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ca-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -440,7 +440,7 @@
         <set-parameter param-id="ca-02_odp.01">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -496,7 +496,7 @@
         <set-parameter param-id="cm-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -540,14 +540,14 @@
         <set-parameter param-id="cp-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="cp-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -624,14 +624,14 @@
         <set-parameter param-id="ia-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ia-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -645,7 +645,7 @@
         <set-parameter param-id="ia-04_odp.01">
             <constraint>
                 <description>
-                    <p>at a minimum, the ISSO (or similar role within the organization) </p>
+                    <p>at a minimum, the ISSO (or similar role within the organization)</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -660,14 +660,14 @@
         <set-parameter param-id="ir-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ir-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -737,7 +737,7 @@
         <set-parameter param-id="ma-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -751,14 +751,14 @@
         <set-parameter param-id="mp-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="mp-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -779,14 +779,14 @@
         <set-parameter param-id="pe-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="pe-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -828,7 +828,7 @@
         <set-parameter param-id="pe-3_prm_9">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -877,14 +877,14 @@
         <set-parameter param-id="pl-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="pl-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -926,14 +926,14 @@
         <set-parameter param-id="ps-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ps-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -969,7 +969,7 @@
         <set-parameter param-id="ps-05_odp.02">
             <constraint>
                 <description>
-                    <p>twenty-four (24) hours </p>
+                    <p>twenty-four (24) hours</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -1018,14 +1018,14 @@
         <set-parameter param-id="ra-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ra-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -1081,14 +1081,14 @@
         <set-parameter param-id="sa-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="sa-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -1123,14 +1123,14 @@
         <set-parameter param-id="sc-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="sc-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -1186,14 +1186,14 @@
         <set-parameter param-id="si-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="si-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -1755,7 +1755,7 @@
                     <title>CM-6(a) Additional FedRAMP Requirements and Guidance</title>
                     <part id="cm-6_fr_smt.1" name="item">
                         <prop name="label" value="Requirement 1:"/>
-                        <p>The service provider shall use the Center for Internet Security guidelines (Level 1) to establish configuration settings or establishes its own configuration settings if USGCB is not available. </p>
+                        <p>The service provider shall use the Center for Internet Security guidelines (Level 1) to establish configuration settings or establishes its own configuration settings if USGCB is not available.</p>
                     </part>
                     <part id="cm-6_fr_smt.2" name="item">
                         <prop name="label" value="Requirement 2:"/>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
@@ -1442,7 +1442,7 @@
                         <prop name="label" value="Requirement:"/>
                         <p>POA&amp;Ms must be provided at least monthly.</p>
                     </part>
-                    <part id="ca-5_fr_smt.1" name="guidance">
+                    <part id="ca-5_fr_gdn.1" name="guidance">
                         <prop name="label" value="Guidance:"/>
                         <p>Reference FedRAMP-POAM-Template</p>
                     </part>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
@@ -3,8 +3,8 @@
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="71ba09a5-97a8-483f-92bd-3db6358f005d">
     <metadata>
         <title>FedRAMP Rev 5 Low Baseline</title>
-        <published>2023-06-15T00:00:00Z</published>
-        <last-modified>2023-06-15T00:00:00Z</last-modified>
+        <published>2023-08-31T00:00:00Z</published>
+        <last-modified>2023-08-31T00:00:00Z</last-modified>
         <version>fedramp-2.0.0-oscal1.0.4</version>
         <oscal-version>1.0.4</oscal-version>
         <role id="prepared-by">
@@ -216,14 +216,14 @@
         <set-parameter param-id="ac-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ac-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -286,14 +286,14 @@
         <set-parameter param-id="at-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="at-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -342,14 +342,14 @@
         <set-parameter param-id="au-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="au-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -419,14 +419,14 @@
         <set-parameter param-id="ca-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ca-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -440,7 +440,7 @@
         <set-parameter param-id="ca-02_odp.01">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -496,7 +496,7 @@
         <set-parameter param-id="cm-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -540,14 +540,14 @@
         <set-parameter param-id="cp-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="cp-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -624,14 +624,14 @@
         <set-parameter param-id="ia-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ia-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -645,7 +645,7 @@
         <set-parameter param-id="ia-04_odp.01">
             <constraint>
                 <description>
-                    <p>at a minimum, the ISSO (or similar role within the organization) </p>
+                    <p>at a minimum, the ISSO (or similar role within the organization)</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -660,14 +660,14 @@
         <set-parameter param-id="ir-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ir-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -737,7 +737,7 @@
         <set-parameter param-id="ma-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -751,14 +751,14 @@
         <set-parameter param-id="mp-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="mp-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -779,14 +779,14 @@
         <set-parameter param-id="pe-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="pe-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -828,7 +828,7 @@
         <set-parameter param-id="pe-3_prm_9">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -877,14 +877,14 @@
         <set-parameter param-id="pl-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="pl-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -926,14 +926,14 @@
         <set-parameter param-id="ps-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ps-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -969,7 +969,7 @@
         <set-parameter param-id="ps-05_odp.02">
             <constraint>
                 <description>
-                    <p>twenty-four (24) hours </p>
+                    <p>twenty-four (24) hours</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -1018,14 +1018,14 @@
         <set-parameter param-id="ra-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ra-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -1081,14 +1081,14 @@
         <set-parameter param-id="sa-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="sa-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -1123,14 +1123,14 @@
         <set-parameter param-id="sc-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="sc-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -1186,14 +1186,14 @@
         <set-parameter param-id="si-01_odp.05">
             <constraint>
                 <description>
-                    <p>at least every 3 years </p>
+                    <p>at least every 3 years</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="si-01_odp.07">
             <constraint>
                 <description>
-                    <p>at least annually </p>
+                    <p>at least annually</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -1330,7 +1330,7 @@
                     <title>AC-8 Additional FedRAMP Requirements and Guidance</title>
                     <part id="ac-8_fr_smt.1" name="item">
                         <prop name="label" value="Requirement:"/>
-                        <p>The service provider shall determine elements of the cloud environment that require the System Use Notification control. The elements of the cloud environment that require System Use Notification are approved and accepted by the JAB/AO. </p>
+                        <p>The service provider shall determine elements of the cloud environment that require the System Use Notification control. The elements of the cloud environment that require System Use Notification are approved and accepted by the JAB/AO.</p>
                     </part>
                     <part id="ac-8_fr_smt.2" name="item">
                         <prop name="label" value="Requirement:"/>
@@ -1948,9 +1948,9 @@
                         </ul>
                         <p> </p>
                         <p>The following applies only when choosing SC-8 (5) in lieu of SC-8 (1).</p>
-                        <p>FedRAMP-Defined Assignment / Selection Parameters </p>
+                        <p>FedRAMP-Defined Assignment / Selection Parameters</p>
                         <p>SC-8 (5)-1 [a hardened or alarmed carrier Protective Distribution System (PDS) when outside of Controlled Access Area (CAA)]</p>
-                        <p>SC-8 (5)-2 [prevent unauthorized disclosure of information AND detect changes to information] </p>
+                        <p>SC-8 (5)-2 [prevent unauthorized disclosure of information AND detect changes to information]</p>
                     </part>
                     <part id="sc-8_fr_gdn.2" name="guidance">
                         <prop name="label" value="Guidance:"/>
@@ -1966,7 +1966,7 @@
                         <p>https://www.dcsa.mil/Portals/91/documents/ctp/nao/CNSSI_7003_PDS_September_2015.pdf</p>
                         <p> </p>
                         <p>DHS Recommended Practice: Improving Industrial Control System Cybersecurity with Defense-in-Depth Strategies can be accessed here:</p>
-                        <p>https://us-cert.cisa.gov/sites/default/files/FactSheets/NCCIC%20ICS_FactSheet_Defense_in_Depth_Strategies_S508C.pdf </p>
+                        <p>https://us-cert.cisa.gov/sites/default/files/FactSheets/NCCIC%20ICS_FactSheet_Defense_in_Depth_Strategies_S508C.pdf</p>
                     </part>
                 </part>
             </add>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
@@ -2709,7 +2709,7 @@
 					<title>IA-5 Additional FedRAMP Requirements and Guidance</title>
 					<part id="ia-5_fr_smt.1" name="item">
 						<prop name="label" value="Requirement:"/>
-						<p>Authenticators must be compliant with NIST SP 800-63-3 Digital Identity Guidelines IAL, AAL, FAL level 3. Link https://pages.nist.gov/800-63-3</p>
+						<p>Authenticators must be compliant with NIST SP 800-63-3 Digital Identity Guidelines IAL, AAL, FAL level 2. Link https://pages.nist.gov/800-63-3</p>
 					</part>
 					<part id="ia-5_fr_gdn.1" name="guidance">
 						<prop name="label" value="Guidance:"/>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
@@ -2,9 +2,9 @@
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="71ba09a5-97a8-483f-92bd-3db6358f005d">
 	<metadata>
-		<title>FedRAMP Rev 5 Moderate Baseline</title>
-		<published>2023-06-15T00:00:00Z</published>
-		<last-modified>2023-06-15T00:00:00Z</last-modified>
+		<title>FedRAMP Rev 5 Moderate Baseline</title>		
+		<published>2023-08-31T00:00:00Z</published>
+		<last-modified>2023-08-31T00:00:00Z</last-modified>
 		<version>fedramp-2.0.0-oscal1.0.4</version>
 		<oscal-version>1.0.4</oscal-version>
 		<role id="prepared-by">
@@ -390,7 +390,7 @@
 		<set-parameter param-id="ac-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -432,7 +432,7 @@
 		<set-parameter param-id="ac-02.02_odp.01">
 			<constraint>
 				<description>
-					<p>Selection: disables </p>
+					<p>Selection: disables</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -548,7 +548,7 @@
 		<set-parameter param-id="at-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -604,7 +604,7 @@
 		<set-parameter param-id="au-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -698,7 +698,7 @@
 		<set-parameter param-id="ca-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -712,7 +712,7 @@
 		<set-parameter param-id="ca-02_odp.01">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -790,7 +790,7 @@
 		<set-parameter param-id="cm-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -889,7 +889,7 @@
 		<set-parameter param-id="cp-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1005,7 +1005,7 @@
 		<set-parameter param-id="ia-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1047,7 +1047,7 @@
 		<set-parameter param-id="ia-04_odp.01">
 			<constraint>
 				<description>
-					<p>at a minimum, the ISSO (or similar role within the organization) </p>
+					<p>at a minimum, the ISSO (or similar role within the organization)</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1076,7 +1076,7 @@
 		<set-parameter param-id="ir-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1161,7 +1161,7 @@
 		<set-parameter param-id="ma-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1203,7 +1203,7 @@
 		<set-parameter param-id="mp-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1252,7 +1252,7 @@
 		<set-parameter param-id="mp-05_odp.01">
 			<constraint>
 				<description>
-					<p>all media with sensitive information </p>
+					<p>all media with sensitive information</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1281,7 +1281,7 @@
 		<set-parameter param-id="pe-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1403,7 +1403,7 @@
 		<set-parameter param-id="pl-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1466,7 +1466,7 @@
 		<set-parameter param-id="ps-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1510,7 +1510,7 @@
 		<set-parameter param-id="ps-05_odp.02">
 			<constraint>
 				<description>
-					<p>twenty-four (24) hours </p>
+					<p>twenty-four (24) hours</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1580,7 +1580,7 @@
 		<set-parameter param-id="ra-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1658,7 +1658,7 @@
 		<set-parameter param-id="sa-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1672,7 +1672,7 @@
 		<set-parameter param-id="sa-04.02_odp.01">
 			<constraint>
 				<description>
-					<p>at a minimum to include security-relevant external system interfaces; high-level design; low-level design; source code or network and data flow diagram; </p>
+					<p>at a minimum to include security-relevant external system interfaces; high-level design; low-level design; source code or network and data flow diagram;</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1745,7 +1745,7 @@
 		<set-parameter param-id="sc-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1885,7 +1885,7 @@
 		<set-parameter param-id="si-01_odp.07">
 			<constraint>
 				<description>
-					<p>at least annually </p>
+					<p>at least annually</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1906,7 +1906,7 @@
 		<set-parameter param-id="si-02.02_odp.02">
 			<constraint>
 				<description>
-					<p>at least monthly </p>
+					<p>at least monthly</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -2183,7 +2183,7 @@
 					</part>
 					<part id="ac-8_fr_gdn.1" name="guidance">
 						<prop name="label" value="Guidance:"/>
-						<p>If performed as part of a Configuration Baseline check, then the % of items requiring setting that are checked and that pass (or fail) check can be provided. </p>
+						<p>If performed as part of a Configuration Baseline check, then the % of items requiring setting that are checked and that pass (or fail) check can be provided.</p>
 					</part>
 				</part>
 			</add>
@@ -2369,7 +2369,7 @@
 					<title>CM-2 Additional FedRAMP Requirements and Guidance</title>
 					<part id="ca-8.2_fr_gdn.1" name="guidance">
 						<prop name="label" value="Guidance:"/>
-						<p>See the FedRAMP Documents page&gt; Penetration Test Guidance </p>
+						<p>See the FedRAMP Documents page&gt; Penetration Test Guidance</p>
 						<p>https://www.FedRAMP.gov/documents/</p>
 					</part>
 				</part>
@@ -3097,9 +3097,9 @@
 						</ul>
 						<p> </p>
 						<p>The following applies only when choosing SC-8 (5) in lieu of SC-8 (1).</p>
-						<p>FedRAMP-Defined Assignment / Selection Parameters </p>
+						<p>FedRAMP-Defined Assignment / Selection Parameters</p>
 						<p>SC-8 (5)-1 [a hardened or alarmed carrier Protective Distribution System (PDS) when outside of Controlled Access Area (CAA)]</p>
-						<p>SC-8 (5)-2 [prevent unauthorized disclosure of information AND detect changes to information] </p>
+						<p>SC-8 (5)-2 [prevent unauthorized disclosure of information AND detect changes to information]</p>
 					</part>
 					<part id="sc-8_fr_gdn.2" name="guidance">
 						<prop name="label" value="Guidance:"/>
@@ -3115,7 +3115,7 @@
 						<p>https://www.dcsa.mil/Portals/91/documents/ctp/nao/CNSSI_7003_PDS_September_2015.pdf</p>
 						<p> </p>
 						<p>DHS Recommended Practice: Improving Industrial Control System Cybersecurity with Defense-in-Depth Strategies can be accessed here:</p>
-						<p>https://us-cert.cisa.gov/sites/default/files/FactSheets/NCCIC%20ICS_FactSheet_Defense_in_Depth_Strategies_S508C.pdf </p>
+						<p>https://us-cert.cisa.gov/sites/default/files/FactSheets/NCCIC%20ICS_FactSheet_Defense_in_Depth_Strategies_S508C.pdf</p>
 					</part>
 				</part>
 			</add>
@@ -3380,7 +3380,7 @@
 					<part id="si-8_fr_gdn.1" name="guidance">
 						<prop name="label" value="Guidance:"/>
 						<p>When CSO sends email on behalf of the government as part of the business offering, Control Description should include implementation of Domain-based Message Authentication, Reporting &amp; Conformance (DMARC) on the sending domain for outgoing messages as described in DHS Binding Operational Directive (BOD) 18-01.</p>
-						<p>https://cyber.dhs.gov/bod/18-01/ </p>
+						<p>https://cyber.dhs.gov/bod/18-01/</p>
 					</part>
 					<part id="si-8_fr_gdn.2" name="guidance">
 						<prop name="label" value="Guidance:"/>

--- a/src/content/rev5/templates/ssp/xml/FedRAMP-SSP-OSCAL-Template.xml
+++ b/src/content/rev5/templates/ssp/xml/FedRAMP-SSP-OSCAL-Template.xml
@@ -2,9 +2,9 @@
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
 <system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="9809eddf-2cd5-468f-97c5-9769905d0629">
    <metadata>
-      <title>FedRAMP System Security Plan (SSP)</title>
-      <published>2023-07-06T00:00:00Z</published>
-      <last-modified>2023-07-06T00:00:00Z</last-modified>
+      <title>FedRAMP System Security Plan (SSP)</title>		
+      <published>2023-08-31T00:00:00Z</published>
+      <last-modified>2023-08-31T00:00:00Z</last-modified>
       <version>fedramp2.0.0-oscal1.0.4</version>
       <oscal-version>1.0.4</oscal-version>
       <revisions>
@@ -1367,10 +1367,10 @@
                <set-parameter param-id="ac-1_prm_1">
                   <value>organization-defined personnel or roles</value>
                </set-parameter>
-               <set-parameter param-id="ac-1_prm_2">
+               <set-parameter param-id="ac-01_odp.05">
                   <value>at least every 3 years</value>
                </set-parameter>
-               <set-parameter param-id="ac-1_prm_3">
+               <set-parameter param-id="ac-01_odp.07">
                   <value>at least annually</value>
                </set-parameter>
             </by-component>


### PR DESCRIPTION
This PR will fix the following:

- Removes trailing spaces at end of parameters
- Fixes IA-5 Moderate profile FedRAMP requirement to "NIST SP 800-63-3 Digital Identity Guidelines IAL, AAL, FAL level 2"
- Fixes CA-5 Low profile FedRAMP guidance part id
- Fix referenced parameter IDs for AC-1 in FedRAMP OSCAL SSP Template