### PR TITLE
Update baseline catalog revision to the previous 1.2.0 oscal content release

### DIFF
--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="9af0a7d3-252c-4f18-9baf-4f10e82bfac8">
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="b648bee9-ec13-42db-af9d-1d6745f92fab">
 	<metadata>
 		<title>FedRAMP Rev 5 High Baseline</title>
 		<published>2023-08-31T00:00:00Z</published>
-		<last-modified>2023-08-31T00:00:00Z</last-modified>
-		<version>fedramp-2.0.0-oscal1.0.4</version>
-		<oscal-version>1.0.4</oscal-version>
+		<last-modified>2023-12-18T16:22:48Z</last-modified>
+		<version>5.1.1+fedramp-20231218-0</version>
+		<oscal-version>1.1.1</oscal-version>
 		<role id="prepared-by">
 			<title>Document creator</title>
 		</role>
@@ -3804,8 +3804,8 @@
 		</resource>
 		<resource uuid="051a77c1-b61d-4995-8275-dacfe688d510">
 			<title>NIST Special Publication (SP) 800-53</title>
-			<prop name="version" value="Revision 5"/>
-			<rlink media-type="application/xml" href="https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
+			<prop name="version" value="5.1.1"/>
+			<rlink media-type="application/xml" href="https://github.com/usnistgov/oscal-content/blob/v1.2.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
 		</resource>
 	</back-matter>
 </profile>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="2b515da9-8a5e-4b7c-9cce-6451e70ca75d">
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="f8522b6b-1c71-4471-8be5-e3303319dc88">
     <metadata>
         <title>FedRAMP Rev 5 Tailored Low Impact Software as a Service (LI-SaaS) Baseline</title>
         <published>2023-08-31T00:00:00Z</published>
-        <last-modified>2023-08-31T00:00:00Z</last-modified>
-        <version>fedramp-2.0.0-oscal1.0.4</version>
-        <oscal-version>1.0.4</oscal-version>
+        <last-modified>2023-12-18T16:22:48Z</last-modified>
+        <version>5.1.1+fedramp-20231218-0</version>
+        <oscal-version>1.1.1</oscal-version>
         <role id="prepared-by">
             <title>Document creator</title>
         </role>
@@ -2951,8 +2951,8 @@
         </resource>
         <resource uuid="051a77c1-b61d-4995-8275-dacfe688d510">
             <title>NIST Special Publication (SP) 800-53</title>
-            <prop name="version" value="Revision 5"/>
-            <rlink media-type="application/oscal.catalog+xml" href="https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
+            <prop name="version" value="5.1.1"/>
+            <rlink media-type="application/oscal+xml" href="https://github.com/usnistgov/oscal-content/blob/v1.2.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
         </resource>
     </back-matter>
 </profile>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="71ba09a5-97a8-483f-92bd-3db6358f005d">
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="f9621961-f261-4e34-9ffd-ac5d169a019e">
     <metadata>
         <title>FedRAMP Rev 5 Low Baseline</title>
         <published>2023-08-31T00:00:00Z</published>
-        <last-modified>2023-08-31T00:00:00Z</last-modified>
-        <version>fedramp-2.0.0-oscal1.0.4</version>
-        <oscal-version>1.0.4</oscal-version>
+        <last-modified>2023-12-18T16:22:48Z</last-modified>
+        <version>5.1.1+fedramp-20231218-0</version>
+        <oscal-version>1.1.1</oscal-version>
         <role id="prepared-by">
             <title>Document creator</title>
         </role>
@@ -2251,8 +2251,8 @@
         </resource>
         <resource uuid="051a77c1-b61d-4995-8275-dacfe688d510">
             <title>NIST Special Publication (SP) 800-53</title>
-            <prop name="version" value="Revision 5"/>
-            <rlink media-type="application/oscal.catalog+xml" href="https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
+            <prop name="version" value="5.1.1"/>
+            <rlink media-type="application/oscal+xml" href="https://github.com/usnistgov/oscal-content/blob/v1.2.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
         </resource>
     </back-matter>
 </profile>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="71ba09a5-97a8-483f-92bd-3db6358f005d">
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="10215c56-5207-48f0-9f91-08994e7dc5d1">
 	<metadata>
 		<title>FedRAMP Rev 5 Moderate Baseline</title>
 		<published>2023-08-31T00:00:00Z</published>
-		<last-modified>2023-08-31T00:00:00Z</last-modified>
-		<version>fedramp-2.0.0-oscal1.0.4</version>
-		<oscal-version>1.0.4</oscal-version>
+		<last-modified>2023-12-18T16:22:48Z</last-modified>
+		<version>5.1.1+fedramp-20231218-0</version>
+		<oscal-version>1.1.1</oscal-version>
 		<role id="prepared-by">
 			<title>Document creator</title>
 		</role>
@@ -3480,8 +3480,8 @@
 		</resource>
 		<resource uuid="051a77c1-b61d-4995-8275-dacfe688d510">
 			<title>NIST Special Publication (SP) 800-53</title>
-			<prop name="version" value="Revision 5"/>
-			<rlink media-type="application/xml" href="https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
+			<prop name="version" value="5.1.1"/>
+			<rlink media-type="application/xml" href="https://github.com/usnistgov/oscal-content/blob/v1.2.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
 		</resource>
 	</back-matter>
 </profile>


### PR DESCRIPTION
# Committer Notes

The PR updates the FedRAMP baselines to point to the prior [OSCAL v1.2.0](https://github.com/usnistgov/oscal-content/releases/tag/v1.2.0) content release. This revision still has the expected label properties. These will be used in the interim to avoid breakage, while PR #540 is reviewed by the FedRAMP stakeholder community.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
