### PR TITLE
informational and warning constraint results

### DIFF
--- a/features/steps/fedramp_extensions_steps.ts
+++ b/features/steps/fedramp_extensions_steps.ts
@@ -303,7 +303,7 @@ async function checkConstraints(
 
       const kinds = constraintResults.map((c) => c.kind);
       const passCount = kinds.filter((k) => k === "pass").length;
-      const failCount = kinds.filter((k) => k === "fail").length;
+      const failCount = kinds.filter((k) => k === "fail"||k==='informational').length;
 
       const result = kinds.reduce((acc, kind) => {
         if (acc === "mixed" || (acc !== kind && acc !== "initial")) {
@@ -562,7 +562,7 @@ When("I analyze the YAML test files for each constraint ID", function () {
 
           if (result === "pass") {
             testResults[constraintId].pass = true;
-          } else if (result === "fail") {
+          } else if (result === "fail"||result==='informational') {
             testResults[constraintId].fail = true;
           } else if (result === undefined || result === "mixed") {
             // Handle cases where only pass_count or fail_count is specified

--- a/features/steps/fedramp_extensions_steps.ts
+++ b/features/steps/fedramp_extensions_steps.ts
@@ -303,7 +303,7 @@ async function checkConstraints(
 
       const kinds = constraintResults.map((c) => c.kind);
       const passCount = kinds.filter((k) => k === "pass").length;
-      const failCount = kinds.filter((k) => k === "fail"||k==='informational').length;
+      const failCount = kinds.filter((k) => k === "fail"||k==="informational").length;
 
       const result = kinds.reduce((acc, kind) => {
         if (acc === "mixed" || (acc !== kind && acc !== "initial")) {

--- a/features/steps/fedramp_extensions_steps.ts
+++ b/features/steps/fedramp_extensions_steps.ts
@@ -301,9 +301,16 @@ async function checkConstraints(
         continue;
       }
 
-      const kinds = constraintResults.map((c) => c.kind);
+      const kinds = constraintResults.map((c) => {
+        if(c.level==='warning'){
+          return 'fail'
+        }else{
+          return c.kind
+      }});
       const passCount = kinds.filter((k) => k === "pass").length;
-      const failCount = kinds.filter((k) => k === "fail"||k==="informational").length;
+      const failCount = kinds.filter((k) => k === "fail").length;
+      const warnCount = constraintResults.filter((k) => k.level === "warning").length;
+      const infoCount = constraintResults.filter((k) => k.kind === "informational").length;
 
       const result = kinds.reduce((acc, kind) => {
         if (acc === "mixed" || (acc !== kind && acc !== "initial")) {
@@ -315,7 +322,15 @@ async function checkConstraints(
       console.log(
         `Received: ${constraintResults.length} matching ${result} results (${passCount} pass, ${failCount} fail)`
       );
-
+      if(warnCount>0)
+        console.log(
+          `Received: ${warnCount} warn)`
+        );
+        if(infoCount>0)
+          console.log(
+            `Received: ${infoCount} informational)`
+          );
+      
       if (result === "initial") {
         throw Error("Unknown Error");
       }

--- a/features/steps/fedramp_extensions_steps.ts
+++ b/features/steps/fedramp_extensions_steps.ts
@@ -302,7 +302,7 @@ async function checkConstraints(
       }
 
       const kinds = constraintResults.map((c) => {
-        if(c.level==='warning'){
+        if(c.level==='warning'||c.kind==='informational'){
           return 'fail'
         }else{
           return c.kind
@@ -577,7 +577,7 @@ When("I analyze the YAML test files for each constraint ID", function () {
 
           if (result === "pass") {
             testResults[constraintId].pass = true;
-          } else if (result === "fail"||result==='informational') {
+          } else if (result === "fail") {
             testResults[constraintId].fail = true;
           } else if (result === undefined || result === "mixed") {
             // Handle cases where only pass_count or fail_count is specified

--- a/src/scripts/dev-constraint.cjs
+++ b/src/scripts/dev-constraint.cjs
@@ -86,7 +86,7 @@ function analyzeTestFiles() {
                 if (result === 'pass' || file.toUpperCase().includes('PASS')) {
                     testResults[constraintId].pass = file;
                     testResults[constraintId].pass_file = filePath.split("/").pop();                
-                } else if (result === 'fail' || file.toUpperCase().includes('FAIL')) {
+                } else if (result === 'fail' ||result ==='informational'|| file.toUpperCase().includes('FAIL')) {
                     testResults[constraintId].fail = file;
                     testResults[constraintId].fail_file = filePath.split("/").pop();                
                 }


### PR DESCRIPTION
# Committer Notes

make test runner aware of informational constraint results
### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
