### PR TITLE
Containerized user guides

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version : '3'
+services:
+  hugo:
+      image: klakegg/hugo:0.107.0-ext-alpine
+      command: server -s /fedramp-automation/docs --enableGitInfo=false --minify
+      volumes:
+        - ".:/fedramp-automation"
+      ports:
+        - "1313:1313"

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ The website is built using the [Hugo](https://gohugo.io/) static site generator 
 
 If using Docker:
 
-- [Docker 20.10+](https://docs.docker.com/install/)
+- [Docker 23.0+](https://docs.docker.com/get-docker/)
 
 If not using Docker:
 
@@ -70,17 +70,14 @@ Whenever you make any changes to the content with the Hugo server running, you'l
 
 ## Developing with Docker
 
-Coming soon:  The site will be available as a Docker container.  
-
-<!--
 The website can also be developed and built using the included Docker resources.
 
-Assuming you've [installed Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/) for your system, you can build and serve the site using Docker Compose as follows:
+Assuming you've [installed Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) for your system, you can build and serve the site using Docker Compose as follows:
 
 ```
 docker-compose build
 docker-compose up
 ```
 
-Once the site is running, it can be accessed at http://localhost:1313/fedramp-automation. 
--->
+Once the site is running, it can be accessed at [http://localhost:1313/](http://localhost:1313/). 
+

--- a/docs/content/guides/general/2-working-with-oscal-files.md
+++ b/docs/content/guides/general/2-working-with-oscal-files.md
@@ -14,10 +14,10 @@ OSCAL-based FedRAMP files.
 Unlike the traditional MS Word-based SSP, SAP, and SAR, the OSCAL-based
 versions of these files are designed to make information available
 through linkages, rather than duplicating information. In OSCAL, these
-linkages are established through ```import``` commands.
+linkages are established through `import` commands.
 
 ![OSCAL File Imports](/img/content-figure-1.png)
-***Each OSCAL file imports information from the one before it.***
+*Each OSCAL file imports information from the one before it.*
 
 \
 For example, the assessment objectives and actions that appear in a
@@ -26,7 +26,7 @@ simply referenced by the SAP and SAR. Only deviations from the TCW are
 captured in the SAP or SAR.
 
 ![Baseline and SSP Info](/img/content-figure-2.png)
-***Baseline and SSP Information is referenced instead of duplicated.***
+*Baseline and SSP Information is referenced instead of duplicated.*
 
 \
 For this reason, an OSCAL-based SAP points to the OSCAL-based SSP of the
@@ -64,8 +64,7 @@ functionality later for the separate profile and catalog handling later
 in their product roadmap.
 
 ![Resolved Profile Catalog](/img/content-figure-3.png)
-***The Resolved Profile Catalog for each FedRAMP Baseline reduce tool
-processing.***
+*The Resolved Profile Catalog for each FedRAMP Baseline reduce tool processing.*
 
 \
 For more information about resolved profile catalogs, see *Appendix C,
@@ -74,24 +73,24 @@ Profile Resolution*.
 ## 2.2. Hierarchy and Sequence
 
 For both XML and JSON, the hierarchy of syntax is important and must be
-followed. For example, the metadata assembly must be at the top level of
+followed. For example, the `metadata` assembly must be at the top level of
 the OSCAL file, just below its root. If it appears within any other
 assembly, it is invalid.
 
 The same field name is interpreted differently in different assemblies.
-For example, the title field under metadata is the document title, while
-the title field under role gives a human-friendly name to that role.
+For example, the `title` field under metadata is the document title, while
+the `title` field under role gives a human-friendly name to that role.
 
 For XML, the sequence of fields and assemblies (elements) is also
 important. JSON typically does not require a specific sequence fields
 and assemblies (objects). Where sequence is important, OSCAL uses array
 objects in JSON.
 
-For example, within the metadata assembly, XML must find title,
-published, last-modified, version, and oscal-version in exactly that
-order. The published field is optional and may be omitted, but if
+For example, within the `metadata` assembly, XML must find `title`,
+`published`, `last-modified`, `version`, and `oscal-version` in exactly that
+order. The `published` field is optional and may be omitted, but if
 present, it must be in that position relative to the other fields. When
-using JSON, these fields are allowed in any order within the metadata
+using JSON, these fields are allowed in any order within the `metadata`
 assembly.
 
 Tools must ensure this sequence is maintained when creating or modifying
@@ -116,36 +115,36 @@ Always use the hierarchy found here:
 
 Most assemblies in OSCAL follow a general pattern as follows:
 
--   title (field): Typically only one title is allowed. Sometimes it is
+-   `title` (field): Typically only one `title` is allowed. Sometimes it is
     optional. This is a *markup-line* datatype.
 
--   description (field): Typically only one description field is
+-   `description` (field): Typically only one `description` field is
     allowed. Sometimes it is optional. This is a *markup-multiline*
     datatype.
 
--   prop (fields): There may be many prop fields. The name flag
-    identifies the specific annotation. The value flag is a string
-    datatype and holds the intended value. The prop field includes an
-    optional uuid flag to give a globally unique identifier, an optional
-    ns field to allow for namespacing the prop and indicate it is
-    optional information that is not of core OSCAL syntax and a class
-    flag to sub-class one or more instances of the prop into specific
+-   `prop` (fields): There may be many `prop` fields. The `name` flag
+    identifies the specific annotation. The `value` flag is a string
+    datatype and holds the intended value. The `prop` field includes an
+    optional `uuid` flag to give a globally unique identifier, an optional
+    `ns` field to allow for namespacing the `prop` and indicate it is
+    optional information that is not of core OSCAL syntax and a `class`
+    flag to sub-class one or more instances of the `prop` into specific
     sub-groups.
 
--   link (fields): There may be many link fields. The href flag allows a
+-   `link` (fields): There may be many `link` fields. The `href` flag allows a
     uniform resource identifier (URI) or URI fragment to a related item.
-    Often, href fields point to a resource in back matter using its UUID
+    Often, `href` fields point to a `resource` in back matter using its UUID
     value in the form of href="#[uuid-value]".
 
 -   ***assembly-specific fields***
 
--   remarks (field): Typically only one remarks field is allowed. It is
+-   `remarks` (field): Typically only one `remarks` field is allowed. It is
     always optional. This is a *markup-multiline* datatype.
 
 While this is not universal in OSCAL, when any of these fields are
 present, they follow this pattern.
 
-The prop field is present to allow OSCAL extensions within each
+The `prop` field is present to allow OSCAL extensions within each
 assembly. See *Section 3, FedRAMP Extensions and Accepted Values* for
 more information on FedRAMP's use of OSCAL extensions.
 
@@ -159,8 +158,8 @@ valid.
 | :-- | :-- |
 |**Well-Formed**|The XML or JSON file follows the rules defined for that format. <br /> Any tool that processes the format will recognize it as "well-formed," which means the tool can proceed with processing the XML or JSON. <br /> XML: [https://www.w3.org/TR/REC-xml/](https://www.w3.org/TR/REC-xml/) <br /> JSON: [https://json.org/](https://json.org/)|
 |**OSCAL Syntax**|The XML or JSON file only uses names and values defined by NIST for OSCAL.  NIST publishes schema validation tools to verify syntax compliance based on the following standards: <br /> XML Syntax Validation: [XML Schema Definition Language (XSD) 1.1](https://www.w3.org/TR/xmlschema11-1/) <br /> JSON Syntax Validation: [JSON Schema, draft 07](https://json-schema.org/)|
-|**OSCAL Content**| For certain OSCAL fields, the NIST syntax validation tools also enforce content - allowing only a pre-defined set of values to be used in certain fields. <br /><br /> For example, Within the SSP model, impact levels within the information type assemblies only allow the following values: fips-199-low, fips-199-moderate, and fips-199-high. Any other value will cause an error when validating the file. <br /><br /> In the future, NIST intends to publish more robust content enforcement mechanisms, such as [Schematron](http://schematron.com/). This enables more complex rules such as, "If field A is marked 'true', field B must have a value." FedRAMP is also exploring the use of Schematron for enhanced validation and may publish these in the future.|
-|**FedRAMP Syntax Extensions**    | NIST designed OSCAL to represents the commonality of most cybersecurity frameworks and provided the ability to extend the language for framework-specific needs. FedRAMP makes use of these extensions. <br /><br />NIST provides prop fields throughout most of its assemblies, always with a name, class, and ns (namespace) flag: <br /> <pr\op name="" class="" ns="">Data</prop> <br /><br /> In the core OSCAL syntax, the ns flag is never used. Where FedRAMP extends OSCAL, the value for ns is always: <br /><br />https://fedramp.gov/ns/oscal (case sensitive). <br /><br /> When ns='https://fedramp.gov/ns/oscal' the name flag is as defined by FedRAMP. If the class flag is present, that is also defined by FedRAMP.|
+|**OSCAL Content**| For certain OSCAL fields, the NIST syntax validation tools also enforce content - allowing only a pre-defined set of values to be used in certain fields. <br /><br /> For example, Within the SSP model, impact levels within the information type assemblies only allow the following values: `fips-199-low`, `fips-199-moderate`, and `fips-199-high`. Any other value will cause an error when validating the file. <br /><br /> In the future, NIST intends to publish more robust content enforcement mechanisms, such as [Schematron](http://schematron.com/). This enables more complex rules such as, "If field A is marked 'true', field B must have a value." FedRAMP is also exploring the use of Schematron for enhanced validation and may publish these in the future.|
+|**FedRAMP Syntax Extensions**    | NIST designed OSCAL to represents the commonality of most cybersecurity frameworks and provided the ability to extend the language for framework-specific needs. FedRAMP makes use of these extensions. <br /><br />NIST provides `prop` fields throughout most of its assemblies, always with a `name`, `class`, and `ns` (namespace) flag: <br /> `<prop name="" class="" ns="">Data</prop>` <br /><br /> In the core OSCAL syntax, the `ns` flag is never used. Where FedRAMP extends OSCAL, the value for `ns` is always: <br /><br />`https://fedramp.gov/ns/oscal` (case sensitive). <br /><br /> When `ns='https://fedramp.gov/ns/oscal'` the `name` flag is as defined by FedRAMP. If the `class` flag is present, that is also defined by FedRAMP.|
 |**FedRAMP Content**| Today, FedRAMP content is enforced programmatically. FedRAMP intends to publish automated validation rules, which may be adopted by tool developers to verify OSCAL-based FedRAMP content is acceptable before submission. <br /><br />Initial validation rules ensure a package has all required elements and will evolve to perform more detailed validation. Separate details will be published about this in the near future.|
 
 ##  2.4. OSCAL's Minimum File Requirements
@@ -168,6 +167,7 @@ valid.
 Every OSCAL-based FedRAMP file must have a minimum set of required
 fields/assemblies, and must follow the core OSCAL syntax found here:
 ![Anatomy of an OSCAL File](/img/content-figure-4.png)
+*Anatomy of an OSCAL file*
 
 In addition to the core OSCAL syntax, the following FedRAMP-specific
 implementation applies:
@@ -248,11 +248,11 @@ used. Other encoding options will create unpredictable results.
 
 ### 2.4.2. OSCAL Syntax Version
 
-Tools designed to read an OSCAL file must verify the ```oscal-version``` field
+Tools designed to read an OSCAL file must verify the `oscal-version` field
 to determine which published syntax is used.
 
 Tools designed to create or manipulate an OSCAL file must specify the
-syntax version of OSCAL used in the file in the ```oscal-version``` field.
+syntax version of OSCAL used in the file in the `oscal-version` field.
 
 NIST ensures backward compatibility of syntax where practical; however,
 this is not always possible. Some syntax changes between milestone
@@ -268,12 +268,12 @@ utilities. See [the OSCAL Support and Deprecation Policy in the FedRAMP Automati
 
 Any time a tool changes the contents of an OSCAL file, it must also:
 
--   update the file's ```uuid flag``` (```/*/@uuid```) with a new UUID; and
+-   update the file's `uuid flag` (`/*/@uuid`) with a new UUID; and
 
--   update the ```last-modified``` field (```/*/metadata/last-modified```) with the current date and time. (Using the OSCAL date/time format, as described in *Section 2.6.1 [Date and Time in OSCAL Files](#date-and-time-in-oscal-files)*)
+-   update the `last-modified` field (`/*/metadata/last-modified`) with the current date and time. (Using the OSCAL date/time format, as described in *Section 2.6.1 [Date and Time in OSCAL Files](#date-and-time-in-oscal-files)*)
 
 Tools that open or import OSCAL files should rely on the UUID value
-provided by the ```uuid``` flag, and ```last-modified``` field as easy methods of
+provided by the `uuid` flag, and `last-modified` field as easy methods of
 knowing the file has changed.
 
 See the following for more information:
@@ -349,9 +349,9 @@ There are four ways identifiers are typically used in OSCAL:
 **Identifiers** appear as an "**id**" or "**uuid**" flag to a data
 field or assembly. Examples include:
 
--   ```<control id="ac-1">```: Uniquely identifies the control.
+-   `<control id="ac-1">`: Uniquely identifies the control.
 
--   ```<party uuid="8e83458e-dde5-4ee2-88bc-152f8da3fc31">```:
+-   `<party uuid="8e83458e-dde5-4ee2-88bc-152f8da3fc31">`:
     Uniquely identifies the party.
 
 **An ID reference** typically appears with a name and hyphen in front of
@@ -366,10 +366,10 @@ _IDs and UUIDs are intended to be managed by tools "behind the scenes," and shou
 
 Examples include:
 
--   ```<responsible-party role-id="prepared-by">```: points to a role
+-   `<responsible-party role-id="prepared-by">`: points to a role
     identified by "prepared-by".
 
--   ```<implemented-requirement id="imp-req-01" control-id="ac-2">```: points to the control identified by
+-   `<implemented-requirement id="imp-req-01" control-id="ac-2">`: points to the control identified by
     "ac-2".
 
 NIST provides some standard identifiers. Where appropriate, FedRAMP has
@@ -380,7 +380,7 @@ Deviation is likely to result in processing errors.
 
 ### 2.5.1. Uniqueness of Identifiers
 
-Within FedRAMP deliverables, only ```roles``` in the ```metadata``` assembly have ID
+Within FedRAMP deliverables, only `roles` in the `metadata` assembly have ID
 flags. All other OSCAL identifiers are UUID.
 
 Some role ID values are prescribed by NIST, and others by FedRAMP. These
@@ -478,14 +478,14 @@ types that directly impact FedRAMP content in OSCAL.
 
 Except where noted, all dates and times in the OSCAL-based content must
 be in an OSCAL
-```dateTime-with-timezone``` format as documented here:
+`dateTime-with-timezone` format as documented here:
 
 [[https://pages.nist.gov/OSCAL/reference/datatypes/#datetime-with-timezone]](https://pages.nist.gov/OSCAL/reference/datatypes/#datetime-with-timezone)
 
 This means all dates and times must be represented in the OSCAL file
 using following format, unless otherwise noted:
 
-```"Y-m-dTH:i:s.uP"``` (See
+`"Y-m-dTH:i:s.uP"` (See
 [HERE](https://www.php.net/manual/en/class.datetime.php) for formatting
 codes.)
 
@@ -541,7 +541,7 @@ verification tools will generate an error if this format is not found.
 
 Tool developers are encouraged to *present* dates as they have
 historically appeared in FedRAMP documents. In other words, tools should
-convert ```"2020-03-04T00:00:00.00-05:00"``` to ```"March 4, 2020"``` when
+convert `"2020-03-04T00:00:00.00-05:00"` to `"March 4, 2020"` when
 presenting the publication date to the user.
 
 Please use the appropriate UTC offset in your region. If you are storing
@@ -558,7 +558,7 @@ information: <https://pages.nist.gov/OSCAL/reference/datatypes/#uuid>
 Version 4 UUIDs are 128-bit numbers, represented as 32 hexadecimal
 (base-16) digits in the pattern:
 
-```xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx```
+`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 
 All alphabetic characters (a-f) representing hexadecimal values must be
 lower case.
@@ -581,7 +581,7 @@ non-compliant or erroneous algorithms.
 ### 2.6.3. ID Datatypes
 
 NIST typically uses ID flags in OSCAL where the identifier is intended
-to be canonical, such as the identifiers for ```role``` IDs or NIST SP 800-53
+to be canonical, such as the identifiers for `role` IDs or NIST SP 800-53
 controls.
 
 Any place an ID flag or ID reference exits, the datatype is
@@ -598,7 +598,7 @@ spaces. The allowable values of an NCName are limited as follows:
 
 -   Spaces are not allowed.
 
-```Token``` values are case sensitive. ```"This"``` does not match ```"this"``` in searches.
+`Token` values are case sensitive. `"This"` does not match `"this"` in searches.
 
 A tool developer may wish to assign UUID values to ID flags. UUIDs may
 start with a numeric character, which is invalid for NCName. To ensure a
@@ -610,7 +610,7 @@ prepending "uuid-" to the UUID value.
 
 ### 2.6.4. Working With href Flags
 
-All OSCAL-based ```href``` flags are URIs formatted according to [section 4.1
+All OSCAL-based `href` flags are URIs formatted according to [section 4.1
 of RFC3986](https://tools.ietf.org/html/rfc3986#section-4.1). When
 assembling or processing an OSCAL-based FedRAMP file, please consider
 the following:
@@ -630,9 +630,9 @@ handling. Sensitive external documents should travel with the OSCAL file
 and be linked using a relative path.
 
 **Internal Locations**: These URI fragments appear as just a hashtag (#)
-followed by a name, such as #a3e9f988-2db7-4a14-9859-0a0f5b0eebee. This
+followed by a name, such as `#a3e9f988-2db7-4a14-9859-0a0f5b0eebee`. This
 notation points to a location internal to the OSCAL content. Typically,
-this references to a resource assembly, but may reference to any field
+this references to a `resource` assembly, but may reference to any field
 or assembly with a unique ID or UUID.
 
 If only a URI fragment (internal location) is present, the OSCAL tool
@@ -641,7 +641,7 @@ reference to a resource. The resource may exist in the current OSCAL
 file, or one of the imported OSCAL files in the stack as described in
 *Section 2.1, File Content Concepts*.
 
-For example, the following OSCAL content contains a href flag with a URI
+For example, the following OSCAL content contains a `href` flag with a URI
 fragment:
 
 #### URI Fragment Example
@@ -658,7 +658,7 @@ fragment:
 
 When a tool processes the above example, it should look inside the
 document for a field or assembly with a UUID of
-"a3e9f988-2db7-4a14-9859-0a0f5b0eebee". This can be accomplished with
+`"a3e9f988-2db7-4a14-9859-0a0f5b0eebee"`. This can be accomplished with
 the following XPath query:
 {{< highlight xml "linenos=table" >}}
 //*[@uuid="a3e9f988-2db7-4a14-9859-0a0f5b0eebee"]
@@ -676,7 +676,7 @@ To express this in XPath 1.0, you must use the following:
 name(//*[@uuid="uri-fragment" | @id="uri-fragment"])
 {{< /highlight >}}
 The above query will return "resource", if the URI Fragment references
-the UUID of a resource assembly.
+the UUID of a `resource` assembly.
 
 ### 2.6.5. Markup-line and Markup-multiline Fields in OSCAL
 
@@ -736,8 +736,8 @@ visit:
 
 In JSON, markup-multiline is based on Markdown syntax and requires no
 special handling. XML-based markup-multiline fields require all content
-to be enclosed in one of the following tags: \<p>, \<h1> - \<h6>,
-\<ol>, \<ul>, \<pre>, or \<table>. At least one of these tags must
+to be enclosed in one of the following tags: `<p>`, `<h1>` - `<h6>`,
+`<ol>`, `<ul>`, `<pre>`, or `<table>`. At least one of these tags must
 be present. More than one may be present. All text must be enclosed
 within one of these tags.
 
@@ -757,7 +757,7 @@ schema.
   
 
 The simplest way to correct the error is to enclose the text in
-\<p>\</p> tags, within the ```description``` field.
+`<p></p>` tags, within the `description` field.
 
 #### Correct Markup-multiline Representation
 {{< highlight xml "linenos=table" >}}
@@ -771,9 +771,9 @@ The simplest way to correct the error is to enclose the text in
   
 
 The example below demonstrates a correct use of markup-multiline in XML.
-Please note, the inclusion of a \<p /> tag on a line by itself inserts
+Please note, the inclusion of a `<p />` tag on a line by itself inserts
 an empty paragraph. Within XML and HTML, this is treated as a shortcut,
-and is interpreted as "\<p>\</p>"
+and is interpreted as `"<p></p>"`.
 
 #### Correct Markup-multiline Representation
 {{< highlight xml "linenos=table" >}}
@@ -816,12 +816,12 @@ please visit:
 ## 2.7. Citations and Attachments in OSCAL Files
 
 OSCAL is designed so that all citations and attachments are defined once
-at the end of the file as a resource, and then referenced as needed
+at the end of the file as a `resource`, and then referenced as needed
 throughout the file. This includes logos, diagrams, policies,
 procedures, plans, evidence, and interconnection security agreements
 (ICAs).
 
-Each resource may be referenced from anywhere in the OSCAL file, using
+Each `resource` may be referenced from anywhere in the OSCAL file, using
 its resource UUID.
 {{< highlight xml "linenos=table" >}}
   <back-matter>
@@ -839,7 +839,7 @@ its resource UUID.
   </back-matter>
 {{< /highlight >}}
 
-The ```media-type``` flag should be present and must be set to an [Internet
+The `media-type` flag should be present and must be set to an [Internet
 Assigned Numbers Authority (IANA) Media
 Type](http://www.iana.org/assignments/media-types/media-types.xhtml).
 
@@ -848,7 +848,7 @@ Type](http://www.iana.org/assignments/media-types/media-types.xhtml).
 Citations are for reference. The content is not included with the
 authorization package.
 
-Citations use an ```rlink``` field with an *absolute path* to content that is
+Citations use an `rlink` field with an *absolute path* to content that is
 accessible by FedRAMP and Agency reviewers from government systems.
 
 Examples include links to publicly available laws such as FISMA, and
@@ -859,8 +859,8 @@ applicable standards, such NIST SP 800 series documents.
 Unlike citations, attachments are included with the authorization
 package when submitted.
 
-Tools may either embed an attachment using the ```base64``` field, or point to an attachment using an ```rlink``` field. If no base64 embedded content is
-present, at least one rlink field must exist with either an *absolute
+Tools may either embed an attachment using the `base64` field, or point to an attachment using an `rlink` field. If no base64 embedded content is
+present, at least one `rlink` field must exist with either an *absolute
 path* to content that is accessible by FedRAMP and Agency reviewers from
 government systems, or a relative path.
 
@@ -873,34 +873,34 @@ diagrams, policies, process, plans, raw scanner output, assessment
 evidence, and POA&M deviation request evidence.
 
 Tools should embed (base64) or link to (rlink) an attachment once as a
-```resource``` in ```back-matter```, then use URI fragments to reference the
+`resource` in `back-matter`, then use URI fragments to reference the
 attachment anyplace it is needed within the body of the OSCAL file, as
 described in *Section 2.5, Assigning Identifiers* or *Section 2.6.2,
 Working With href Flags*.
 
 For example, a policy document that satisfies several control families
-is attached as a ```resource``` in the ```back-matter```, with a UUID of
-```"3df7eeea-421b-459d-98cf-3d972bec610a"```. Each control satisfied by that
+is attached as a `resource` in the `back-matter`, with a UUID of
+`"3df7eeea-421b-459d-98cf-3d972bec610a"`. Each control satisfied by that
 policy, links to the policy using a URI fragment as follows:
 {{< highlight xml "linenos=table" >}}
 <link href="#3df7eeea-421b-459d-98cf-3d972bec610a" rel="policy" />
 {{< /highlight >}}
 
 As described in *Section 2.6.2, Working With href Flags*, when a tool
-identifies a URI fragment in an href value, the leading hashtag (#) must
+identifies a URI fragment in an `href` value, the leading hashtag (#) must
 be dropped and the remaining value is expected to reference an OSCAL
 addressable ID or UUID. This ID/UUID may be either within the OSCAL file
-itself, or within other OSCAL documents linked via the ```import``` field.
+itself, or within other OSCAL documents linked via the `import` field.
 
 The policy's title, version, publication date and other details are
 defined once in the resource and are displayed anyplace the policy is
 referenced. If a newer policy is published, only the one resource in
 needs to be updated.
 
-If the policy's location is identified as ```="./policies/doc.pdf"```, the
+If the policy's location is identified as `="./policies/doc.pdf"`, the
 OSCAL file and the doc.pdf file should be delivered together and
 packaged such that the folder containing the OSCAL file includes a
-sub-folder named ```"policies"```, which contains the ```"doc.pdf"``` file.
+sub-folder named `"policies"`, which contains the `"doc.pdf"` file.
 
 When using attachments with relative paths, consider using a technology
 such as a ZIP archive to package and deliver attachments while
@@ -908,34 +908,34 @@ maintaining their relative position to the OSCAL file.
 
 ### 2.7.3. Including Multiple rlink and base64 Fields
 
-Within a ```resource```, there may be:
+Within a `resource`, there may be:
 
--   no ```rlink``` nor ```base64``` fields;
+-   no `rlink` nor `base64` fields;
 
--   one or more ```rlink``` fields;
+-   one or more `rlink` fields;
 
 -   one or more base64-encoded data fields within the OSCAL file; or
 
--   any combination of ```rlink``` and ```base64``` fields.
+-   any combination of `rlink` and `base64` fields.
 
-OSCAL allows multiple ```rlink``` and ```base64``` fields to exist within the same ```resource```. This provides the flexibility to identify multiple locations or multiple formats of the same resource. Some examples of using
-multiple rlink and/or base64 fields within the same resource include:
+OSCAL allows multiple `rlink` and `base64` fields to exist within the same `resource`. This provides the flexibility to identify multiple locations or multiple formats of the same resource. Some examples of using
+multiple `rlink` and/or `base64` fields within the same resource include:
 
--   **Multiple Locations**: Multiple ```rlink``` fields allow an OSCAL tool to
-    include one ```rlink``` field with an *absolute* path to the authoritative
+-   **Multiple Locations**: Multiple `rlink` fields allow an OSCAL tool to
+    include one `rlink` field with an *absolute* path to the authoritative
     location of a policy document within the CSP's intranet. The same
-    ```resource``` could have a second ```rlink``` field with a *relative* path to
+    `resource` could have a second `rlink` field with a *relative* path to
     the same policy document. Having both allows the CSP to maintain the
     link to authoritative location of the policy when working with the
     OSCAL file internally, while allowing a cached, local copy to travel
     with the OSCAL file when delivered to FedRAMP for review.
 
--   **Multiple Quality Levels**: Multiple ```rlink``` or ```base64``` fields allow
+-   **Multiple Quality Levels**: Multiple `rlink` or `base64` fields allow
     both low-resolution and high-resolution versions of the same image,
     which is sometimes used to boost the performance of web-based
     applications.
 
--   **Multiple Formats**: Multiple ```rlink``` or ```base64``` fields allow a
+-   **Multiple Formats**: Multiple `rlink` or `base64` fields allow a
     portable network graphic (PNG) version of an image may be provided
     for presentation by a web application, and a more detailed portable
     document format (PDF) version of the same image for download by
@@ -943,17 +943,17 @@ multiple rlink and/or base64 fields within the same resource include:
 
 ### 2.7.4. Handling Multiple rlink and base64 Fields
 
-NIST designed ```resource``` assemblies to be flexible and wanted to offer
-developers the flexibility to implement handling of multiple ```rlink``` and
-```base64``` fields on a case-by-case basis.
+NIST designed `resource` assemblies to be flexible and wanted to offer
+developers the flexibility to implement handling of multiple `rlink` and
+`base64` fields on a case-by-case basis.
 
-This section describes FedRAMP's processing of multiple ```rlink``` and
-```base64``` fields, which will be used by default unless a compelling
+This section describes FedRAMP's processing of multiple `rlink` and
+`base64` fields, which will be used by default unless a compelling
 circumstance requires otherwise.
 
-FedRAMP accepts both ```base64``` and ```rlink``` option content for diagrams and
+FedRAMP accepts both `base64` and `rlink` option content for diagrams and
 graphics. FedRAMP prefers documents, such as policies and plans, are
-attached using rlink fields and relative paths.
+attached using `rlink` fields and relative paths.
 
 If the tool is designed to work interactively with a user, the tool
 developer should consider designing the tool to make intelligent choices
@@ -961,38 +961,38 @@ based on context and circumstances where practical. The tool could also
 present valid choices to the user where the correct choice is ambiguous
 to the tool.
 
-When more than one rlink and/or base64 field is present in a resource,
+When more than one `rlink` and/or `base64` field is present in a resource,
 FedRAMP's automated processing tools will attempt to find valid content
 using the following priority, unless specified otherwise:
 
-1.  FedRAMP tools will look first in ```base64``` fields
+1.  FedRAMP tools will look first in `base64` fields
 
-    a.  Start with the first ```base64``` field in the resource.
+    a.  Start with the first `base64` field in the resource.
 
-    b.  Check each ```base64``` field in the sequence in which they appear in
-        the ```resource```.
+    b.  Check each `base64` field in the sequence in which they appear in
+        the `resource`.
 
     c.  If valid content is found, stop looking and use the content.
 
-    d.  If no valid content is found after checking all ```base64``` fields in
+    d.  If no valid content is found after checking all `base64` fields in
         the resource, proceed to step #2.
 
-2.  If no valid base64 content is found, look in ```rlink``` fields.
+2.  If no valid base64 content is found, look in `rlink` fields.
 
-    a.  Start with the first ```rlink``` field in the resource.
+    a.  Start with the first `rlink` field in the resource.
 
-    b.  Check each ```rlink``` field in the sequence in which they appear in
-        the ```resource```.
+    b.  Check each `rlink` field in the sequence in which they appear in
+        the `resource`.
 
     c.  If valid content is found, stop looking and use the content.
 
-    d.  If no valid content is found after checking all ```rlink``` fields,
+    d.  If no valid content is found after checking all `rlink` fields,
         treat the resource as invalid, which may include raising a
         warning or error message.
 
 ### 2.7.5. Citation and Attachment Details
 
-IMPORTANT: As of 1.0.0, NIST includes ```type```, ```version```, and ```published```
+IMPORTANT: As of 1.0.0, NIST includes `type`, `version`, and `published`
 properties as part of core OSCAL, eliminating the requirement to treat
 this content as FedRAMP Extensions.
 

--- a/docs/content/guides/general/3-fedramp-extensions-and-accepted-values.md
+++ b/docs/content/guides/general/3-fedramp-extensions-and-accepted-values.md
@@ -38,21 +38,21 @@ unique needs existed.
 _All FedRAMP extensions include a namespace (ns) flag set to "https://fedramp.gov/ns/oscal"._
 {{</callout>}}
 
-NIST allows organizations to extend OSCAL anyplace ```prop``` fields or ```part```
+NIST allows organizations to extend OSCAL anyplace `prop` fields or `part`
 assemblies exist in the core syntax. (Please note, there are currently
 no part assemblies in the SSP, SAP, SAR, or POA&M.) There are two
 fundamental requirements for extending OSCAL:
 
--   The organization must establish a unique namespace (```ns```) identifier,
-    such as (```ns="http://domain.tld/ns/oscal"```), and use it to
-    consistently tag all ```prop``` and ```part``` extensions from that
+-   The organization must establish a unique namespace (`ns`) identifier,
+    such as (`ns="http://domain.tld/ns/oscal"`), and use it to
+    consistently tag all `prop` and `part` extensions from that
     organization.
 
 -   The organization is responsible for defining, managing, and
-    communicating all names (```name="scan-type"```) defined and tagged with
+    communicating all names (`name="scan-type"`) defined and tagged with
     the above name space identifier.
 
-NIST\'s core OSCAL ```prop``` assemblies have no ```ns``` flag. If an ```ns``` flag is
+NIST\'s core OSCAL `prop` assemblies have no `ns` flag. If an `ns` flag is
 present, it is an organization-defined extension. This allows each
 industry standards body or organization to create their own extensions
 in their own name space without concern for overlapping names.
@@ -63,12 +63,12 @@ point in the future, NIST may provide a registry for organizational
 extensions. For now, FedRAMP is publishing its own registry to document
 its extensions.
 
-All FedRAMP extensions must have a namespace (```ns```) flag set to ```"https://fedramp.gov/ns/oscal"```.
+All FedRAMP extensions must have a namespace (`ns`) flag set to `"https://fedramp.gov/ns/oscal"`.
 
-For example, if the core OSCAL syntax has a ```status``` field, but both
+For example, if the core OSCAL syntax has a `status` field, but both
 FedRAMP and the payment card industry (PCI) require their own
 framework-specific status field, each may define an extension with the
-```name="status"``` and assign their own ```ns``` flag. This results in three
+`name="status"` and assign their own `ns` flag. This results in three
 possible status fields as follows:
 
 #### NIST OSCAL User Representation
@@ -109,15 +109,15 @@ flag using the syntax above.**
 \* This is an example, and is not intended to represent an actual PCI
 extension.
 
-Tool developers must always refer to extensions using **both** the name
-and ns flags as a pair.
+Tool developers must always refer to extensions using **both** the `name`
+and `ns` flags as a pair.
 
 All FedRAMP extensions will appear as:
 {{< highlight xml "linenos=table" >}}
   <prop name="____" ns="https://fedramp.gov/ns/oscal" value="Value"/>
 {{< /highlight >}}
 
-**NOTE:** The catalog and profile OSCAL models also allow the ```part```
+**NOTE:** The catalog and profile OSCAL models also allow the `part`
 assembly to be used for extensions. This is not currently the case for
 the OSCAL SSP, SAP, SAR, or POA&M.
 

--- a/docs/content/guides/general/4-expressing-common-fedramp-template-elements-in-oscal.md
+++ b/docs/content/guides/general/4-expressing-common-fedramp-template-elements-in-oscal.md
@@ -60,17 +60,17 @@ landscape orientation.**
 {{<callout>}}
 The **FedRAMP Logo** is a resource in the back-matter section of the OSCAL-based FedRAMP Templates, and can be referenced with the following XPath:
 
-```   /*/metadata/party[@uuid=../responsible-party[@role-id='fedramp-pmo']/party-uuid]/link[@rel='logo']/@href```
+`   /*/metadata/party[@uuid=../responsible-party[@role-id='fedramp-pmo']/party-uuid]/link[@rel='logo']/@href`
 
 As with any href value, this can include a relative or absolute URI external to the OSCAL file, or it can contain a URI fragment, pointing to a resource inside the OSCAL file itself (or other OSCAL files in the stack).
 
 If the above returns an href value beginning with a hashtag (#), the rest of the value is the UUID value for the resource containing the logo. Drop the hashtag and use the remaining value to locate the resource as follows:
 
-```   /*/back-matter/resource[@uuid='[UUID-value-returned-above]']/rlink/@href```
+`   /*/back-matter/resource[@uuid='[UUID-value-returned-above]']/rlink/@href`
 
 OR\
 
-```   /*/back-matter/resource[@uuid='[UUID-value-returned-above]']/base64```
+`   /*/back-matter/resource[@uuid='[UUID-value-returned-above]']/base64`
 {{</callout>}}
 
 #### Representation
@@ -113,7 +113,7 @@ OR\
 {{<callout>}}
 **FedRAMP Allowed Value** \
 Required Role ID:
-- fedramp-pmo
+- `fedramp-pmo`
 {{</callout>}}
 
 #### XPath Queries
@@ -189,7 +189,7 @@ using this Prepared By syntax.
 {{<callout>}}
 **NIST Allowed Value** \
 Required Role ID:
-- prepared-by
+- `prepared-by`
 
 {{</callout>}}
 
@@ -202,7 +202,7 @@ NOTE: Replace "org-name" with "address/addr-line", "address/city", "address/stat
 
 **NOTES:**
 
--   The ```responsible-party``` assembly connects the role to the party and is
+-   The `responsible-party` assembly connects the role to the party and is
     required for compliance.
 
 -   If the content was prepared by an organization other than the CSP,
@@ -250,7 +250,7 @@ content. The FedRAMP SAP and SAR must never be CSP self-prepared.
 {{<callout>}}
 **NIST Allowed Value** \
 Required Role ID:
-- prepared-by
+- `prepared-by`
 
 {{</callout>}}
 
@@ -263,7 +263,7 @@ NOTE: Replace "org-name" with "address/addr-line", "address/city", "address/stat
 
 **NOTES:**
 
--   The ```responsible-party``` assembly connects the role to the party and is
+-   The `responsible-party` assembly connects the role to the party and is
     required for compliance.
 
 ## 4.4. Prepared For (CSP)
@@ -324,9 +324,9 @@ NOTE: Replace "org-name" with "address/addr-line", "address/city", "address/stat
 ![Document Revision History](/img/content-figure-8.png)
 
 {{<callout>}}
-The ```remarks``` field is Markup multiline, which enables the text to be formatted. This requires special handling. See Section 2.5.3 Markup-line and Markup-multiline Fields in OSCAL, or visit: https://pages.nist.gov/OSCAL/documentation/schema/datatypes/#markup-multiline <br/>
+The `remarks` field is Markup multiline, which enables the text to be formatted. This requires special handling. See Section 2.5.3 Markup-line and Markup-multiline Fields in OSCAL, or visit: https://pages.nist.gov/OSCAL/documentation/schema/datatypes/#markup-multiline <br/>
 
-NOTE: At time of publication, NIST is evaluating the possibility of including party-uuid or similar in the revision assembly. This section will be updated if that decision is made.
+NOTE: At time of publication, NIST is evaluating the possibility of including party-uuid or similar in the `revision` assembly. This section will be updated if that decision is made.
 
 {{</callout>}}
 
@@ -391,7 +391,7 @@ Replace XPath predicate "[1]" with "[2]", "[3]", etc.
 **NOTES:**
 
 -   The Revision History\'s Author field is addressed using a FedRAMP
-    extension, which points to a metadata ```party```.
+    extension, which points to a metadata `party`.
 
 -   The published field requires the OSCAL data type,
     [dateTime-with-timezone](https://pages.nist.gov/OSCAL/reference/datatypes/#datetime-with-timezone).
@@ -412,9 +412,9 @@ content for the FedRAMP PMO party. This information already exists in
 OSCAL-based FedRAMP Templates.
 
 There must be a role defined in the file with the ID value set to
-```"fedramp-pmo"```. There must be a ```party``` defined with FedRAMP\'s details,
-and there must be a ```responsible-party``` defined, linking the
-```"fedramp-pmo"``` ```role-id``` to the FedRAMP ```party``` uuid.
+`"fedramp-pmo"`. There must be a `party` defined with FedRAMP\'s details,
+and there must be a `responsible-party` defined, linking the
+`"fedramp-pmo"` `role-id` to the FedRAMP `party` uuid.
 
 #### Representation
 {{< highlight xml "linenos=table" >}}
@@ -451,7 +451,7 @@ and there must be a ```responsible-party``` defined, linking the
 <br />
 {{<callout>}}
 **FedRAMP-Role Identifiers:**
-- fedramp-pmo
+- `fedramp-pmo`
 
 {{</callout>}}
 
@@ -514,12 +514,12 @@ assessor\'s organization.
 
 **Defined Identifiers** \
 Required Role IDs:
-- content-approver
-- cloud-service-provider
+- `content-approver`
+- `cloud-service-provider`
 
 **FedRAMP Extension (Person's Title)** \
 prop (ns="https://fedramp.gov/ns/oscal"):
-- name="title"
+- `name="title"`
 
 {{</callout>}}
 
@@ -538,8 +538,8 @@ CSP Name:
 **NOTES:**
 
 The code above is an SSP example For SAP and SAR, a similar approach is
-used for the assessor, using the ```"assessor"``` role ID instead of the
-```"cloud-service-provider"``` role ID.
+used for the assessor, using the `"assessor"` role ID instead of the
+`"cloud-service-provider"` role ID.
 
 ## 4.8. FedRAMP Standard Attachments (Acronyms, Laws/Regulations)
 
@@ -548,10 +548,10 @@ the FedRAMP Laws and Regulations file, as well as the FedRAMP Acronyms
 file posted on <https://fedramp.gov>.
 
 These are already included in the OSCAL-based FedRAMP templates as
-resources. The ```resource``` linking to the FedRAMP citations file is
-identified with links from the property type, ```"fedramp-citations"```. The
+resources. The `resource` linking to the FedRAMP citations file is
+identified with links from the property type, `"fedramp-citations"`. The
 resource linking to the FedRAMP acronyms file is identified with the
-property type, ```"fedramp-acronyms"```.
+property type, `"fedramp-acronyms"`.
 
 #### Representation
 {{< highlight xml "linenos=table" >}}
@@ -595,14 +595,14 @@ Link to FedRAMP Acronyms and Glossary:
 ![Laws and Regulations](/img/content-figure-11.png)
 
 Additional citations must be represented as
-additional ```resource``` assemblies. One ```resource``` assembly per citation. This
+additional `resource` assemblies. One `resource` assembly per citation. This
 applies to applicable laws, regulations, standards, or guidance beyond
 FedRAMP\'s predefined set.
 
 Each must have a type defined. The value of the type filed must be set
 to \"law\", \"regulation\", \"standard\", or \"guidance\" as
 appropriate. There may be more than one type defined. FedRAMP tools use
-the ```type``` property to differentiate these resource assemblies from
+the `type` property to differentiate these resource assemblies from
 others.
 
 #### Representation
@@ -711,9 +711,9 @@ Publication Date of PIA:
 
 {{</ highlight >}}
 
-Tools creating OSCAL content should include a ```media-type``` for all ```rlink```
-and ```base64``` fields, as well as a ```filename``` for all ```base64``` fields.
+Tools creating OSCAL content should include a `media-type` for all `rlink`
+and `base64` fields, as well as a `filename` for all `base64` fields.
 
-Tools should process ```rlink``` and ```base64``` content with or without these
+Tools should process `rlink` and `base64` content with or without these
 fields. Where present they should be used when validating or rendering
 the linked or embedded content.

--- a/docs/content/guides/general/5-appendices.md
+++ b/docs/content/guides/general/5-appendices.md
@@ -35,7 +35,7 @@ syntax below.
     /*/system-characteristics/security-sensitivity-level
 {{</ highlight >}}
 
-This determines which URL should be entered for the import-profile field
+This determines which URL should be entered for the `import-profile` field
 in an OSCAL-based FedRAMP SSP.
 
 #### Baseline Representation
@@ -114,20 +114,20 @@ follows:
 1.  **Create a new, blank OSCAL Profile.**
 
 2.  **Point to the FedRAMP Baseline**: Point it to the appropriate
-    FedRAMP baseline using an ```import``` field.
+    FedRAMP baseline using an `import` field.
 
-3.  **Select the Relevant Controls**: Use the ```include``` and ```exclude``` fields
+3.  **Select the Relevant Controls**: Use the `include` and `exclude` fields
     to identify the controls to include or exclude from the FedRAMP
     baseline.
 
-    a.  For example, if you need all but one control, you can ```include all```, then ```exclude``` the one.
+    a.  For example, if you need all but one control, you can `include all`, then `exclude` the one.
 
 4.  **Specify How Controls Are Organized**: FedRAMP prefers you merge
     \"as-is\" using those merge fields. This is relevant when resolving
     the profile. See the *Profile Resolution* section of this appendix
     for more information.
 
-5.  **Modify the Selected Controls**: Use the ```modify``` assembly to make modifications to parameters and control definitions.
+5.  **Modify the Selected Controls**: Use the `modify` assembly to make modifications to parameters and control definitions.
 
 {{< callout >}}
 Create a new profile, importing to the appropriate FedRAMP profile, then use profile syntax to make necessary changes.
@@ -238,10 +238,10 @@ Each FedRAMP XML and JSON baseline profile has a resolved profile
 catalog in the same location as the pre-processed profile. Where
 available, these may be used by tools to save processing time.
 
-The ```merge``` assembly within an OSCAL profile offers a profile resolver
+The `merge` assembly within an OSCAL profile offers a profile resolver
 control over how the final file is organized. To maintain the same
-organization as within the catalog, simply use the ```as-is``` field and set
-it to ```"yes"```.
+organization as within the catalog, simply use the `as-is` field and set
+it to `"yes"`.
 
 The complete profile syntax is available here:
 
@@ -287,19 +287,19 @@ NIST at <oscal@nist.gov> or by submitting an issue here:
 An OSCAL file defines roles, people, and organizations within the
 metadata as part of three separate assemblies:
 
--   **role**: A role ID and role title are required. Other content, such
-    as a short-name, description, or remarks are optional.
+-   **role**: A role ID and role `title` are required. Other content, such
+    as a `short-name`, `description`, or `remarks` are optional.
 
 -   **location**: Locations, such as corporate offices and data center
-    addresses, are defined as location assemblies
+    addresses, are defined as `location` assemblies
 
--   **party**: People and organizations are defined as party assemblies.
+-   **party**: People and organizations are defined as `party` assemblies.
     An organization is any collection of people, and can represent a
     company, agency, department, or team.
 
--   **responsible-party**: Links roles to parties. The same role can
-    have more than one party assigned to it. Also a party can be
-    assigned to more than one role.
+-   **responsible-party**: Links roles to parties. The same `role` can
+    have more than one `party` assigned to it. Also a `party` can be
+    assigned to more than one `role`.
 
 ### *FedRAMP Defined Party Identifiers*
 
@@ -349,16 +349,16 @@ Registry.**
 
 ### *Working with Location Assemblies*
 
-The ```location``` assembly is intended to represent the address of a location
+The `location` assembly is intended to represent the address of a location
 such as the HQ of a CSP or 3PAO, a data center, or an Agency.
 
 Some locations are required. For example, the SSP must contain the at
-least one ```location``` assembly with the primary business address of the
-CSP. The SAP and SAR must contain at least one ```location``` assembly with
+least one `location` assembly with the primary business address of the
+CSP. The SAP and SAR must contain at least one `location` assembly with
 the primary business address of the assessor.
 
-OSCAL allows the ```title``` field to be optional. FedRAMP strongly encourages
-its use. If the ```country``` field is missing, FedRAMP tools will assume the
+OSCAL allows the `title` field to be optional. FedRAMP strongly encourages
+its use. If the `country` field is missing, FedRAMP tools will assume the
 address is within the United States of America.
 
 {{< highlight xml "linenos=table" >}}
@@ -381,22 +381,22 @@ address is within the United States of America.
 
 Some locations require type properties to ensure FedRAMP tools can
 accurately identify required content. For example, the location assembly
-for a data center must include a ```type``` property with a value of
-```"data-center"```. The class may be used to indicate whether the data
+for a data center must include a `type` property with a value of
+`"data-center"`. The class may be used to indicate whether the data
 center is \"primary\" or \"alternate\".
 
 ### *Working with Party Assemblies*
 
 Party assemblies may be used to represent individuals, teams, or an
-entire company/agency. When representing an individual, the ```type``` flag
-must have a value of ```"person"```. When representing a team, company or
-agency, the ```type``` flag must have a value of ```"organization"```. FedRAMP
+entire company/agency. When representing an individual, the `type` flag
+must have a value of `"person"`. When representing a team, company or
+agency, the `type` flag must have a value of `"organization"`. FedRAMP
 artifacts typically require an individual\'s title to be identified, the
-```prop``` ```"job-title"``` is designated for this purpose.
+`prop` `"job-title"` is designated for this purpose.
 
 Contact details, such as an individual\'s email address and phone
 number, or a business web site, may be included and are often required
-within FedRAMP artifacts. A short-name filed provides an ability to
+within FedRAMP artifacts. A `short-name` field provides an ability to
 define an organization\'s acronym or desired abbreviation. This is
 required for the CSP, assessor, and any Agency.
 
@@ -423,7 +423,7 @@ required for the CSP, assessor, and any Agency.
 ### *Identifying Organizational Membership of Individuals*
 
 An individual may be affiliated with one or more teams/organizations.\
-Use one ```member-of-organization``` field for each team, and one to link the
+Use one `member-of-organization` field for each team, and one to link the
 individual to their employer.
 
 {{< highlight xml "linenos=table" >}}
@@ -452,18 +452,18 @@ accomplished with one of three approaches:
 
 **Preferred Approach**: When multiple parties share the same address,
 such as multiple staff members at a company HQ, define the address once
-as a ```location``` assembly, then use the ```location-uuid``` field within each
-```party``` assembly to identify the location of that individual or team.
+as a `location` assembly, then use the `location-uuid` field within each
+`party` assembly to identify the location of that individual or team.
 
 **Alternate Approach**: If the address is unique to this individual, it
-may be included in the ```party``` assembly itself.
+may be included in the `party` assembly itself.
 
-**Hybrid Approach**: It is possible to include both a ```location-uuid``` and
-an ```address``` assembly within a ```party``` assembly. This may be used where
+**Hybrid Approach**: It is possible to include both a `location-uuid` and
+an `address` assembly within a `party` assembly. This may be used where
 multiple staff are in the same building, yet have different office
-numbers or mail stops. Use the ```location-uuid``` to identify the shared
-building, and only include a single ```addr-line``` field within the party\'s
-```address``` assembly.
+numbers or mail stops. Use the `location-uuid` to identify the shared
+building, and only include a single `addr-line` field within the party\'s
+`address` assembly.
 
 A tool developer may elect to always create a location assembly, even
 when only used once; however, tools must recognize and handle all of the


### PR DESCRIPTION
# Committer Notes

This PR resolves issue #556 by adding support and instructions for running the FedRAMP OSCAL guides site as a container.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
