### PR TITLE
Improve test runner and make commands

### DIFF
--- a/src/scripts/dev-constraint.cjs
+++ b/src/scripts/dev-constraint.cjs
@@ -229,12 +229,15 @@ async function runCucumberTest(constraintId, testFiles) {
     const nodeOptions = '--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node';
     const cucumberCommand = `NODE_OPTIONS="${nodeOptions}" npx cucumber-js`;
 
-    const scenarioLines = getScenarioLineNumbers(featureFile, constraintId,testFiles);
+    let scenarioLines = getScenarioLineNumbers(featureFile, constraintId,testFiles);
 
     if (scenarioLines.length === 0) {
         console.error(`No scenarios found for constraintId: ${constraintId}`);
-        execSync("npm run test:coverage",{stdio:'inherit'});
+        execSync("npm run test:coverage",{stdio:'ignore'});
+        scenarioLines = getScenarioLineNumbers(featureFile, constraintId,testFiles);
+        if(scenarioLines.length===0){
         return false;
+        }
     }
 
     try {

--- a/src/validations/module.mk
+++ b/src/validations/module.mk
@@ -24,6 +24,8 @@ clean-validations:
 update:
 	npm install
 	$(OSCAL_CLI) use latest
+constraint:
+	npm run constraint
 
 test-validations:
 	@echo "Validating rev5 artifacts recursively..."

--- a/src/validations/module.mk
+++ b/src/validations/module.mk
@@ -21,6 +21,10 @@ build-validations:
 clean-validations:
 	@echo "Nothing to clean"
 
+update:
+	npm install
+	$(OSCAL_CLI) use latest
+
 test-validations:
 	@echo "Validating rev5 artifacts recursively..."
 	$(OSCAL_CLI) validate -f $(REV5_BASELINES) -e ./src/validations/constraints/fedramp-external-constraints.xml -r


### PR DESCRIPTION
# Committer Notes

adding make update which runs npm install and installs latest oscal cli
and make constraint which is an alias to npm run constraint
this PR also adjusts npm run constraint to run test coverage in the background so that the feature number can be found and it can be ran right after making a new constraint suite




### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
