### PR TITLE
General cleanup related to 'system-characteristics' constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -71,8 +71,6 @@ Examples:
   | has-information-system-contingency-plan-PASS.yaml |
   | has-network-architecture-FAIL.yaml |
   | has-network-architecture-PASS.yaml |
-  | has-network-architecture-description-FAIL.yaml |
-  | has-network-architecture-description-PASS.yaml |
   | has-network-architecture-diagram-FAIL.yaml |
   | has-network-architecture-diagram-PASS.yaml |
   | has-network-architecture-diagram-caption-FAIL.yaml |
@@ -85,8 +83,6 @@ Examples:
   | has-network-architecture-diagram-link-rel-PASS.yaml |
   | has-network-architecture-diagram-link-rel-allowed-value-FAIL.yaml |
   | has-network-architecture-diagram-link-rel-allowed-value-PASS.yaml |
-  | has-network-architecture-diagram-uuid-FAIL.yaml |
-  | has-network-architecture-diagram-uuid-PASS.yaml |
   | has-rules-of-behavior-FAIL.yaml |
   | has-rules-of-behavior-PASS.yaml |
   | has-separation-of-duties-matrix-FAIL.yaml |
@@ -162,14 +158,12 @@ Examples:
   | has-incident-response-plan |
   | has-information-system-contingency-plan |
   | has-network-architecture |
-  | has-network-architecture-description |
   | has-network-architecture-diagram |
   | has-network-architecture-diagram-caption |
   | has-network-architecture-diagram-description |
   | has-network-architecture-diagram-link |
   | has-network-architecture-diagram-link-rel |
   | has-network-architecture-diagram-link-rel-allowed-value |
-  | has-network-architecture-diagram-uuid |
   | has-rules-of-behavior |
   | has-separation-of-duties-matrix |
   | has-user-guide |

--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -57,8 +57,6 @@ Examples:
   | has-authorization-boundary-diagram-link-rel-PASS.yaml |
   | has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml |
   | has-authorization-boundary-diagram-link-rel-allowed-value-PASS.yaml |
-  | has-authorization-boundary-diagram-uuid-FAIL.yaml |
-  | has-authorization-boundary-diagram-uuid-PASS.yaml |
   | has-configuration-management-plan-FAIL.yaml |
   | has-configuration-management-plan-PASS.yaml |
   | has-federation-assurance-level-FAIL.yaml |
@@ -151,7 +149,6 @@ Examples:
   | has-authorization-boundary-diagram-link |
   | has-authorization-boundary-diagram-link-rel |
   | has-authorization-boundary-diagram-link-rel-allowed-value |
-  | has-authorization-boundary-diagram-uuid |
   | has-configuration-management-plan |
   | has-federation-assurance-level |
   | has-identity-assurance-level |

--- a/src/validations/constraints/content/has-authorization-boundary-diagram-INVALID.xml
+++ b/src/validations/constraints/content/has-authorization-boundary-diagram-INVALID.xml
@@ -98,9 +98,6 @@
       <description>
         <p>The authorization boundary includes all components within the main data center and the disaster recovery site.</p>
       </description>
-      <diagram uuid="dbf46c27-52a9-49c4-beb6-b6399cd75497">
-        <link href="#d2eb3c18-6754-4e3a-a933-03d289e3fad5"/>
-      </diagram>
     </authorization-boundary>
     <network-architecture>
       <description>

--- a/src/validations/constraints/content/has-authorization-boundary-diagram-link-INVALID.xml
+++ b/src/validations/constraints/content/has-authorization-boundary-diagram-link-INVALID.xml
@@ -99,7 +99,6 @@
         <p>The authorization boundary includes all components within the main data center and the disaster recovery site.</p>
       </description>
       <diagram uuid="dbf46c27-52a9-49c4-beb6-b6399cd75497">
-        <link href="#d2eb3c18-6754-4e3a-a933-03d289e3fad5"/>
       </diagram>
     </authorization-boundary>
     <network-architecture>

--- a/src/validations/constraints/content/has-authorization-boundary-diagram-link-rel-allowed-value-INVALID.xml
+++ b/src/validations/constraints/content/has-authorization-boundary-diagram-link-rel-allowed-value-INVALID.xml
@@ -99,7 +99,7 @@
         <p>The authorization boundary includes all components within the main data center and the disaster recovery site.</p>
       </description>
       <diagram uuid="dbf46c27-52a9-49c4-beb6-b6399cd75497">
-        <link href="#d2eb3c18-6754-4e3a-a933-03d289e3fad5"/>
+        <link href="#d2eb3c18-6754-4e3a-a933-03d289e3fad5" rel="not-diagram"/>
       </diagram>
     </authorization-boundary>
     <network-architecture>

--- a/src/validations/constraints/content/has-network-architecture-INVALID.xml
+++ b/src/validations/constraints/content/has-network-architecture-INVALID.xml
@@ -99,14 +99,6 @@
         <p>The authorization boundary includes all components within the main data center and the disaster recovery site.</p>
       </description>
     </authorization-boundary>
-    <network-architecture>
-      <description>
-        <p>A holistic, top-level explanation of the network architecture.</p>
-      </description>
-      <diagram uuid="e97c3395-433a-48c1-8cc7-dd1e1555941c">
-        <link href="#61081e81-850b-43c1-bf43-1ecbddcb9e7f" rel="not-diagram"/>
-      </diagram>
-    </network-architecture>
   </system-characteristics>
   
   <system-implementation>

--- a/src/validations/constraints/content/has-network-architecture-diagram-INVALID.xml
+++ b/src/validations/constraints/content/has-network-architecture-diagram-INVALID.xml
@@ -103,9 +103,6 @@
       <description>
         <p>A holistic, top-level explanation of the network architecture.</p>
       </description>
-      <diagram uuid="e97c3395-433a-48c1-8cc7-dd1e1555941c">
-        <link href="#61081e81-850b-43c1-bf43-1ecbddcb9e7f" rel="not-diagram"/>
-      </diagram>
     </network-architecture>
   </system-characteristics>
   

--- a/src/validations/constraints/content/has-network-architecture-diagram-link-INVALID.xml
+++ b/src/validations/constraints/content/has-network-architecture-diagram-link-INVALID.xml
@@ -104,7 +104,6 @@
         <p>A holistic, top-level explanation of the network architecture.</p>
       </description>
       <diagram uuid="e97c3395-433a-48c1-8cc7-dd1e1555941c">
-        <link href="#61081e81-850b-43c1-bf43-1ecbddcb9e7f" rel="not-diagram"/>
       </diagram>
     </network-architecture>
   </system-characteristics>

--- a/src/validations/constraints/content/has-network-architecture-diagram-link-rel-INVALID.xml
+++ b/src/validations/constraints/content/has-network-architecture-diagram-link-rel-INVALID.xml
@@ -104,7 +104,8 @@
         <p>A holistic, top-level explanation of the network architecture.</p>
       </description>
       <diagram uuid="e97c3395-433a-48c1-8cc7-dd1e1555941c">
-        <link href="#61081e81-850b-43c1-bf43-1ecbddcb9e7f" rel="not-diagram"/>
+        <link href="#61081e81-850b-43c1-bf43-1ecbddcb9e7f"/>
+        <caption>Network Diagram</caption>
       </diagram>
     </network-architecture>
   </system-characteristics>

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -121,17 +121,17 @@
          </diagram>
     </authorization-boundary>
     <network-architecture>
-         <description>
-            <p>A holistic, top-level explanation of the network architecture.</p>
-         </description>
-         <diagram uuid="e97c3395-433a-48c1-8cc7-dd1e1555941c">
-            <description>
-               <p>A diagram-specific explanation.</p>
-            </description>
-            <link href="#61081e81-850b-43c1-bf43-1ecbddcb9e7f" rel="diagram"/>
-            <caption>Network Diagram</caption>
-         </diagram>
-      </network-architecture>
+      <description>
+        <p>A holistic, top-level explanation of the network architecture.</p>
+      </description>
+      <diagram uuid="e97c3395-433a-48c1-8cc7-dd1e1555941c">
+        <description>
+          <p>A diagram-specific explanation.</p>
+        </description>
+        <link href="#61081e81-850b-43c1-bf43-1ecbddcb9e7f" rel="diagram"/>
+        <caption>Network Diagram</caption>
+      </diagram>
+    </network-architecture>
   </system-characteristics>
   
   <system-implementation>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -92,34 +92,27 @@
             <expect id="has-authorization-boundary-diagram-caption" target="./system-characteristics/authorization-boundary" test="diagram/caption" level="ERROR">
                 <message>Each FedRAMP SSP authorization boundary diagram must have a caption.</message>
             </expect>
-            <expect id="has-network-architecture" target="./system-characteristics" test="network-architecture" level="ERROR">
+            <expect id="has-network-architecture" target="system-characteristics" test="network-architecture" level="ERROR">
                 <message>A FedRAMP SSP must include a network architecture.</message>
             </expect>
-            <expect id="has-network-architecture-diagram" target="./system-characteristics" test="network-architecture/diagram" level="WARNING">
+            <expect id="has-network-architecture-diagram" target="system-characteristics/network-architecture" test="diagram" level="WARNING">
                 <message>A FedRAMP SSP must have at least one network architecture diagram.</message>
             </expect>
-            <expect id="has-network-architecture-diagram-uuid" target="./system-characteristics" test="network-architecture/diagram/@uuid" level="ERROR">
-                <message>Each FedRAMP SSP network architecture diagram must have a unique identifier.</message>
-            </expect>
-            <expect id="has-network-architecture-diagram-description" target="./system-characteristics" test="network-architecture/diagram/description" level="ERROR">
+            <expect id="has-network-architecture-diagram-description" target="system-characteristics/network-architecture/diagram" test="description" level="ERROR">
                 <message>Each FedRAMP SSP network architecture diagram must have a description.</message>
             </expect>
-            <expect id="has-network-architecture-diagram-link" target="./system-characteristics" test="network-architecture/diagram/link" level="ERROR">
+            <expect id="has-network-architecture-diagram-link" target="system-characteristics/network-architecture/diagram" test="link" level="ERROR">
                 <message>Each FedRAMP SSP network architecture diagram must have a link.</message>
             </expect>
-            <expect id="has-network-architecture-diagram-caption" target="./system-characteristics" test="network-architecture/diagram/caption" level="ERROR">
+            <expect id="has-network-architecture-diagram-caption" target="system-characteristics/network-architecture/diagram" test="caption" level="ERROR">
                 <message>Each FedRAMP SSP network architecture diagram must have a caption.</message>
             </expect>
-            <expect id="has-network-architecture-diagram-link-rel" target="./system-characteristics" test="network-architecture/diagram/link/@rel" level="ERROR">
+            <expect id="has-network-architecture-diagram-link-rel" target="system-characteristics/network-architecture/diagram/link" test="@rel" level="ERROR">
                 <message>Each FedRAMP SSP network architecture diagram must have a link rel attribute.</message>
             </expect>
-            <expect id="has-network-architecture-diagram-link-rel-allowed-value" target="./system-characteristics" test="network-architecture/diagram/link/@rel eq 'diagram'" level="ERROR">
+            <expect id="has-network-architecture-diagram-link-rel-allowed-value" target="system-characteristics/network-architecture/diagram/link" test="@rel eq 'diagram'" level="ERROR">
                 <message>Each FedRAMP SSP network architecture diagram must have a link rel attribute with the value "diagram".</message>
             </expect>
-            <expect id="has-network-architecture-description" target="./system-characteristics" test="network-architecture/description" level="ERROR">
-                <message>A FedRAMP SSP must have a network architecture description.</message>
-            </expect>
-
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -56,19 +56,19 @@
             <expect id="has-separation-of-duties-matrix" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'separation-of-duties-matrix']]" level="ERROR">
                 <message>A FedRAMP SSP must have a Separation of Duties Matrix attached.</message>
             </expect>
-            <expect id="categorization-has-correct-system-attribute" target="./system-characteristics" test="system-information/information-type/categorization/@system eq 'https://doi.org/10.6028/NIST.SP.800-60v2r1'" level="ERROR">
+            <expect id="categorization-has-correct-system-attribute" target="system-characteristics/system-information/information-type/categorization" test="@system eq 'https://doi.org/10.6028/NIST.SP.800-60v2r1'" level="ERROR">
                 <message>A FedRAMP SSP information-type categorization requires a correct system attribute. FedRAMP only supports the system value 'https://doi.org/10.6028/NIST.SP.800-60v2r1'.</message>
             </expect>
-            <expect id="categorization-has-information-type-id" target="./system-characteristics" test="system-information/information-type/categorization/information-type-id" level="ERROR">
+            <expect id="categorization-has-information-type-id" target="system-characteristics/system-information/information-type/categorization" test="information-type-id" level="ERROR">
                 <message>A FedRAMP SSP information type categorization must have at least one information type identifier.</message>
             </expect>
-            <expect id="has-identity-assurance-level" target="./system-characteristics" test="prop[@name eq 'identity-assurance-level']" level="INFORMATIONAL">
+            <expect id="has-identity-assurance-level" target="system-characteristics" test="prop[@name eq 'identity-assurance-level']" level="INFORMATIONAL">
                 <message>This FedRAMP SSP does define its NIST SP 800-63 identity assurance level (IAL).</message>
             </expect>
-            <expect id="has-authenticator-assurance-level" target="./system-characteristics" test="prop[@name eq 'authenticator-assurance-level']" level="INFORMATIONAL">
+            <expect id="has-authenticator-assurance-level" target="system-characteristics" test="prop[@name eq 'authenticator-assurance-level']" level="INFORMATIONAL">
                 <message>This FedRAMP SSP does define its NIST SP 800-63 authenticator assurance level (AAL).</message>
             </expect>
-            <expect id="has-federation-assurance-level" target="./system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
+            <expect id="has-federation-assurance-level" target="system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
                 <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (FAL).</message>
             </expect>
             <expect id="has-authorization-boundary-diagram" target="system-characteristics/authorization-boundary" test="diagram" level="WARNING">

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -71,25 +71,22 @@
             <expect id="has-federation-assurance-level" target="./system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
                 <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (FAL).</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram" target="./system-characteristics/authorization-boundary" test="diagram" level="WARNING">
+            <expect id="has-authorization-boundary-diagram" target="system-characteristics/authorization-boundary" test="diagram" level="WARNING">
                 <message>A FedRAMP SSP must have at least one authorization boundary diagram.</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram-uuid" target="./system-characteristics/authorization-boundary" test="diagram/@uuid" level="ERROR">
-                <message>Each authorization boundary diagram in a FedRAMP SSP must have a unique identifier.</message>
-            </expect>
-            <expect id="has-authorization-boundary-diagram-description" target="./system-characteristics/authorization-boundary" test="diagram/description" level="ERROR">
+            <expect id="has-authorization-boundary-diagram-description" target="system-characteristics/authorization-boundary/diagram" test="description" level="ERROR">
                 <message>A FedRAMP SSP document authorization boundary diagram must have a description.</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram-link" target="./system-characteristics/authorization-boundary" test="diagram/link" level="ERROR">
+            <expect id="has-authorization-boundary-diagram-link" target="system-characteristics/authorization-boundary/diagram" test="link" level="ERROR">
                 <message>Each FedRAMP SSP authorization boundary diagram must have a link.</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram-link-rel" target="./system-characteristics/authorization-boundary" test="diagram/link/@rel" level="ERROR">
+            <expect id="has-authorization-boundary-diagram-link-rel" target="system-characteristics/authorization-boundary/diagram/link" test="@rel" level="ERROR">
                 <message>Each FedRAMP SSP authorization boundary diagram must have a link rel attribute.</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram-link-rel-allowed-value" target="./system-characteristics/authorization-boundary" test="diagram/link/@rel eq 'diagram'" level="ERROR">
+            <expect id="has-authorization-boundary-diagram-link-rel-allowed-value" target="system-characteristics/authorization-boundary/diagram/link" test="@rel eq 'diagram'" level="ERROR">
                 <message>Each FedRAMP SSP authorization boundary diagram must have a link rel attribute with the value "diagram".</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram-caption" target="./system-characteristics/authorization-boundary" test="diagram/caption" level="ERROR">
+            <expect id="has-authorization-boundary-diagram-caption" target="system-characteristics/authorization-boundary/diagram" test="caption" level="ERROR">
                 <message>Each FedRAMP SSP authorization boundary diagram must have a caption.</message>
             </expect>
             <expect id="has-network-architecture" target="system-characteristics" test="network-architecture" level="ERROR">

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-FAIL.yaml
@@ -3,7 +3,7 @@ test-case:
   description: >-
     This test case validates the behavior of constraint
     has-authorization-boundary-diagram
-  content: ../content/ssp-all-INVALID.xml
+  content: ../content/has-authorization-boundary-diagram-INVALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram
       result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-FAIL.yaml
@@ -3,7 +3,7 @@ test-case:
   description: >-
     This test case validates the behavior of constraint
     has-authorization-boundary-diagram-link
-  content: ../content/ssp-all-INVALID.xml
+  content: ../content/has-authorization-boundary-diagram-link-INVALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-link
       result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml
@@ -3,7 +3,7 @@ test-case:
   description: >-
     This test case validates the behavior of constraint
     has-authorization-boundary-diagram-link-rel-allowed-value
-  content: ../content/ssp-all-INVALID.xml
+  content: ../content/has-authorization-boundary-diagram-link-rel-allowed-value-INVALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-link-rel-allowed-value
       result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-uuid-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-uuid-FAIL.yaml
@@ -1,9 +1,0 @@
-test-case:
-  name: Negative Test for has-authorization-boundary-diagram-uuid
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-uuid
-  content: ../content/ssp-all-INVALID.xml
-  expectations:
-    - constraint-id: has-authorization-boundary-diagram-uuid
-      result: fail

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-uuid-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-uuid-PASS.yaml
@@ -1,9 +1,0 @@
-test-case:
-  name: Positive Test for has-authorization-boundary-diagram-uuid
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-uuid
-  content: ../content/ssp-all-VALID.xml
-  expectations:
-    - constraint-id: has-authorization-boundary-diagram-uuid
-      result: pass

--- a/src/validations/constraints/unit-tests/has-network-architecture-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-FAIL.yaml
@@ -1,7 +1,7 @@
 test-case:
   name: Negative Test for has-network-architecture
   description: This test case validates the behavior of constraint has-network-architecture
-  content: ../content/ssp-all-INVALID.xml
+  content: ../content/has-network-architecture-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture
       result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-description-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-description-FAIL.yaml
@@ -1,9 +1,0 @@
-test-case:
-  name: Negative Test for has-network-architecture-description
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-description
-  content: ../content/ssp-all-INVALID.xml
-  expectations:
-    - constraint-id: has-network-architecture-description
-      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-description-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-description-PASS.yaml
@@ -1,9 +1,0 @@
-test-case:
-  name: Positive Test for has-network-architecture-description
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-description
-  content: ../content/ssp-all-VALID.xml
-  expectations:
-    - constraint-id: has-network-architecture-description
-      result: pass

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-FAIL.yaml
@@ -3,7 +3,7 @@ test-case:
   description: >-
     This test case validates the behavior of constraint
     has-network-architecture-diagram
-  content: ../content/ssp-all-INVALID.xml
+  content: ../content/has-network-architecture-diagram-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram
       result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-FAIL.yaml
@@ -3,7 +3,7 @@ test-case:
   description: >-
     This test case validates the behavior of constraint
     has-network-architecture-diagram-link
-  content: ../content/ssp-all-INVALID.xml
+  content: ../content/has-network-architecture-diagram-link-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-link
       result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-FAIL.yaml
@@ -3,7 +3,7 @@ test-case:
   description: >-
     This test case validates the behavior of constraint
     has-network-architecture-diagram-link-rel
-  content: ../content/ssp-all-INVALID.xml
+  content: ../content/has-network-architecture-diagram-link-rel-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-link-rel
       result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-uuid-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-uuid-FAIL.yaml
@@ -1,9 +1,0 @@
-test-case:
-  name: Negative Test for has-network-architecture-diagram-uuid
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-uuid
-  content: ../content/ssp-all-INVALID.xml
-  expectations:
-    - constraint-id: has-network-architecture-diagram-uuid
-      result: fail

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-uuid-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-uuid-PASS.yaml
@@ -1,9 +1,0 @@
-test-case:
-  name: Positive Test for has-network-architecture-diagram-uuid
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-uuid
-  content: ../content/ssp-all-VALID.xml
-  expectations:
-    - constraint-id: has-network-architecture-diagram-uuid
-      result: pass


### PR DESCRIPTION
# Committer Notes

### Description
Removed system-characteristics constraints that are handled by the schema, and tests for each of these constraints. I also created separate invalid test files for constraints that caused conflicts in the `ssp-all-INVALID.xml` file. I moved some metapath for constraints from "test" to "target" so that it is cleaner and easier to understand. The metapath was originally in the test because this was a workaround that allowed the constraints to all share the same `ssp-all-INVALID.xml` file without conflicts. The functionality is the exact same. These changes should be added as they are part of the effort write all of the constraints from the constraint tracker.

### Changes
- Removed constraints `has-authorization-boundary-diagram-uuid`, `has-network-architecture-description`, `has-network-architecture-diagram-uuid` from `fedramp-external-constraints.xml`.
- Removed pass and fail yaml tests for all of the above constraints.
- Created separate invalid test data files for constraints where necessary to ensure all constraints fail correctly without conflicts.
-  Edited targets of `system-characteristics` constraints to be cleaner and easier to understand.
### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~~
~~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
