### PR TITLE
Add system-characteristics 'has-network-architecture' constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -55,6 +55,24 @@ Examples:
   | has-incident-response-plan-PASS.yaml |
   | has-information-system-contingency-plan-FAIL.yaml |
   | has-information-system-contingency-plan-PASS.yaml |
+  | has-network-architecture-FAIL.yaml |
+  | has-network-architecture-PASS.yaml |
+  | has-network-architecture-description-FAIL.yaml |
+  | has-network-architecture-description-PASS.yaml |
+  | has-network-architecture-diagram-FAIL.yaml |
+  | has-network-architecture-diagram-PASS.yaml |
+  | has-network-architecture-diagram-caption-FAIL.yaml |
+  | has-network-architecture-diagram-caption-PASS.yaml |
+  | has-network-architecture-diagram-description-FAIL.yaml |
+  | has-network-architecture-diagram-description-PASS.yaml |
+  | has-network-architecture-diagram-link-FAIL.yaml |
+  | has-network-architecture-diagram-link-PASS.yaml |
+  | has-network-architecture-diagram-link-rel-FAIL.yaml |
+  | has-network-architecture-diagram-link-rel-PASS.yaml |
+  | has-network-architecture-diagram-link-rel-allowed-value-FAIL.yaml |
+  | has-network-architecture-diagram-link-rel-allowed-value-PASS.yaml |
+  | has-network-architecture-diagram-uuid-FAIL.yaml |
+  | has-network-architecture-diagram-uuid-PASS.yaml |
   | has-rules-of-behavior-FAIL.yaml |
   | has-rules-of-behavior-PASS.yaml |
   | has-separation-of-duties-matrix-FAIL.yaml |
@@ -122,6 +140,15 @@ Examples:
   | has-identity-assurance-level |
   | has-incident-response-plan |
   | has-information-system-contingency-plan |
+  | has-network-architecture |
+  | has-network-architecture-description |
+  | has-network-architecture-diagram |
+  | has-network-architecture-diagram-caption |
+  | has-network-architecture-diagram-description |
+  | has-network-architecture-diagram-link |
+  | has-network-architecture-diagram-link-rel |
+  | has-network-architecture-diagram-link-rel-allowed-value |
+  | has-network-architecture-diagram-uuid |
   | has-rules-of-behavior |
   | has-separation-of-duties-matrix |
   | has-user-guide |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -113,6 +113,18 @@
         <p>The authorization boundary includes all components within the main data center and the disaster recovery site.</p>
       </description>
     </authorization-boundary>
+    <network-architecture>
+         <description>
+            <p>A holistic, top-level explanation of the network architecture.</p>
+         </description>
+         <diagram uuid="e97c3395-433a-48c1-8cc7-dd1e1555941c">
+            <description>
+               <p>A diagram-specific explanation.</p>
+            </description>
+            <link href="#61081e81-850b-43c1-bf43-1ecbddcb9e7f" rel="diagram"/>
+            <caption>Network Diagram</caption>
+         </diagram>
+      </network-architecture>
   </system-characteristics>
   
   <system-implementation>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -72,7 +72,7 @@
             <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (IAL).</message>
             </expect>
             <expect id="has-network-architecture" target="./system-characteristics" test="network-architecture" level="ERROR">
-                <message>A FedRAMP SSP must include a network architecture diagram.</message>
+                <message>A FedRAMP SSP must include a network architecture.</message>
             </expect>
             <expect id="has-network-architecture-diagram" target="./system-characteristics" test="network-architecture/diagram" level="WARNING">
                 <message>A FedRAMP SSP must have at least one network architecture diagram.</message>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -71,6 +71,34 @@
             <expect id="has-federation-assurance-level" target="./system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
             <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (IAL).</message>
             </expect>
+            <expect id="has-network-architecture" target="./system-characteristics" test="network-architecture" level="ERROR">
+                <message>A FedRAMP SSP must include a network architecture diagram.</message>
+            </expect>
+            <expect id="has-network-architecture-diagram" target="./system-characteristics" test="network-architecture/diagram" level="WARNING">
+                <message>A FedRAMP SSP must have at least one network architecture diagram.</message>
+            </expect>
+            <expect id="has-network-architecture-diagram-uuid" target="./system-characteristics" test="network-architecture/diagram/@uuid" level="ERROR">
+                <message>Each FedRAMP SSP network architecture diagram must have a unique identifier.</message>
+            </expect>
+            <expect id="has-network-architecture-diagram-description" target="./system-characteristics" test="network-architecture/diagram/description" level="ERROR">
+                <message>Each FedRAMP SSP network architecture diagram must have a description.</message>
+            </expect>
+            <expect id="has-network-architecture-diagram-link" target="./system-characteristics" test="network-architecture/diagram/link" level="ERROR">
+                <message>Each FedRAMP SSP network architecture diagram must have a link.</message>
+            </expect>
+            <expect id="has-network-architecture-diagram-caption" target="./system-characteristics" test="network-architecture/diagram/caption" level="ERROR">
+                <message>Each FedRAMP SSP network architecture diagram must have a caption.</message>
+            </expect>
+            <expect id="has-network-architecture-diagram-link-rel" target="./system-characteristics" test="network-architecture/diagram/link/@rel" level="ERROR">
+                <message>Each FedRAMP SSP network architecture diagram must have a link rel attribute.</message>
+            </expect>
+            <expect id="has-network-architecture-diagram-link-rel-allowed-value" target="./system-characteristics" test="network-architecture/diagram/link/@rel eq 'diagram'" level="ERROR">
+                <message>Each FedRAMP SSP network architecture diagram must have a link rel attribute with the value "diagram".</message>
+            </expect>
+            <expect id="has-network-architecture-description" target="./system-characteristics" test="network-architecture/description" level="ERROR">
+                <message>A FedRAMP SSP must have a network architecture description.</message>
+            </expect>
+
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/unit-tests/has-network-architecture-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-network-architecture
+  description: This test case validates the behavior of constraint has-network-architecture
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-network-architecture
+      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-network-architecture
+  description: This test case validates the behavior of constraint has-network-architecture
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-network-architecture
+      result: pass

--- a/src/validations/constraints/unit-tests/has-network-architecture-description-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-description-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-network-architecture-description
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-description
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-description
+      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-description-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-description-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-network-architecture-description
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-description
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-description
+      result: pass

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-network-architecture-diagram
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram
+      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-network-architecture-diagram
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram
+      result: pass

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-caption-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-caption-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-network-architecture-diagram-caption
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-caption
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-caption
+      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-caption-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-caption-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-network-architecture-diagram-caption
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-caption
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-caption
+      result: pass

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-description-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-description-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-network-architecture-diagram-description
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-description
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-description
+      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-description-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-description-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-network-architecture-diagram-description
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-description
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-description
+      result: pass

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-network-architecture-diagram-link
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-link
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-link
+      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-network-architecture-diagram-link
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-link
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-link
+      result: pass

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-network-architecture-diagram-link-rel
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-link-rel
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-link-rel
+      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-network-architecture-diagram-link-rel
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-link-rel
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-link-rel
+      result: pass

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-allowed-value-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-allowed-value-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-network-architecture-diagram-link-rel-allowed-value
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-link-rel-allowed-value
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-link-rel-allowed-value
+      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-allowed-value-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-allowed-value-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-network-architecture-diagram-link-rel-allowed-value
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-link-rel-allowed-value
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-link-rel-allowed-value
+      result: pass

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-uuid-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-uuid-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for has-network-architecture-diagram-uuid
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-uuid
+  content: ../content/ssp-all-INVALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-uuid
+      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-uuid-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-uuid-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for has-network-architecture-diagram-uuid
+  description: >-
+    This test case validates the behavior of constraint
+    has-network-architecture-diagram-uuid
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-network-architecture-diagram-uuid
+      result: pass


### PR DESCRIPTION
# Committer Notes

### Description 
Added system-characteristics 'has-network-architecture' constraints and tests for each of the constraints. These should be added as they are part of the effort write all of the constraints from the constraint tracker.  

### Changes 
- Added constraints has-network-architecture, has-network-architecture-diagram, has-network-architecture-description, has-network-architecture-diagram-uuid, has-network-architecture-diagram-description, has-network-architecture-diagram-link, has-network-architecture-diagram-caption, has-network-architecture-diagram-link-rel, and has-network-architecture-diagram-link-rel-allowed-value to fedramp-external-constraints.xml.  
- Added pass and fail yaml tests for all of the above constraints.  
- Edited ssp-all-VALID.xml to ensure all constraints pass correctly.  

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~~
~~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
