### PR TITLE
Add system-characteristics 'has-assurance-level' constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -43,8 +43,14 @@ Examples:
   | data-center-us-PASS.yaml |
   | deployment-mode-FAIL.yaml |
   | deployment-mode-PASS.yaml |
+  | has-authenticator-assurance-level-FAIL.yaml |
+  | has-authenticator-assurance-level-PASS.yaml |
   | has-configuration-management-plan-FAIL.yaml |
   | has-configuration-management-plan-PASS.yaml |
+  | has-federation-assurance-level-FAIL.yaml |
+  | has-federation-assurance-level-PASS.yaml |
+  | has-identity-assurance-level-FAIL.yaml |
+  | has-identity-assurance-level-PASS.yaml |
   | has-incident-response-plan-FAIL.yaml |
   | has-incident-response-plan-PASS.yaml |
   | has-information-system-contingency-plan-FAIL.yaml |
@@ -71,12 +77,12 @@ Examples:
   | resource-has-title-PASS.yaml |
   | response-point-FAIL.yaml |
   | response-point-PASS.yaml |
-  | role-defined-system-owner-FAIL.yaml |
-  | role-defined-system-owner-PASS.yaml |
   | role-defined-authorizing-official-poc-FAIL.yaml |
   | role-defined-authorizing-official-poc-PASS.yaml |
   | role-defined-information-system-security-officer-FAIL.yaml |
   | role-defined-information-system-security-officer-PASS.yaml |
+  | role-defined-system-owner-FAIL.yaml |
+  | role-defined-system-owner-PASS.yaml |
   | scan-type-FAIL.yaml |
   | scan-type-PASS.yaml |
   | user-type-FAIL.yaml |
@@ -110,7 +116,10 @@ Examples:
   | data-center-country-code |
   | data-center-primary |
   | deployment-model |
+  | has-authenticator-assurance-level |
   | has-configuration-management-plan |
+  | has-federation-assurance-level |
+  | has-identity-assurance-level |
   | has-incident-response-plan |
   | has-information-system-contingency-plan |
   | has-rules-of-behavior |
@@ -124,9 +133,9 @@ Examples:
   | prop-response-point-has-cardinality-one |
   | resource-has-base64-or-rlink |
   | resource-has-title |
-  | role-defined-system-owner |
   | role-defined-authorizing-official-poc |
   | role-defined-information-system-security-officer |
+  | role-defined-system-owner |
   | scan-type |
   | user-type |
 #END_DYNAMIC_CONSTRAINT_IDS

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -78,6 +78,9 @@
     <prop name='cloud-deployment-model' value='government-only-cloud' ns="https://fedramp.gov/ns/oscal"/>
     <prop name='cloud-service-model' value='other' ns="https://fedramp.gov/ns/oscal"/>
     <prop name='authorization-type' value='fedramp-agency' ns="https://fedramp.gov/ns/oscal"/>
+    <prop name="identity-assurance-level" value="2"/>
+    <prop name="authenticator-assurance-level" value="2"/>
+    <prop name="federation-assurance-level" value="2"/>
     <security-sensitivity-level>moderate</security-sensitivity-level>
     <system-information>
       <information-type  uuid="33333333-0000-4000-9000-000000000003">

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -63,13 +63,13 @@
             <message>A FedRAMP SSP information type categorization must have at least one information type identifier.</message>
             </expect>
             <expect id="has-identity-assurance-level" target="./system-characteristics" test="prop[@name eq 'identity-assurance-level']" level="INFORMATIONAL">
-            <message>A FedRAMP SSP may have a Digital Identity Determination identity assurance level property.</message>
+            <message>This FedRAMP SSP does define its NIST SP 800-63 identity assurance level (IAL).</message>
             </expect>
             <expect id="has-authenticator-assurance-level" target="./system-characteristics" test="prop[@name eq 'authenticator-assurance-level']" level="INFORMATIONAL">
-            <message>A FedRAMP SSP may have a Digital Identity Determination authenticator assurance level property.</message>
+            <message>This FedRAMP SSP does define its NIST SP 800-63 authenticator assurance level (AAL).</message>
             </expect>
             <expect id="has-federation-assurance-level" target="./system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
-            <message>A FedRAMP SSP may have a Digital Identity Determination federation assurance level property.</message>
+            <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (IAL).</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -59,8 +59,17 @@
             <expect id="categorization-has-correct-system-attribute" target="./system-characteristics" test="system-information/information-type/categorization/@system eq 'https://doi.org/10.6028/NIST.SP.800-60v2r1'" level="ERROR">
             <message>A FedRAMP SSP information-type categorization requires a correct system attribute. FedRAMP only supports the system value 'https://doi.org/10.6028/NIST.SP.800-60v2r1'.</message>
             </expect>
-            <expect id="categorization-has-information-type-id" target="//system-characteristics" test="system-information/information-type/categorization/information-type-id" level="ERROR">
+            <expect id="categorization-has-information-type-id" target="./system-characteristics" test="system-information/information-type/categorization/information-type-id" level="ERROR">
             <message>A FedRAMP SSP information type categorization must have at least one information type identifier.</message>
+            </expect>
+            <expect id="has-identity-assurance-level" target="./system-characteristics" test="prop[@name eq 'identity-assurance-level']" level="INFORMATIONAL">
+            <message>A FedRAMP SSP may have a Digital Identity Determination identity assurance level property.</message>
+            </expect>
+            <expect id="has-authenticator-assurance-level" target="./system-characteristics" test="prop[@name eq 'authenticator-assurance-level']" level="INFORMATIONAL">
+            <message>A FedRAMP SSP may have a Digital Identity Determination authenticator assurance level property.</message>
+            </expect>
+            <expect id="has-federation-assurance-level" target="./system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
+            <message>A FedRAMP SSP may have a Digital Identity Determination federation assurance level property.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/unit-tests/has-authenticator-assurance-level-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authenticator-assurance-level-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-authenticator-assurance-level
+  description: >-
+    This test case validates the behavior of constraint
+    has-authenticator-assurance-level
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-authenticator-assurance-level
+      result: fail

--- a/src/validations/constraints/unit-tests/has-authenticator-assurance-level-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authenticator-assurance-level-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-authenticator-assurance-level
+  description: >-
+    This test case validates the behavior of constraint
+    has-authenticator-assurance-level
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-authenticator-assurance-level
+      result: pass

--- a/src/validations/constraints/unit-tests/has-federation-assurance-level-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-federation-assurance-level-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-federation-assurance-level
+  description: >-
+    This test case validates the behavior of constraint
+    has-federation-assurance-level
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-federation-assurance-level
+      result: fail

--- a/src/validations/constraints/unit-tests/has-federation-assurance-level-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-federation-assurance-level-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-federation-assurance-level
+  description: >-
+    This test case validates the behavior of constraint
+    has-federation-assurance-level
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-federation-assurance-level
+      result: pass

--- a/src/validations/constraints/unit-tests/has-identity-assurance-level-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-identity-assurance-level-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-identity-assurance-level
+  description: >-
+    This test case validates the behavior of constraint
+    has-identity-assurance-level
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-identity-assurance-level
+      result: fail

--- a/src/validations/constraints/unit-tests/has-identity-assurance-level-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-identity-assurance-level-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-identity-assurance-level
+  description: >-
+    This test case validates the behavior of constraint
+    has-identity-assurance-level
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-identity-assurance-level
+      result: pass


### PR DESCRIPTION
# Committer Notes
{Please provide a description of what this PR accomplishes. Be sure to reference any issues addressed. If the PR is a work-in-progress submitted for early review, please submit the PR as a draft PR using the "Draft pull request" dropdown.}

### Description
Added system-characteristics 'has-assurance-level' constraints and tests for each of the constraints. These should be added as they are part of the effort write all of the constraints from the constraint tracker.  

### Changes
- Added constraints has-identity-assurance-level, has-authenticator-assurance-level, and has-federation-assurance-level to fedramp-external-constraints.xml.  
- Added pass and fail yaml tests for all of the above constraints.  
- Edited ssp-all-VALID.xml to ensure all constraints pass correctly.  

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~~
~~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
