### PR TITLE
Fix typo in CA-8(2) FR additional guidance

### DIFF
--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
@@ -4647,7 +4647,7 @@
 		<alter control-id="ca-8.2">
 			<add position="ending" by-id="ca-8.2_smt">
 				<part id="ca-8.2_fr" name="item">
-					<title>CM-2 Additional FedRAMP Requirements and Guidance</title>
+					<title>CA-8(2) Additional FedRAMP Requirements and Guidance</title>
 					<part id="ca-8.2_fr_gdn.1" name="guidance">
 						<prop name="label" value="Guidance:"/>
 						<p>See the FedRAMP Documents page&gt; Penetration Test Guidance</p>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
@@ -4067,7 +4067,7 @@
 		<alter control-id="ca-8.2">
 			<add position="ending" by-id="ca-8.2_smt">
 				<part id="ca-8.2_fr" name="item">
-					<title>CM-2 Additional FedRAMP Requirements and Guidance</title>
+					<title>CA-8(2) Additional FedRAMP Requirements and Guidance</title>
 					<part id="ca-8.2_fr_gdn.1" name="guidance">
 						<prop name="label" value="Guidance:"/>
 						<p>See the FedRAMP Documents page&gt; Penetration Test Guidance</p>


### PR DESCRIPTION
# Committer Notes

This PR resolves issue #551 correcting a typo in the "Additional FedRAMP Requirements and Guidance" part of the control.  


### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
