### PR TITLE
Add system-characteristics 'categorization-has' constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -21,6 +21,10 @@ Examples:
   | attachment-type-PASS.yaml |
   | authorization-type-FAIL.yaml |
   | authorization-type-PASS.yaml |
+  | categorization-has-correct-system-attribute-FAIL.yaml |
+  | categorization-has-correct-system-attribute-PASS.yaml |
+  | categorization-has-information-type-id-FAIL.yaml |
+  | categorization-has-information-type-id-PASS.yaml |
   | cloud-service-model-FAIL.yaml |
   | cloud-service-model-PASS.yaml |
   | component-type-FAIL.yaml |
@@ -91,6 +95,8 @@ Examples:
   | address-type |
   | attachment-type |
   | authorization-type |
+  | categorization-has-correct-system-attribute |
+  | categorization-has-information-type-id |
   | cloud-service-model |
   | component-type |
   | control-implementation-status |

--- a/src/validations/constraints/content/ssp-all-INVALID.xml
+++ b/src/validations/constraints/content/ssp-all-INVALID.xml
@@ -72,7 +72,7 @@
           <p>Contains sensitive financial data related to organizational operations.</p>
         </description>
         <categorization system="https://unsupported-system.com">
-          <information-type-id>C.2.8.12</information-type-id>
+          <!-- Removed information-type-id to ensure that categorization-has-information-type-id fails correctly. -->
         </categorization>
         <confidentiality-impact>
           <base>high</base>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -56,6 +56,12 @@
             <expect id="has-separation-of-duties-matrix" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'separation-of-duties-matrix']]" level="ERROR">
                 <message>A FedRAMP SSP must have a Separation of Duties Matrix attached.</message>
             </expect>
+            <expect id="categorization-has-correct-system-attribute" target="//system-characteristics" test="system-information/information-type/categorization/@system eq 'https://doi.org/10.6028/NIST.SP.800-60v2r1'" level="ERROR">
+            <message>A FedRAMP SSP information-type categorization lacks a correct system attribute. The correct value is "https://doi.org/10.6028/NIST.SP.800-60v2r1".</message>
+            </expect>
+            <expect id="categorization-has-information-type-id" target="//system-characteristics" test="system-information/information-type/categorization/information-type-id" level="ERROR">
+            <message>A FedRAMP SSP information type categorization must have at least one information type identifier.</message>
+            </expect>
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -56,8 +56,8 @@
             <expect id="has-separation-of-duties-matrix" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'separation-of-duties-matrix']]" level="ERROR">
                 <message>A FedRAMP SSP must have a Separation of Duties Matrix attached.</message>
             </expect>
-            <expect id="categorization-has-correct-system-attribute" target="//system-characteristics" test="system-information/information-type/categorization/@system eq 'https://doi.org/10.6028/NIST.SP.800-60v2r1'" level="ERROR">
-            <message>A FedRAMP SSP information-type categorization lacks a correct system attribute. The correct value is "https://doi.org/10.6028/NIST.SP.800-60v2r1".</message>
+            <expect id="categorization-has-correct-system-attribute" target="./system-characteristics" test="system-information/information-type/categorization/@system eq 'https://doi.org/10.6028/NIST.SP.800-60v2r1'" level="ERROR">
+            <message>A FedRAMP SSP information-type categorization requires a correct system attribute. FedRAMP only supports the system value 'https://doi.org/10.6028/NIST.SP.800-60v2r1'.</message>
             </expect>
             <expect id="categorization-has-information-type-id" target="//system-characteristics" test="system-information/information-type/categorization/information-type-id" level="ERROR">
             <message>A FedRAMP SSP information type categorization must have at least one information type identifier.</message>

--- a/src/validations/constraints/unit-tests/categorization-has-correct-system-attribute-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/categorization-has-correct-system-attribute-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for categorization-has-correct-system-attribute
+  description: >-
+    This test case validates the behavior of constraint
+    categorization-has-correct-system-attribute
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: categorization-has-correct-system-attribute
+      result: fail

--- a/src/validations/constraints/unit-tests/categorization-has-correct-system-attribute-PASS.yaml
+++ b/src/validations/constraints/unit-tests/categorization-has-correct-system-attribute-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for categorization-has-correct-system-attribute
+  description: >-
+    This test case validates the behavior of constraint
+    categorization-has-correct-system-attribute
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: categorization-has-correct-system-attribute
+      result: pass

--- a/src/validations/constraints/unit-tests/categorization-has-information-type-id-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/categorization-has-information-type-id-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for categorization-has-information-type-id
+  description: >-
+    This test case validates the behavior of constraint
+    categorization-has-information-type-id
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: categorization-has-information-type-id
+      result: fail

--- a/src/validations/constraints/unit-tests/categorization-has-information-type-id-PASS.yaml
+++ b/src/validations/constraints/unit-tests/categorization-has-information-type-id-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for categorization-has-information-type-id
+  description: >-
+    This test case validates the behavior of constraint
+    categorization-has-information-type-id
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: categorization-has-information-type-id
+      result: pass


### PR DESCRIPTION
# Committer Notes

### Description 
Added system-characteristics 'categorization-has' constraints and tests for each of the constraints. These should be added as they are part of the effort write all of the constraints from the constraint tracker.

### Changes
- Added constraints categorization-has-correct-system-attribute, categorization-has-information-type-id to fedramp-external-constraints.xml.  
- Added pass and fail yaml tests for all of the above constraints.  
- Edited ssp-all-INVALID.xml to ensure all constraints fail correctly.  

{Please provide a description of what this PR accomplishes. Be sure to reference any issues addressed. If the PR is a work-in-progress submitted for early review, please submit the PR as a draft PR using the "Draft pull request" dropdown.}

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
