### PR TITLE
Add has-allowed-media-type constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -37,6 +37,8 @@ Examples:
   | interconnection-security-PASS.yaml |
   | privilege-level-FAIL.yaml |
   | privilege-level-PASS.yaml |
+  | resource-media-type-FAIL.yaml |
+  | resource-media-type-PASS.yaml |
   | response-point-FAIL.yaml |
   | response-point-PASS.yaml |
   | scan-type-FAIL.yaml |
@@ -68,6 +70,7 @@ Examples:
   | information-type-system |
   | interconnection-direction |
   | interconnection-security |
+  | media-type |
   | privilege-level |
   | prop-response-point-has-cardinality-one |
   | scan-type |

--- a/src/validations/constraints/content/ssp-all-INVALID.xml
+++ b/src/validations/constraints/content/ssp-all-INVALID.xml
@@ -197,7 +197,14 @@
         <p>Detailed access control policy document</p>
       </description>
       <prop name="type" value="unsupported-type" ns="https://fedramp.gov/ns/oscal"/>
-      <rlink href="https://example.com/policies/access-control.pdf"/>
+      <rlink media-type="invalid/nosuchtype" href="https://example.com/policies/access-control.pdf"/>
+    </resource>
+    <resource uuid="aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee">
+      <title>Embedded content encoded in base64</title>
+      <description>
+        <p>Instead of pointing an external with rlink, the content is embedded and base64 with an invalid media-type.</p>
+      </description>
+      <base64 media-type="invalid/nosuchtype" filename="failure.txt">VGhpcyB3b24ndCB3b3JrIGFueXdheS4K</base64>
     </resource>
   </back-matter>
 </system-security-plan>

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -193,7 +193,14 @@
         <p>Detailed access control policy document</p>
       </description>
       <prop name="type" value="policy" ns="https://fedramp.gov/ns/oscal"/>
-      <rlink href="https://example.com/policies/access-control.pdf"/>
+      <rlink media-type="application/pdf" href="https://example.com/policies/access-control.pdf"/>
+    </resource>
+    <resource uuid="aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee">
+      <title>Embedded content encoded in base64</title>
+      <description>
+        <p>Instead of pointing an external with rlink, the content is embedded and base64 with a valid media-type.</p>
+      </description>
+      <base64 media-type="text/plain" filename="success.txt">V2FsayB3aXRob3V0IHJoeXRobSwgYW5kIGl0IHdvbid0IGF0dHJhY3QgdGhlIHdvcm0K</base64>
     </resource>
   </back-matter>
 </system-security-plan>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -174,6 +174,35 @@
                 <enum value="saas">Software as a Service</enum>
                 <enum value="other">Other</enum>
             </allowed-values>
+
+            <allowed-values id="media-types" target="back-matter/resource/@media-type">
+                <enum value="application/gzip">application/gzip</enum>
+                <enum value="application/msword">application/msword</enum>
+                <enum value="application/octet-stream">application/octet-stream</enum>
+                <enum value="application/pdf">application/pdf</enum>
+                <enum value="application/vnd.ms-excel">application/vnd.ms-excel</enum>
+                <enum value="application/vnd.ms-works">application/vnd.ms-works</enum>
+                <enum value="application/vnd.oasis.opendocument.graphics">application/vnd.oasis.opendocument.graphics</enum>
+                <enum value="application/vnd.oasis.opendocument.presentation">application/vnd.oasis.opendocument.presentation</enum>
+                <enum value="application/vnd.oasis.opendocument.spreadsheet">application/vnd.oasis.opendocument.spreadsheet</enum>
+                <enum value="application/vnd.oasis.opendocument.text">application/vnd.oasis.opendocument.text</enum>
+                <enum value="application/vnd.openxmlformats-officedocument.presentationml.presentation">application/vnd.openxmlformats-officedocument.presentationml.presentation</enum>
+                <enum value="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</enum>
+                <enum value="application/vnd.openxmlformats-officedocument.wordprocessingml.document">application/vnd.openxmlformats-officedocument.wordprocessingml.document</enum>
+                <enum value="application/x-bzip">application/x-bzip</enum>
+                <enum value="application/x-bzip2">application/x-bzip2</enum>
+                <enum value="application/x-tar">application/x-tar</enum>
+                <enum value="application/zip">application/zip</enum>
+                <enum value="image/bmp">image/bmp</enum>
+                <enum value="image/jpeg">image/jpeg</enum>
+                <enum value="image/png">image/png</enum>
+                <enum value="image/tiff">image/tiff</enum>
+                <enum value="image/webp">image/webp</enum>
+                <enum value="image/svg+xml">image/svg+xml</enum>
+                <enum value="text/csv">text/csv</enum>
+                <enum value="text/html">text/html</enum>
+                <enum value="text/plain">text/plain</enum>
+            </allowed-values>
         </constraints>
 
     </context>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -175,7 +175,7 @@
                 <enum value="other">Other</enum>
             </allowed-values>
 
-            <allowed-values id="media-types" target="back-matter/resource/@media-type">
+            <allowed-values id="media-type" target="back-matter/resource/(rlink|base64)/@media-type">
                 <enum value="application/gzip">application/gzip</enum>
                 <enum value="application/msword">application/msword</enum>
                 <enum value="application/octet-stream">application/octet-stream</enum>

--- a/src/validations/constraints/unit-tests/resource-media-type-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/resource-media-type-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for resource/(base64|rlink)/@media-type
+  description: This test case validates the behavior of constraint media-types allowed-values for FedRAMP
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: media-type
+      result: fail

--- a/src/validations/constraints/unit-tests/resource-media-type-PASS.yaml
+++ b/src/validations/constraints/unit-tests/resource-media-type-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for resource/rlink/@media-type
+  description: This test case validates the behavior of constraint media-types allowed-values for FedRAMP
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: media-type
+      result: pass


### PR DESCRIPTION
# Committer Notes

Add a constraint for `media-type` being one of the allowed-values and report an error otherwise.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~ Using tracker spreadsheet.

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
