### PR TITLE
Update SSP metadata role constraints (#676)

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -69,6 +69,10 @@ Examples:
   | response-point-PASS.yaml |
   | role-defined-system-owner-FAIL.yaml |
   | role-defined-system-owner-PASS.yaml |
+  | role-defined-authorizing-official-poc-FAIL.yaml |
+  | role-defined-authorizing-official-poc-PASS.yaml |
+  | role-defined-information-system-security-officer-FAIL.yaml |
+  | role-defined-information-system-security-officer-PASS.yaml |
   | scan-type-FAIL.yaml |
   | scan-type-PASS.yaml |
   | user-type-FAIL.yaml |
@@ -115,6 +119,8 @@ Examples:
   | resource-has-base64-or-rlink |
   | resource-has-title |
   | role-defined-system-owner |
+  | role-defined-authorizing-official-poc |
+  | role-defined-information-system-security-officer |
   | scan-type |
   | user-type |
 #END_DYNAMIC_CONSTRAINT_IDS

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -26,6 +26,12 @@
     <role id="system-owner">
       <title>System Owner</title>
     </role>
+     <role id="authorizing-official-poc">
+       <title>Authorizing Official Point of Contact</title>
+     </role>
+     <role id="information-system-security-officer">
+       <title>Information System Security Officer (or Equivalent)</title>
+     </role>
 
     <location uuid="11111112-0000-4000-9001-000000000009">
       <address >

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -73,6 +73,12 @@
             <expect id="role-defined-system-owner" target="." test="role[@id eq 'system-owner']" level="ERROR">
                 <message>A FedRAMP SSP must define the system owner role.</message>
             </expect>
+            <expect id="role-defined-authorizing-official-poc" target="." test="role[@id eq 'authorizing-official-poc']" level="ERROR">
+                <message>A FedRAMP SSP must define a role for the point of contact for an authorizing official.</message>
+            </expect>
+            <expect id="role-defined-information-system-security-officer" target="." test="role[@id eq 'information-system-security-officer']" level="ERROR">
+                <message>A FedRAMP SSP must define a role for the point of contact for an information system security officer.</message>
+            </expect>
         </constraints>
     </context>
     <context>
@@ -80,12 +86,6 @@
         <constraints>
             <expect id="missing-response-components" target="implemented-requirement" test="count(./by-component) gt 0">
                 <message>Each implemented requirement must have at least one by-component reference to the source component implementing it.</message>
-            </expect>
-            <expect id="role-defined-authorizing-official-poc" target="." test="role[@id eq 'authorizing-official-poc']" level="ERROR">
-                <message>SSP metadata must have the authorizing official POC role.</message>
-            </expect>
-            <expect id="role-defined-information-system-security-officer" target="." test="role[@id eq 'information-system-security-officer']" level="ERROR">
-                <message>SSP metadata must have the information system security officer POC role.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -78,9 +78,15 @@
     <context>
         <metapath target="/system-security-plan/control-implementation"/>
         <constraints>
-        <expect id="missing-response-components" target="implemented-requirement" test="count(./by-component) gt 0">
-            <message>Each implemented requirement must have at least one by-component reference to the source component implementing it.</message>
-        </expect>
+            <expect id="missing-response-components" target="implemented-requirement" test="count(./by-component) gt 0">
+                <message>Each implemented requirement must have at least one by-component reference to the source component implementing it.</message>
+            </expect>
+            <expect id="role-defined-authorizing-official-poc" target="." test="role[@id eq 'authorizing-official-poc']" level="ERROR">
+                <message>SSP metadata must have the authorizing official POC role.</message>
+            </expect>
+            <expect id="role-defined-information-system-security-officer" target="." test="role[@id eq 'information-system-security-officer']" level="ERROR">
+                <message>SSP metadata must have the information system security officer POC role.</message>
+            </expect>
         </constraints>
     </context>
 </metaschema-meta-constraints>

--- a/src/validations/constraints/unit-tests/role-defined-authorizing-official-poc-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/role-defined-authorizing-official-poc-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid role-defined-authorizing-official-poc constraint unit test.
+test-case:
+  name: The invalid role-defined-authorizing-official-poc constraint unit test.
+  description: Test that SSP metadata does not contain the authorizing-official-poc role.
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+  - constraint-id: role-defined-authorizing-official-poc
+    result: fail

--- a/src/validations/constraints/unit-tests/role-defined-authorizing-official-poc-PASS.yaml
+++ b/src/validations/constraints/unit-tests/role-defined-authorizing-official-poc-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid role-defined-authorizing-official-poc constraint unit test.
+test-case:
+  name: The valid role-defined-authorizing-official-poc constraint unit test.
+  description: Test that SSP metadata contains the authorizing-official-poc role.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+  - constraint-id: role-defined-authorizing-official-poc
+    result: pass

--- a/src/validations/constraints/unit-tests/role-defined-information-system-security-officer-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/role-defined-information-system-security-officer-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid role-defined-information-system-security-officer constraint unit test.
+test-case:
+  name: The invalid role-defined-information-system-security-officer constraint unit test.
+  description: Test that SSP metadata does not contain the information-system-security-officer role.
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+  - constraint-id: role-defined-information-system-security-officer
+    result: fail

--- a/src/validations/constraints/unit-tests/role-defined-information-system-security-officer-PASS.yaml
+++ b/src/validations/constraints/unit-tests/role-defined-information-system-security-officer-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid role-defined-information-system-security-officer constraint unit test.
+test-case:
+  name: The valid role-defined-information-system-security-officer constraint unit test.
+  description: Test that SSP metadata contains the information-system-security-officer role.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+  - constraint-id: role-defined-information-system-security-officer
+    result: pass


### PR DESCRIPTION
# Committer Notes

Removed the system-poc-other constraint (#676).

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
