### PR TITLE
Actions: tighten when docker build runs and how

### DIFF
--- a/.github/workflows/content-artifacts.yml
+++ b/.github/workflows/content-artifacts.yml
@@ -21,6 +21,8 @@ env:
   REGISTRY: ghcr.io
   # Docs: github.com/docker/metadata-action/?tab=readme-ov-file#typesha
   DOCKER_METADATA_PR_HEAD_SHA: true
+  # https://github.com/docker/metadata-action?tab=readme-ov-file#annotations
+  DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 jobs:
   validate-and-publish-content:
     name: Content Validation Checking, Conversion and Validation

--- a/.github/workflows/content-artifacts.yml
+++ b/.github/workflows/content-artifacts.yml
@@ -107,7 +107,7 @@ jobs:
             org.opencontainers.image.title="FedRAMP Validation Tools"
             org.opencontainers.image.description="FedRAMP's tools for validating OSCAL data"
             org.opencontainers.image.licenses="CC0-1.0"
-      - if: github.repository == env.HOME_REPO && (github.ref == 'refs/heads/master' || 'refs/heads/feature/**')
+      - if: github.repository == env.HOME_REPO && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/feature/**')
         name: Container image registry push
         id: image_registry_push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
@@ -119,7 +119,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - if: github.repository == env.HOME_REPO && (github.ref == 'refs/heads/master' || 'refs/heads/feature/**')
+      - if: github.repository == env.HOME_REPO && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/feature/**')
         name: Container image push attestations
         uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c
         with:

--- a/.github/workflows/content-artifacts.yml
+++ b/.github/workflows/content-artifacts.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths:
+      - Dockerfile
       - "src/**"
       - "oscal"
   pull_request:
@@ -12,6 +13,7 @@ on:
   workflow_dispatch:
     branches:
       - master
+      - 'feature**'
 name: Process Content
 env:
   HOME_REPO: GSA/fedramp-automation
@@ -62,22 +64,26 @@ jobs:
           commit_user_name: OSCAL GitHub Actions Bot
           commit_user_email: oscal@nist.gov
           commit_author: OSCAL GitHub Actions Bot <oscal@nist.gov>
-      - name: Container image QEMU setup for cross-arch builds
+      - if: github.repository == env.HOME_REPO
+        name: Container image QEMU setup for cross-arch builds
         id: image_setup_qemu
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
-      - name: Container image buildx setup for cross-arch builds
+      - if: github.repository == env.HOME_REPO
+        name: Container image buildx setup for cross-arch builds
         id: image_setup_buildx
         with:
           platforms: linux/amd64,linux/arm64 
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db
-      - name: Container image login
+      - if: github.repository == env.HOME_REPO
+        name: Container image login
         id: image_login
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Container image metadata and tag generation
+      - if: github.repository == env.HOME_REPO
+        name: Container image metadata and tag generation
         id: image_metadata
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
         with:
@@ -91,7 +97,7 @@ jobs:
           # For now, do not auto-tag latest, maintainers will decided what is
           # release-worthy.
           flavor: |
-            latest=false
+            latest=true
           annotations:
             maintainers="FedRAMP Automation Team <oscal@fedramp.gov>"
             org.opencontainers.image.authors="FedRAMP Automation Team <oscal@fedramp.gov>"
@@ -101,7 +107,8 @@ jobs:
             org.opencontainers.image.title="FedRAMP Validation Tools"
             org.opencontainers.image.description="FedRAMP's tools for validating OSCAL data"
             org.opencontainers.image.licenses="CC0-1.0"
-      - name: Container image registry push
+      - if: github.repository == env.HOME_REPO && (github.ref == 'refs/heads/master' || 'refs/heads/feature/**')
+        name: Container image registry push
         id: image_registry_push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
@@ -112,7 +119,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Container image push attestations
+      - if: github.repository == env.HOME_REPO && (github.ref == 'refs/heads/master' || 'refs/heads/feature/**')
+        name: Container image push attestations
         uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}

--- a/.github/workflows/content-artifacts.yml
+++ b/.github/workflows/content-artifacts.yml
@@ -107,7 +107,7 @@ jobs:
             org.opencontainers.image.title="FedRAMP Validation Tools"
             org.opencontainers.image.description="FedRAMP's tools for validating OSCAL data"
             org.opencontainers.image.licenses="CC0-1.0"
-      - if: github.repository == env.HOME_REPO && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/feature/**')
+      - if: github.repository == env.HOME_REPO && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/feature'))
         name: Container image registry push
         id: image_registry_push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
@@ -119,7 +119,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - if: github.repository == env.HOME_REPO && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/feature/**')
+      - if: github.repository == env.HOME_REPO && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/feature'))
         name: Container image push attestations
         uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c
         with:


### PR DESCRIPTION
# Committer Notes

- We do not want to fails build when staff and community make fork PRs.
- We want to make sure the latest feature branch is tagged and deployed for now, stop push PR container builds before merge.
- Improve metadata on GHCR versions page (maybe? still unclear why it doesn't show)
- 
### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
