### PR TITLE
Add system-characteristics 'has-authorization-boundary' constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -45,6 +45,20 @@ Examples:
   | deployment-mode-PASS.yaml |
   | has-authenticator-assurance-level-FAIL.yaml |
   | has-authenticator-assurance-level-PASS.yaml |
+  | has-authorization-boundary-diagram-FAIL.yaml |
+  | has-authorization-boundary-diagram-PASS.yaml |
+  | has-authorization-boundary-diagram-caption-FAIL.yaml |
+  | has-authorization-boundary-diagram-caption-PASS.yaml |
+  | has-authorization-boundary-diagram-description-FAIL.yaml |
+  | has-authorization-boundary-diagram-description-PASS.yaml |
+  | has-authorization-boundary-diagram-link-FAIL.yaml |
+  | has-authorization-boundary-diagram-link-PASS.yaml |
+  | has-authorization-boundary-diagram-link-rel-FAIL.yaml |
+  | has-authorization-boundary-diagram-link-rel-PASS.yaml |
+  | has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml |
+  | has-authorization-boundary-diagram-link-rel-allowed-value-PASS.yaml |
+  | has-authorization-boundary-diagram-uuid-FAIL.yaml |
+  | has-authorization-boundary-diagram-uuid-PASS.yaml |
   | has-configuration-management-plan-FAIL.yaml |
   | has-configuration-management-plan-PASS.yaml |
   | has-federation-assurance-level-FAIL.yaml |
@@ -117,6 +131,13 @@ Examples:
   | data-center-primary |
   | deployment-model |
   | has-authenticator-assurance-level |
+  | has-authorization-boundary-diagram |
+  | has-authorization-boundary-diagram-caption |
+  | has-authorization-boundary-diagram-description |
+  | has-authorization-boundary-diagram-link |
+  | has-authorization-boundary-diagram-link-rel |
+  | has-authorization-boundary-diagram-link-rel-allowed-value |
+  | has-authorization-boundary-diagram-uuid |
   | has-configuration-management-plan |
   | has-federation-assurance-level |
   | has-identity-assurance-level |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -112,6 +112,13 @@
       <description>
         <p>The authorization boundary includes all components within the main data center and the disaster recovery site.</p>
       </description>
+      <diagram uuid="dbf46c27-52a9-49c4-beb6-b6399cd75497">
+            <description>
+               <p>A diagram-specific explanation.</p>
+            </description>
+            <link href="#d2eb3c18-6754-4e3a-a933-03d289e3fad5" rel="diagram"/>
+            <caption>Authorization Boundary Diagram</caption>
+         </diagram>
     </authorization-boundary>
   </system-characteristics>
   

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -57,40 +57,40 @@
                 <message>A FedRAMP SSP must have a Separation of Duties Matrix attached.</message>
             </expect>
             <expect id="categorization-has-correct-system-attribute" target="./system-characteristics" test="system-information/information-type/categorization/@system eq 'https://doi.org/10.6028/NIST.SP.800-60v2r1'" level="ERROR">
-            <message>A FedRAMP SSP information-type categorization requires a correct system attribute. FedRAMP only supports the system value 'https://doi.org/10.6028/NIST.SP.800-60v2r1'.</message>
+                <message>A FedRAMP SSP information-type categorization requires a correct system attribute. FedRAMP only supports the system value 'https://doi.org/10.6028/NIST.SP.800-60v2r1'.</message>
             </expect>
             <expect id="categorization-has-information-type-id" target="./system-characteristics" test="system-information/information-type/categorization/information-type-id" level="ERROR">
-            <message>A FedRAMP SSP information type categorization must have at least one information type identifier.</message>
+                <message>A FedRAMP SSP information type categorization must have at least one information type identifier.</message>
             </expect>
             <expect id="has-identity-assurance-level" target="./system-characteristics" test="prop[@name eq 'identity-assurance-level']" level="INFORMATIONAL">
-            <message>This FedRAMP SSP does define its NIST SP 800-63 identity assurance level (IAL).</message>
+                <message>This FedRAMP SSP does define its NIST SP 800-63 identity assurance level (IAL).</message>
             </expect>
             <expect id="has-authenticator-assurance-level" target="./system-characteristics" test="prop[@name eq 'authenticator-assurance-level']" level="INFORMATIONAL">
-            <message>This FedRAMP SSP does define its NIST SP 800-63 authenticator assurance level (AAL).</message>
+                <message>This FedRAMP SSP does define its NIST SP 800-63 authenticator assurance level (AAL).</message>
             </expect>
             <expect id="has-federation-assurance-level" target="./system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
-            <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (IAL).</message>
+                <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (IAL).</message>
             </expect>
             <expect id="has-authorization-boundary-diagram" target="./system-characteristics/authorization-boundary" test="diagram" level="WARNING">
-            <message>A FedRAMP SSP has at least one authorization boundary diagram.</message>
+                <message>A FedRAMP SSP must have at least one authorization boundary diagram.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-uuid" target="./system-characteristics/authorization-boundary" test="diagram/@uuid" level="ERROR">
-            <message>Each OSCAL SSP authorization boundary diagram has a unique identifier.</message>
+                <message>Each authorization boundary diagram in a FedRAMP SSP must have a unique identifier.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-description" target="./system-characteristics/authorization-boundary" test="diagram/description" level="ERROR">
-            <message>An OSCAL SSP document authorization boundary diagram has a description.</message>
+                <message>An OSCAL SSP document authorization boundary diagram has a description.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-link" target="./system-characteristics/authorization-boundary" test="diagram/link" level="ERROR">
-            <message>Each FedRAMP SSP authorization boundary diagram has a link.</message>
+                <message>Each FedRAMP SSP authorization boundary diagram has a link.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-link-rel" target="./system-characteristics/authorization-boundary" test="diagram/link/@rel" level="ERROR">
-            <message>Each FedRAMP SSP authorization boundary diagram has a link rel attribute.</message>
+                <message>Each FedRAMP SSP authorization boundary diagram has a link rel attribute.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-link-rel-allowed-value" target="./system-characteristics/authorization-boundary" test="diagram/link/@rel eq 'diagram'" level="ERROR">
-            <message>Each FedRAMP SSP authorization boundary diagram has a link rel attribute with the value "diagram".</message>
+                <message>Each FedRAMP SSP authorization boundary diagram has a link rel attribute with the value "diagram".</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-caption" target="./system-characteristics/authorization-boundary" test="diagram/caption" level="ERROR">
-            <message>Each FedRAMP SSP authorization boundary diagram has a caption.</message>
+                <message>Each FedRAMP SSP authorization boundary diagram has a caption.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -69,7 +69,7 @@
                 <message>This FedRAMP SSP does define its NIST SP 800-63 authenticator assurance level (AAL).</message>
             </expect>
             <expect id="has-federation-assurance-level" target="./system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
-                <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (IAL).</message>
+                <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (FAL).</message>
             </expect>
             <expect id="has-authorization-boundary-diagram" target="./system-characteristics/authorization-boundary" test="diagram" level="WARNING">
                 <message>A FedRAMP SSP must have at least one authorization boundary diagram.</message>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -78,19 +78,19 @@
                 <message>Each authorization boundary diagram in a FedRAMP SSP must have a unique identifier.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-description" target="./system-characteristics/authorization-boundary" test="diagram/description" level="ERROR">
-                <message>An OSCAL SSP document authorization boundary diagram has a description.</message>
+                <message>A FedRAMP SSP document authorization boundary diagram must have a description.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-link" target="./system-characteristics/authorization-boundary" test="diagram/link" level="ERROR">
-                <message>Each FedRAMP SSP authorization boundary diagram has a link.</message>
+                <message>Each FedRAMP SSP authorization boundary diagram must have a link.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-link-rel" target="./system-characteristics/authorization-boundary" test="diagram/link/@rel" level="ERROR">
-                <message>Each FedRAMP SSP authorization boundary diagram has a link rel attribute.</message>
+                <message>Each FedRAMP SSP authorization boundary diagram must have a link rel attribute.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-link-rel-allowed-value" target="./system-characteristics/authorization-boundary" test="diagram/link/@rel eq 'diagram'" level="ERROR">
-                <message>Each FedRAMP SSP authorization boundary diagram has a link rel attribute with the value "diagram".</message>
+                <message>Each FedRAMP SSP authorization boundary diagram must have a link rel attribute with the value "diagram".</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-caption" target="./system-characteristics/authorization-boundary" test="diagram/caption" level="ERROR">
-                <message>Each FedRAMP SSP authorization boundary diagram has a caption.</message>
+                <message>Each FedRAMP SSP authorization boundary diagram must have a caption.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -71,6 +71,27 @@
             <expect id="has-federation-assurance-level" target="./system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
             <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (IAL).</message>
             </expect>
+            <expect id="has-authorization-boundary-diagram" target="./system-characteristics/authorization-boundary" test="diagram" level="WARNING">
+            <message>A FedRAMP SSP has at least one authorization boundary diagram.</message>
+            </expect>
+            <expect id="has-authorization-boundary-diagram-uuid" target="./system-characteristics/authorization-boundary" test="diagram/@uuid" level="ERROR">
+            <message>Each OSCAL SSP authorization boundary diagram has a unique identifier.</message>
+            </expect>
+            <expect id="has-authorization-boundary-diagram-description" target="./system-characteristics/authorization-boundary" test="diagram/description" level="ERROR">
+            <message>An OSCAL SSP document authorization boundary diagram has a description.</message>
+            </expect>
+            <expect id="has-authorization-boundary-diagram-link" target="./system-characteristics/authorization-boundary" test="diagram/link" level="ERROR">
+            <message>Each FedRAMP SSP authorization boundary diagram has a link.</message>
+            </expect>
+            <expect id="has-authorization-boundary-diagram-link-rel" target="./system-characteristics/authorization-boundary" test="diagram/link/@rel" level="ERROR">
+            <message>Each FedRAMP SSP authorization boundary diagram has a link rel attribute.</message>
+            </expect>
+            <expect id="has-authorization-boundary-diagram-link-rel-allowed-value" target="./system-characteristics/authorization-boundary" test="diagram/link/@rel eq 'diagram'" level="ERROR">
+            <message>Each FedRAMP SSP authorization boundary diagram has a link rel attribute with the value "diagram".</message>
+            </expect>
+            <expect id="has-authorization-boundary-diagram-caption" target="./system-characteristics/authorization-boundary" test="diagram/caption" level="ERROR">
+            <message>Each FedRAMP SSP authorization boundary diagram has a caption.</message>
+            </expect>
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-authorization-boundary-diagram
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram
+      result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-authorization-boundary-diagram
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram
+      result: pass

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-caption-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-caption-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-authorization-boundary-diagram-caption
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-caption
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-caption
+      result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-caption-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-caption-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-authorization-boundary-diagram-caption
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-caption
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-caption
+      result: pass

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-description-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-description-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-authorization-boundary-diagram-description
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-description
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-description
+      result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-description-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-description-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-authorization-boundary-diagram-description
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-description
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-description
+      result: pass

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-authorization-boundary-diagram-link
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-link
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-link
+      result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-authorization-boundary-diagram-link
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-link
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-link
+      result: pass

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-authorization-boundary-diagram-link-rel
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-link-rel
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-link-rel
+      result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-authorization-boundary-diagram-link-rel
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-link-rel
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-link-rel
+      result: pass

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-authorization-boundary-diagram-link-rel-allowed-value
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-link-rel-allowed-value
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-link-rel-allowed-value
+      result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-allowed-value-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-allowed-value-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-authorization-boundary-diagram-link-rel-allowed-value
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-link-rel-allowed-value
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-link-rel-allowed-value
+      result: pass

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-uuid-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-uuid-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-authorization-boundary-diagram-uuid
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-uuid
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-uuid
+      result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-uuid-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-uuid-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-authorization-boundary-diagram-uuid
+  description: >-
+    This test case validates the behavior of constraint
+    has-authorization-boundary-diagram-uuid
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-authorization-boundary-diagram-uuid
+      result: pass


### PR DESCRIPTION
# Committer Notes

### Description 
Added system-characteristics 'has-authorization-boundary' constraints and tests for each of the constraints. These should be added as they are part of the effort write all of the constraints from the constraint tracker.

### Changes  
- Added constraints has-authorization-boundary-diagram, has-authorization-boundary-diagram-uuid, has-authorization-boundary-diagram-description, has-authorization-boundary-diagram-link, has-authorization-boundary-diagram-caption, has-authorization-boundary-diagram-link-rel, and has-authorization-boundary-diagram-link-rel-allowed-value to fedramp-external-constraints.xml.  
- Added pass and fail yaml tests for all of the above constraints.  
- Edited ssp-all-VALID.xml to ensure all constraints pass correctly.  

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~~
~~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
