### PR TITLE
[DONOTMERGE] Add SSP metadata system-poc-technical role

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -77,6 +77,8 @@ Examples:
   | role-defined-authorizing-official-poc-PASS.yaml |
   | role-defined-information-system-security-officer-FAIL.yaml |
   | role-defined-information-system-security-officer-PASS.yaml |
+  | role-defined-system-poc-technical-FAIL.yaml |
+  | role-defined-system-poc-technical-PASS.yaml |
   | scan-type-FAIL.yaml |
   | scan-type-PASS.yaml |
   | user-type-FAIL.yaml |
@@ -127,6 +129,7 @@ Examples:
   | role-defined-system-owner |
   | role-defined-authorizing-official-poc |
   | role-defined-information-system-security-officer |
+  | role-defined-system-poc-technical |
   | scan-type |
   | user-type |
 #END_DYNAMIC_CONSTRAINT_IDS

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -32,6 +32,9 @@
      <role id="information-system-security-officer">
        <title>Information System Security Officer (or Equivalent)</title>
      </role>
+    <role id="system-poc-technical">
+      <title>Technical System Point of Contact</title>
+    </role>
 
     <location uuid="11111112-0000-4000-9001-000000000009">
       <address >

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -85,6 +85,9 @@
             <expect id="role-defined-information-system-security-officer" target="." test="role[@id eq 'information-system-security-officer']" level="ERROR">
                 <message>A FedRAMP SSP must define a role for the point of contact for an information system security officer.</message>
             </expect>
+            <expect id="role-defined-system-poc-technical" target="." test="role[@id eq 'system-poc-technical']" level="ERROR">
+                <message>SSP metadata must have the system technical POC role.</message>
+            </expect>            
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -86,7 +86,7 @@
                 <message>A FedRAMP SSP must define a role for the point of contact for an information system security officer.</message>
             </expect>
             <expect id="role-defined-system-poc-technical" target="." test="role[@id eq 'system-poc-technical']" level="ERROR">
-                <message>SSP metadata must have the system technical POC role.</message>
+                <message>A FedRAMP SSP must define the system technical POC role.</message>
             </expect>            
         </constraints>
     </context>

--- a/src/validations/constraints/unit-tests/role-defined-system-poc-technical-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/role-defined-system-poc-technical-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid role-defined-system-poc-technical constraint unit test.
+test-case:
+  name: The invalid role-defined-system-poc-technical constraint unit test.
+  description: Test that SSP metadata does not contain the system-poc-technical role.
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+  - constraint-id: role-defined-system-poc-technical
+    result: fail

--- a/src/validations/constraints/unit-tests/role-defined-system-poc-technical-PASS.yaml
+++ b/src/validations/constraints/unit-tests/role-defined-system-poc-technical-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid role-defined-system-poc-technical constraint unit test.
+test-case:
+  name: The valid role-defined-system-poc-technical constraint unit test.
+  description: Test that SSP metadata contains the system-poc-technical role.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+  - constraint-id: role-defined-system-poc-technical
+    result: pass


### PR DESCRIPTION
# Committer Notes

I'm not sure about this `system-poc-technical` role. I couldn't find in anywhere in documentation.
I found `<responsible-party role-id="system-poc-technical">`, but not `<role id="system-poc-technical">`.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
