### PR TITLE
handle base64 filename and media type constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -47,6 +47,10 @@ Examples:
   | interconnection-security-PASS.yaml |
   | privilege-level-FAIL.yaml |
   | privilege-level-PASS.yaml |
+  | resource-base64-available-filename-FAIL.yaml |
+  | resource-base64-available-filename-PASS.yaml |
+  | resource-base64-available-media-type-FAIL.yaml |
+  | resource-base64-available-media-type-PASS.yaml |
   | resource-has-base64-or-rlink-FAIL.yaml |
   | resource-has-base64-or-rlink-PASS.yaml |
   | resource-has-title-FAIL.yaml |
@@ -89,6 +93,8 @@ Examples:
   | interconnection-security |
   | privilege-level |
   | prop-response-point-has-cardinality-one |
+  | resource-base64-available-filename |
+  | resource-base64-available-media-type |
   | resource-has-base64-or-rlink |
   | resource-has-title |
   | scan-type |

--- a/src/validations/constraints/content/ssp-all-INVALID.xml
+++ b/src/validations/constraints/content/ssp-all-INVALID.xml
@@ -203,6 +203,7 @@
       </description>
       <prop name="type" value="unsupported-type" ns="https://fedramp.gov/ns/oscal"/>
       <!-- There is no <rlink/> to purposefully to trigger an error for negative testing. -->
+      <base64>eyJhd2Vzb21lIjoic2F1Y2UifQ==</base64>
     </resource>
   </back-matter>
 </system-security-plan>

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -205,5 +205,21 @@
       <prop name="type" value="policy" ns="https://fedramp.gov/ns/oscal"/>
       <rlink href="https://example.com/policies/access-control.pdf"/>
     </resource>
+    <resource uuid="eeeeeeee-0000-4000-9000-00000000000e">
+      <title>Access Control Policy</title>
+      <description>
+        <p>Detailed access control policy document</p>
+      </description>
+      <prop name="type" value="policy" ns="https://fedramp.gov/ns/oscal"/>
+      <rlink href="https://example.com/policies/access-control.pdf"/>
+    </resource>
+    <resource uuid="ffffffff-0000-4000-9000-00000000000f">
+    <title>System Diagram</title>
+    <description>
+      <p>High-level diagram of the system architecture</p>
+    </description>
+    <prop name="type" value="diagram" ns="https://fedramp.gov/ns/oscal"/>
+    <base64 filename="sauce.json" media-type="application/json">eyJhd2Vzb21lIjoic2F1Y2UifQ==</base64>
+  </resource>
   </back-matter>
 </system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -57,4 +57,23 @@
         </expect>
     </constraints>
 </context>
+
+
+   <context>
+        <metapath target="//back-matter/resource"/>
+        <constraints>
+            <expect id="resource-base64-available-filename" 
+                    target="base64"
+                    test="@filename"
+                    level="WARNING">
+                <message>This base64 lacks a filename attribute.</message>
+            </expect>
+            <expect id="resource-base64-available-media-type" 
+                    target="base64"
+                    test="@media-type"
+                    level="WARNING">
+                <message>This base64 lacks a media-type attribute.</message>
+            </expect>
+        </constraints>
+    </context>
 </metaschema-meta-constraints>

--- a/src/validations/constraints/unit-tests/resource-base64-available-filename-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/resource-base64-available-filename-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for resource-base64-available-filename
+  description: >-
+    This test case validates the behavior of constraint
+    resource-base64-available-filename
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: resource-base64-available-filename
+      result: fail

--- a/src/validations/constraints/unit-tests/resource-base64-available-filename-PASS.yaml
+++ b/src/validations/constraints/unit-tests/resource-base64-available-filename-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for resource-base64-available-filename
+  description: >-
+    This test case validates the behavior of constraint
+    resource-base64-available-filename
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: resource-base64-available-filename
+      result: pass

--- a/src/validations/constraints/unit-tests/resource-base64-available-media-type-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/resource-base64-available-media-type-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for resource-base64-available-media-type
+  description: >-
+    This test case validates the behavior of constraint
+    resource-base64-available-media-type
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: resource-base64-available-media-type
+      result: fail

--- a/src/validations/constraints/unit-tests/resource-base64-available-media-type-PASS.yaml
+++ b/src/validations/constraints/unit-tests/resource-base64-available-media-type-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for resource-base64-available-media-type
+  description: >-
+    This test case validates the behavior of constraint
+    resource-base64-available-media-type
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: resource-base64-available-media-type
+      result: pass


### PR DESCRIPTION
# Committer Notes

introduce two constraints for //backmatter/resource/base64 node 
check for filename and file type

Making this a draft for now so we can discuss if we would like to verify that we have a valid media type, but it works for just assuring that something is there.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
