### PR TITLE
Add responsible-party-is-person constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -133,6 +133,8 @@ Examples:
   | resource-has-title-PASS.yaml |
   | response-point-FAIL.yaml |
   | response-point-PASS.yaml |
+  | responsible-party-is-person-FAIL.yaml |
+  | responsible-party-is-person-PASS.yaml |
   | role-defined-authorizing-official-poc-FAIL.yaml |
   | role-defined-authorizing-official-poc-PASS.yaml |
   | role-defined-information-system-security-officer-FAIL.yaml |
@@ -221,6 +223,7 @@ Examples:
   | prop-response-point-has-cardinality-one |
   | resource-has-base64-or-rlink |
   | resource-has-title |
+  | responsible-party-is-person |
   | role-defined-authorizing-official-poc |
   | role-defined-information-system-security-officer |
   | role-defined-system-owner |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -33,6 +33,24 @@
      <role id="information-system-security-officer">
        <title>Information System Security Officer (or Equivalent)</title>
      </role>
+     <role id="system-poc-management">
+      <title>Information System Management Point of Contact (POC)</title>
+      <description>
+         <p>The highest level manager who responsible for system operation on behalf of the System Owner.</p>
+      </description>
+      </role>
+      <role id="system-poc-technical">
+          <title>Information System Technical Point of Contact</title>
+          <description>
+            <p>The individual or individuals leading the technical operation of the system.</p>
+          </description>
+      </role>
+      <role id="system-poc-other">
+          <title>General Point of Contact (POC)</title>
+          <description>
+            <p>A general point of contact for the system, designated by the system owner.</p>
+          </description>
+      </role>
 
     <location uuid="11111112-0000-4000-9001-000000000009">
       <address >
@@ -63,6 +81,29 @@
     <responsible-party role-id="content-approver">
       <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
     </responsible-party>
+
+    <responsible-party role-id="system-owner">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="authorizing-official">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="authorizing-official-poc">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="system-poc-management">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="system-poc-technical">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="system-poc-other">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="information-system-security-officer">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+
     <remarks>
       <p>This SSP is an example for demonstration purposes.</p>
     </remarks>

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -36,7 +36,7 @@
      <role id="system-poc-management">
       <title>Information System Management Point of Contact (POC)</title>
       <description>
-         <p>The highest level manager who responsible for system operation on behalf of the System Owner.</p>
+         <p>The highest level manager who is responsible for system operation on behalf of the System Owner.</p>
       </description>
       </role>
       <role id="system-poc-technical">

--- a/src/validations/constraints/content/ssp-responsible-party-is-person-INVALID.xml
+++ b/src/validations/constraints/content/ssp-responsible-party-is-person-INVALID.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
+                      uuid="12345678-1234-4321-8765-123456789012">
+    <metadata>
+        <title>Enhanced Example System Security Plan</title>
+        <published>2024-08-01T14:30:00Z</published>
+        <last-modified>2024-08-01T14:30:00Z</last-modified>
+        <version>1.1</version>
+        <oscal-version>1.0.0</oscal-version>
+        <document-id scheme="https://example.com/identifiers">SSP-2024-002</document-id>
+
+        <role id="creator">
+            <title>Document Creator</title>
+        </role>
+        <role id="content-approver">
+            <title>Content Approver</title>
+        </role>
+        <role id="system-admin">
+            <title>System Administrator</title>
+        </role>
+        <role id="asset-owner">
+            <title>Asset Owner</title>
+        </role>
+        <role id="system-poc-management">
+            <title>Information System Management Point of Contact (POC)</title>
+            <description>
+                <p>The highest level manager who responsible for system operation on behalf of the System Owner.</p>
+            </description>
+        </role>
+        <role id="system-poc-technical">
+            <title>Information System Technical Point of Contact</title>
+            <description>
+                <p>The individual or individuals leading the technical operation of the system.</p>
+            </description>
+        </role>
+        <role id="system-poc-other">
+            <title>General Point of Contact (POC)</title>
+            <description>
+                <p>A general point of contact for the system, designated by the system owner.</p>
+            </description>
+        </role>
+        <location uuid="11111112-0000-4000-9001-000000000009">
+            <address >
+            <country>US</country>
+            </address>
+            <prop name='data-center' value='dc-zone-1' class='tertiary' ns="https://fedramp.gov/ns/oscal"/>
+        </location>
+        <party uuid="11111111-0000-4000-9000-000000000001" type="organization">
+            <name>Example Organization</name>
+            <short-name>ExOrg</short-name>
+            <link rel="website" href="https://example.com"/>
+            <address type="work"  />
+        </party>
+        <party uuid="22222222-0000-4000-9000-000000000002" type="person">
+            <name>Jane Doe</name>
+            <email-address>jane.doe@example.com</email-address>
+            <address type="work"  />
+        </party>
+
+        <responsible-party role-id="creator">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-party>
+        <responsible-party role-id="content-approver">
+            <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+        </responsible-party>
+
+        <responsible-party role-id="system-owner">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-party>
+        <responsible-party role-id="authorizing-official">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-party>
+        <responsible-party role-id="authorizing-official-poc">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-party>
+        <responsible-party role-id="system-poc-management">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-party>
+        <responsible-party role-id="system-poc-technical">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-party>
+        <responsible-party role-id="system-poc-other">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-party>
+        <responsible-party role-id="information-system-security-officer">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-party>
+
+        <remarks>
+            <p>This SSP is an example for demonstration purposes.</p>
+        </remarks>
+    </metadata>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-responsible-party-is-person-INVALID.xml
+++ b/src/validations/constraints/content/ssp-responsible-party-is-person-INVALID.xml
@@ -72,18 +72,6 @@
         <responsible-party role-id="authorizing-official">
             <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
         </responsible-party>
-        <responsible-party role-id="authorizing-official-poc">
-            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
-        </responsible-party>
-        <responsible-party role-id="system-poc-management">
-            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
-        </responsible-party>
-        <responsible-party role-id="system-poc-technical">
-            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
-        </responsible-party>
-        <responsible-party role-id="system-poc-other">
-            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
-        </responsible-party>
         <responsible-party role-id="information-system-security-officer">
             <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
         </responsible-party>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -181,6 +181,11 @@
                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0"  name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-centers" />
                 <message>There must be one or more alternate data center(s).</message>
             </expect>
+            <index-has-key id="responsible-party-is-person" name="index-person-party-uuid" target="./responsible-party[(@role-id='system-owner') or (@role-id='authorizing-official-poc') or (@role-id='system-poc-management') or (@role-id='system-poc-technical') or (@role-id='system-poc-other') or (@role-id='information-system-security-officer')]" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#information-system-owner"/>
+                <key-field target="party-uuid"/>
+                <message>For roles 'system-owner', 'authorizing-official-poc', 'system-poc-management', 'system-poc-technical', 'system-poc-other', and 'information-system-security-officer', the responsible-role party must be a party of type 'person'.</message>
+            </index-has-key>
             <expect id="role-defined-system-owner" target="." test="role[@id eq 'system-owner']" level="ERROR">
                 <message>A FedRAMP SSP must define the system owner role.</message>
             </expect>
@@ -195,13 +200,6 @@
             	<description>An index of  UUIDs for party assemblies of type "person".</description>
                 <key-field target="@uuid"/>
             </index>
-            <index-has-key id="responsible-party-is-person" name="index-person-party-uuid" target="./responsible-party[(@role-id='system-owner') or (@role-id='authorizing-official-poc') or (@role-id='system-poc-management') or (@role-id='system-poc-technical') or (@role-id='system-poc-other') or (@role-id='information-system-security-officer')]" level="ERROR">
-                <key-field target="party-uuid"/>
-                <message>This responsible-party references a party which is not a person.</message>
-            </index-has-key>
-            <remarks>
-                <p>For roles 'system-owner', 'authorizing-official-poc', 'system-poc-management', 'system-poc-technical', 'system-poc-other', and 'information-system-security-officer', the responsible-role party must be a party of type 'person'.</p>
-            </remarks>
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -190,6 +190,18 @@
             <expect id="role-defined-information-system-security-officer" target="." test="role[@id eq 'information-system-security-officer']" level="ERROR">
                 <message>A FedRAMP SSP must define a role for the point of contact for an information system security officer.</message>
             </expect>
+            <index name="index-person-party-uuid" target="map:merge(party[@type='person'] ! map:entry(@uuid,.))?*">
+            	<formal-name>In-Scope UUIDs for party assemblies of type "person".</formal-name>
+            	<description>An index of  UUIDs for party assemblies of type "person".</description>
+                <key-field target="@uuid"/>
+            </index>
+            <index-has-key id="responsible-party-is-person" name="index-person-party-uuid" target="./responsible-party[(@role-id='system-owner') or (@role-id='authorizing-official-poc') or (@role-id='system-poc-management') or (@role-id='system-poc-technical') or (@role-id='system-poc-other') or (@role-id='information-system-security-officer')]" level="ERROR">
+                <key-field target="party-uuid"/>
+                <message>This responsible-party references a party which is not a person.</message>
+            </index-has-key>
+            <remarks>
+                <p>For roles 'system-owner', 'authorizing-official-poc', 'system-poc-management', 'system-poc-technical', 'system-poc-other', and 'information-system-security-officer', the responsible-role party must be a party of type 'person'.</p>
+            </remarks>
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -181,6 +181,11 @@
                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0"  name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-centers" />
                 <message>There must be one or more alternate data center(s).</message>
             </expect>
+            <index name="index-person-party-uuid" target="map:merge(party[@type='person'] ! map:entry(@uuid,.))?*">
+            	<formal-name>Index of parties of type "person".</formal-name>
+            	<description>This index is a list of the UUIDs of all of the parties that are type "person" in the document.</description>
+                <key-field target="@uuid"/>
+            </index>
             <index-has-key id="responsible-party-is-person" name="index-person-party-uuid" target="./responsible-party[(@role-id='system-owner') or (@role-id='information-system-security-officer')]" level="ERROR">
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#summary-of-ssp-roles-requirements"/>
                 <key-field target="party-uuid"/>
@@ -195,11 +200,6 @@
             <expect id="role-defined-information-system-security-officer" target="." test="role[@id eq 'information-system-security-officer']" level="ERROR">
                 <message>A FedRAMP SSP must define a role for the point of contact for an information system security officer.</message>
             </expect>
-            <index name="index-person-party-uuid" target="map:merge(party[@type='person'] ! map:entry(@uuid,.))?*">
-            	<formal-name>In-Scope UUIDs for party assemblies of type "person".</formal-name>
-            	<description>An index of  UUIDs for party assemblies of type "person".</description>
-                <key-field target="@uuid"/>
-            </index>
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -181,10 +181,10 @@
                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0"  name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-centers" />
                 <message>There must be one or more alternate data center(s).</message>
             </expect>
-            <index-has-key id="responsible-party-is-person" name="index-person-party-uuid" target="./responsible-party[(@role-id='system-owner') or (@role-id='authorizing-official-poc') or (@role-id='system-poc-management') or (@role-id='system-poc-technical') or (@role-id='system-poc-other') or (@role-id='information-system-security-officer')]" level="ERROR">
-                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#information-system-owner"/>
+            <index-has-key id="responsible-party-is-person" name="index-person-party-uuid" target="./responsible-party[(@role-id='system-owner') or (@role-id='information-system-security-officer')]" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#summary-of-ssp-roles-requirements"/>
                 <key-field target="party-uuid"/>
-                <message>For roles 'system-owner', 'authorizing-official-poc', 'system-poc-management', 'system-poc-technical', 'system-poc-other', and 'information-system-security-officer', the responsible-role party must be a party of type 'person'.</message>
+                <message>For roles 'system-owner' and 'information-system-security-officer', the responsible-role party must be a party of type 'person'.</message>
             </index-has-key>
             <expect id="role-defined-system-owner" target="." test="role[@id eq 'system-owner']" level="ERROR">
                 <message>A FedRAMP SSP must define the system owner role.</message>

--- a/src/validations/constraints/unit-tests/responsible-party-is-person-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/responsible-party-is-person-FAIL.yaml
@@ -1,0 +1,8 @@
+# driver for the responsible party is person unit test
+test-case:
+  name: Negative Test for responsible-party-is-person
+  description: This test case validates the behavior of constraint responsible-party-is-person
+  content: ssp-responsible-party-is-person-INVALID.xml
+  expectations:
+    - constraint-id: responsible-party-is-person
+      result: fail	

--- a/src/validations/constraints/unit-tests/responsible-party-is-person-PASS.yaml
+++ b/src/validations/constraints/unit-tests/responsible-party-is-person-PASS.yaml
@@ -1,0 +1,8 @@
+# driver for the responsible party is person unit test
+test-case:
+  name: Positive Test for responsible-party-is-person
+  description: This test case validates the behavior of constraint responsible-party-is-person
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: responsible-party-is-person
+      result: pass


### PR DESCRIPTION
# Committer Notes

This PR adds responsible-party-is-person constraint, which checks that ```responsible-party``` assemblies with ```role-id``` set to certain values (e.g., "system-owner", "authorizing-official", "authorizing-official-poc", "system-poc-management", "system-poc-technical", "system-poc-other", and "information-system-security-officer") must reference a ```party``` of type "person".

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
