### PR TITLE
Add back-matter 'has' constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -39,6 +39,18 @@ Examples:
   | data-center-us-PASS.yaml |
   | deployment-mode-FAIL.yaml |
   | deployment-mode-PASS.yaml |
+  | has-configuration-management-plan-FAIL.yaml |
+  | has-configuration-management-plan-PASS.yaml |
+  | has-incident-response-plan-FAIL.yaml |
+  | has-incident-response-plan-PASS.yaml |
+  | has-information-system-contingency-plan-FAIL.yaml |
+  | has-information-system-contingency-plan-PASS.yaml |
+  | has-rules-of-behavior-FAIL.yaml |
+  | has-rules-of-behavior-PASS.yaml |
+  | has-separation-of-duties-matrix-FAIL.yaml |
+  | has-separation-of-duties-matrix-PASS.yaml |
+  | has-user-guide-FAIL.yaml |
+  | has-user-guide-PASS.yaml |
   | information-type-system-FAIL.yaml |
   | information-type-system-PASS.yaml |
   | interconnection-direction-FAIL.yaml |
@@ -84,6 +96,12 @@ Examples:
   | data-center-country-code |
   | data-center-primary |
   | deployment-model |
+  | has-configuration-management-plan |
+  | has-incident-response-plan |
+  | has-information-system-contingency-plan |
+  | has-rules-of-behavior |
+  | has-separation-of-duties-matrix |
+  | has-user-guide |
   | information-type-system |
   | interconnection-direction |
   | interconnection-security |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -205,5 +205,92 @@
       <prop name="type" value="policy" ns="https://fedramp.gov/ns/oscal"/>
       <rlink href="https://example.com/policies/access-control.pdf"/>
     </resource>
+    <resource uuid="90a128ac-c850-48f6-8fff-a55692f80b41">
+      <title>User's Guide</title>
+      <description>
+         <p>User's Guide</p>
+      </description>
+      <prop name="type" value="users-guide"/>
+      <prop name="published" value="2023-01-01T00:00:00Z"/>
+      <rlink href="./documents/guides/sample_guide.pdf"/>
+      <remarks>
+         <p>Table 12-1 Attachments: User's Guide Attachment</p>
+         <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+      </remarks>
+   </resource>
+   <resource uuid="489112e1-57f2-4c29-8dd0-95b1442fbf3b">
+    <title>Document Title</title>
+    <description>
+       <p>Rules of Behavior</p>
+    </description>
+    <prop name="type" value="rules-of-behavior"/>
+    <prop name="published" value="2023-01-01T00:00:00Z"/>
+    <prop name="version" value="Document Version"/>
+    <rlink href="./documents/rob.docx" media-type="application/msword"/>
+    <base64 filename="rob.docx" media-type="application/msword">00000000</base64>
+    <remarks>
+       <p>Table 12-1 Attachments: Rules of Behavior (ROB)</p>
+       <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+    </remarks>
+ </resource>
+ <resource uuid="c7860916-f2f4-43aa-b578-d48cf8e6d381">
+  <title>Document Title</title>
+  <description>
+     <p>Contingency Plan (CP)</p>
+  </description>
+  <prop name="type" value="plan" class="information-system-contingency-plan"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/cp.docx" media-type="application/msword"/>
+  <base64 filename="cp.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>Table 12-1 Attachments: Contingency Plan (CP) Attachment</p>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
+<resource uuid="ab56cf27-0dae-40d6-89b7-d750137309af">
+  <title>Document Title</title>
+  <description>
+     <p>Configuration Management (CM) Plan</p>
+  </description>
+  <prop name="type" value="plan" class="configuration-management-plan"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/CM_Plan.docx" media-type="application/msword"/>
+  <base64 filename="CM_Plan.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>Table 12-1 Attachments: Configuration Management (CM) Plan Attachment</p>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
+<resource uuid="3f771ab5-8016-4571-98d1-f0fb962e15e2">
+  <title>Document Title</title>
+  <description>
+     <p>Incident Response (IR) Plan</p>
+  </description>
+  <prop name="type" value="plan" class="incident-response-plan"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/IR_Plan.docx" media-type="application/msword"/>
+  <base64 filename="IR_Plan.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>Table 12-1 Attachments: Incident Response (IR) Plan Attachment</p>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
+<resource uuid="49fb4631-1da2-41ca-b0b3-e1b1006d4025">
+  <title>Separation of Duties Matrix</title>
+  <description>
+     <p>Separation of Duties Matrix</p>
+  </description>
+  <prop ns="https://fedramp.gov/ns/oscal" name="type" value="separation-of-duties-matrix"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/Sep_Matrix.docx" media-type="application/msword"/>
+  <base64 filename="Sep_Matrix.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
   </back-matter>
 </system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -40,6 +40,24 @@
         <expect id="resource-has-base64-or-rlink" target="back-matter/resource" test="count(./rlink) >= 1 or count(./base64) >= 1" level="WARNING">
             <message>Every supporting artifact found in a citation must have at least one base64 or rlink element.</message>
         </expect>
+        <expect id="has-user-guide" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'users-guide']]" level="WARNING">
+            <message>A FedRAMP SSP must have a User Guide attached.</message>
+        </expect>
+        <expect id="has-rules-of-behavior" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'rules-of-behavior']]" level="WARNING">
+            <message>A FedRAMP SSP must have Rules of Behavior.</message>
+        </expect>
+        <expect id="has-information-system-contingency-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'information-system-contingency-plan']]" level="WARNING">
+            <message>A FedRAMP SSP must have a Contingency Plan attached.</message>
+        </expect>
+        <expect id="has-configuration-management-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'configuration-management-plan']]" level="WARNING">
+            <message>A FedRAMP SSP must have a Configuration Management Plan attached.</message>
+        </expect>
+        <expect id="has-incident-response-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'incident-response-plan']]" level="WARNING">
+            <message>A FedRAMP SSP must have an Incident Response Plan attached.</message>
+        </expect>
+        <expect id="has-separation-of-duties-matrix" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'separation-of-duties-matrix']]" level="WARNING">
+            <message>A FedRAMP SSP must have a Separation of Duties Matrix attached.</message>
+        </expect>
     </constraints>
 </context>
 <context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -40,22 +40,22 @@
         <expect id="resource-has-base64-or-rlink" target="back-matter/resource" test="count(./rlink) >= 1 or count(./base64) >= 1" level="WARNING">
             <message>Every supporting artifact found in a citation must have at least one base64 or rlink element.</message>
         </expect>
-        <expect id="has-user-guide" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'users-guide']]" level="WARNING">
+        <expect id="has-user-guide" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'users-guide']]" level="ERROR">
             <message>A FedRAMP SSP must have a User Guide attached.</message>
         </expect>
-        <expect id="has-rules-of-behavior" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'rules-of-behavior']]" level="WARNING">
+        <expect id="has-rules-of-behavior" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'rules-of-behavior']]" level="ERROR">
             <message>A FedRAMP SSP must have Rules of Behavior.</message>
         </expect>
-        <expect id="has-information-system-contingency-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'information-system-contingency-plan']]" level="WARNING">
+        <expect id="has-information-system-contingency-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'information-system-contingency-plan']]" level="ERROR">
             <message>A FedRAMP SSP must have a Contingency Plan attached.</message>
         </expect>
-        <expect id="has-configuration-management-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'configuration-management-plan']]" level="WARNING">
+        <expect id="has-configuration-management-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'configuration-management-plan']]" level="ERROR">
             <message>A FedRAMP SSP must have a Configuration Management Plan attached.</message>
         </expect>
-        <expect id="has-incident-response-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'incident-response-plan']]" level="WARNING">
+        <expect id="has-incident-response-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'incident-response-plan']]" level="ERROR">
             <message>A FedRAMP SSP must have an Incident Response Plan attached.</message>
         </expect>
-        <expect id="has-separation-of-duties-matrix" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'separation-of-duties-matrix']]" level="WARNING">
+        <expect id="has-separation-of-duties-matrix" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'separation-of-duties-matrix']]" level="ERROR">
             <message>A FedRAMP SSP must have a Separation of Duties Matrix attached.</message>
         </expect>
     </constraints>

--- a/src/validations/constraints/unit-tests/has-configuration-management-plan-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-configuration-management-plan-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-configuration-management-plan
+  description: >-
+    This test case validates the behavior of constraint
+    has-configuration-management-plan
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-configuration-management-plan
+      result: fail

--- a/src/validations/constraints/unit-tests/has-configuration-management-plan-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-configuration-management-plan-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-configuration-management-plan
+  description: >-
+    This test case validates the behavior of constraint
+    has-configuration-management-plan
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-configuration-management-plan
+      result: pass

--- a/src/validations/constraints/unit-tests/has-incident-response-plan-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-incident-response-plan-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-incident-response-plan
+  description: >-
+    This test case validates the behavior of constraint
+    has-incident-response-plan
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-incident-response-plan
+      result: fail

--- a/src/validations/constraints/unit-tests/has-incident-response-plan-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-incident-response-plan-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-incident-response-plan
+  description: >-
+    This test case validates the behavior of constraint
+    has-incident-response-plan
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-incident-response-plan
+      result: pass

--- a/src/validations/constraints/unit-tests/has-information-system-contingency-plan-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-information-system-contingency-plan-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-information-system-contingency-plan
+  description: >-
+    This test case validates the behavior of constraint
+    has-information-system-contingency-plan
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-information-system-contingency-plan
+      result: fail

--- a/src/validations/constraints/unit-tests/has-information-system-contingency-plan-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-information-system-contingency-plan-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-information-system-contingency-plan
+  description: >-
+    This test case validates the behavior of constraint
+    has-information-system-contingency-plan
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-information-system-contingency-plan
+      result: pass

--- a/src/validations/constraints/unit-tests/has-rules-of-behavior-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-rules-of-behavior-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-rules-of-behavior
+  description: This test case validates the behavior of constraint has-rules-of-behavior
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-rules-of-behavior
+      result: fail

--- a/src/validations/constraints/unit-tests/has-rules-of-behavior-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-rules-of-behavior-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-rules-of-behavior
+  description: This test case validates the behavior of constraint has-rules-of-behavior
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-rules-of-behavior
+      result: pass

--- a/src/validations/constraints/unit-tests/has-separation-of-duties-matrix-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-separation-of-duties-matrix-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-separation-of-duties-matrix
+  description: >-
+    This test case validates the behavior of constraint
+    has-separation-of-duties-matrix
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-separation-of-duties-matrix
+      result: fail

--- a/src/validations/constraints/unit-tests/has-separation-of-duties-matrix-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-separation-of-duties-matrix-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-separation-of-duties-matrix
+  description: >-
+    This test case validates the behavior of constraint
+    has-separation-of-duties-matrix
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-separation-of-duties-matrix
+      result: pass

--- a/src/validations/constraints/unit-tests/has-user-guide-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-user-guide-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-user-guide
+  description: This test case validates the behavior of constraint has-user-guide
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-user-guide
+      result: fail

--- a/src/validations/constraints/unit-tests/has-user-guide-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-user-guide-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-user-guide
+  description: This test case validates the behavior of constraint has-user-guide
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-user-guide
+      result: pass


### PR DESCRIPTION
# Committer Notes

### Description 
Added back-matter 'has' constraints and tests for each of the constraints. These should be added as they are part of the effort write all of the constraints from the constraint tracker.

### Changes 
- Added constraints has-user-guide, has-rules-of-behavior, has-information-system-contingency-plan, has-configuration-management-plan, has-incident-response-plan, has-separation-of-duties-matrix to fedramp-external-constraints.xml.  
- Added pass and fail yaml tests for all of the above constraints.  
- Edited ssp-all-VALID to ensure all constraints pass correctly.  

{Please provide a description of what this PR accomplishes. Be sure to reference any issues addressed. If the PR is a work-in-progress submitted for early review, please submit the PR as a draft PR using the "Draft pull request" dropdown.}

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
