### PR TITLE
Add `system-characteristics` `has-data-flow` constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -59,6 +59,24 @@ Examples:
   | has-authorization-boundary-diagram-link-rel-allowed-value-PASS.yaml |
   | has-configuration-management-plan-FAIL.yaml |
   | has-configuration-management-plan-PASS.yaml |
+  | has-data-flow-FAIL.yaml |
+  | has-data-flow-PASS.yaml |
+  | has-data-flow-description-FAIL.yaml |
+  | has-data-flow-description-PASS.yaml |
+  | has-data-flow-diagram-FAIL.yaml |
+  | has-data-flow-diagram-PASS.yaml |
+  | has-data-flow-diagram-caption-FAIL.yaml |
+  | has-data-flow-diagram-caption-PASS.yaml |
+  | has-data-flow-diagram-description-FAIL.yaml |
+  | has-data-flow-diagram-description-PASS.yaml |
+  | has-data-flow-diagram-link-FAIL.yaml |
+  | has-data-flow-diagram-link-PASS.yaml |
+  | has-data-flow-diagram-link-rel-FAIL.yaml |
+  | has-data-flow-diagram-link-rel-PASS.yaml |
+  | has-data-flow-diagram-link-rel-allowed-value-FAIL.yaml |
+  | has-data-flow-diagram-link-rel-allowed-value-PASS.yaml |
+  | has-data-flow-diagram-uuid-FAIL.yaml |
+  | has-data-flow-diagram-uuid-PASS.yaml |
   | has-federation-assurance-level-FAIL.yaml |
   | has-federation-assurance-level-PASS.yaml |
   | has-identity-assurance-level-FAIL.yaml |
@@ -150,6 +168,15 @@ Examples:
   | has-authorization-boundary-diagram-link-rel |
   | has-authorization-boundary-diagram-link-rel-allowed-value |
   | has-configuration-management-plan |
+  | has-data-flow |
+  | has-data-flow-description |
+  | has-data-flow-diagram |
+  | has-data-flow-diagram-caption |
+  | has-data-flow-diagram-description |
+  | has-data-flow-diagram-link |
+  | has-data-flow-diagram-link-rel |
+  | has-data-flow-diagram-link-rel-allowed-value |
+  | has-data-flow-diagram-uuid |
   | has-federation-assurance-level |
   | has-identity-assurance-level |
   | has-incident-response-plan |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -132,6 +132,18 @@
         <caption>Network Diagram</caption>
       </diagram>
     </network-architecture>
+    <data-flow>
+      <description>
+        <p>A holistic, top-level explanation of the system's data flows.</p>
+      </description>
+      <diagram uuid="e3b98448-4219-46a5-b229-412423c566f3">
+        <description>
+          <p>A diagram-specific explanation.</p>
+        </description>
+        <link href="#ac5d7535-f3b8-45d3-bf3b-735c82c64547" rel="diagram"/>
+        <caption>Data Flow Diagram</caption>
+      </diagram>
+    </data-flow>
   </system-characteristics>
   
   <system-implementation>

--- a/src/validations/constraints/content/ssp-has-data-flow-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-data-flow-INVALID.xml
@@ -1,0 +1,4 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-has-data-flow-description-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-data-flow-description-INVALID.xml
@@ -1,0 +1,6 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+    <data-flow>
+    </data-flow>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-has-data-flow-diagram-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-data-flow-diagram-INVALID.xml
@@ -1,0 +1,6 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+    <data-flow>
+    </data-flow>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-has-data-flow-diagram-caption-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-data-flow-diagram-caption-INVALID.xml
@@ -1,0 +1,8 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+    <data-flow>
+      <diagram>
+      </diagram>
+    </data-flow>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-has-data-flow-diagram-description-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-data-flow-diagram-description-INVALID.xml
@@ -1,0 +1,8 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+    <data-flow>
+      <diagram>
+      </diagram>
+    </data-flow>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-has-data-flow-diagram-link-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-data-flow-diagram-link-INVALID.xml
@@ -1,0 +1,8 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+    <data-flow>
+      <diagram>
+      </diagram>
+    </data-flow>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-has-data-flow-diagram-link-rel-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-data-flow-diagram-link-rel-INVALID.xml
@@ -1,0 +1,9 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+    <data-flow>
+      <diagram>
+      <link href="#ac5d7535-f3b8-45d3-bf3b-735c82c64547"/>
+      </diagram>
+    </data-flow>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-has-data-flow-diagram-link-rel-allowed-value-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-data-flow-diagram-link-rel-allowed-value-INVALID.xml
@@ -1,0 +1,9 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+    <data-flow>
+      <diagram>
+      <link href="#ac5d7535-f3b8-45d3-bf3b-735c82c64547" rel="not-diagram"/>
+      </diagram>
+    </data-flow>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-has-data-flow-diagram-uuid-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-data-flow-diagram-uuid-INVALID.xml
@@ -1,0 +1,8 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+    <data-flow>
+      <diagram>
+      </diagram>
+    </data-flow>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -110,6 +110,33 @@
             <expect id="has-network-architecture-diagram-link-rel-allowed-value" target="system-characteristics/network-architecture/diagram/link" test="@rel eq 'diagram'" level="ERROR">
                 <message>Each FedRAMP SSP network architecture diagram must have a link rel attribute with the value "diagram".</message>
             </expect>
+            <expect id="has-data-flow" target="system-characteristics" test="data-flow" level="WARNING">
+                <message>A FedRAMP SSP must include a data flow section.</message>
+            </expect>
+            <expect id="has-data-flow-diagram" target="system-characteristics/data-flow" test="diagram" level="ERROR">
+                <message>A FedRAMP SSP must have at least one data flow diagram.</message>
+            </expect>
+            <expect id="has-data-flow-description" target="system-characteristics/data-flow" test="description" level="ERROR">
+                <message>An OSCAL SSP document with a data flow must have a description.</message>
+            </expect>
+            <expect id="has-data-flow-diagram-uuid" target="system-characteristics/data-flow/diagram" test="@uuid" level="ERROR">
+                <message>An OSCAL SSP document with a data flow diagram must have a unique identifier.</message>
+            </expect>
+            <expect id="has-data-flow-diagram-description" target="system-characteristics/data-flow/diagram" test="description" level="ERROR">
+                <message>Each FedRAMP SSP data flow diagram must have a description.</message>
+            </expect>
+            <expect id="has-data-flow-diagram-link" target="system-characteristics/data-flow/diagram" test="link" level="ERROR">
+                <message>Each FedRAMP SSP data flow diagram must have a link.</message>
+            </expect>
+            <expect id="has-data-flow-diagram-caption" target="system-characteristics/data-flow/diagram" test="caption" level="ERROR">
+                <message>Each FedRAMP SSP data flow diagram must have a caption.</message>
+            </expect>
+            <expect id="has-data-flow-diagram-link-rel" target="system-characteristics/data-flow/diagram/link" test="@rel" level="ERROR">
+                <message>Each FedRAMP SSP data flow diagram must have a link rel attribute.</message>
+            </expect>
+            <expect id="has-data-flow-diagram-link-rel-allowed-value" target="system-characteristics/data-flow/diagram/link" test="@rel eq 'diagram'" level="ERROR">
+                <message>Each FedRAMP SSP data flow diagram must have a link rel attribute with the value "diagram".</message>
+            </expect>
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/unit-tests/has-data-flow-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-data-flow
+  description: Test that system-characteristics does not have a data-flow element.
+  content: ../content/ssp-has-data-flow-INVALID.xml
+  expectations:
+    - constraint-id: has-data-flow
+      result: fail

--- a/src/validations/constraints/unit-tests/has-data-flow-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-data-flow
+  description: Test that system-characteristics has a data-flow element.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-data-flow
+      result: pass

--- a/src/validations/constraints/unit-tests/has-data-flow-description-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-description-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-data-flow-description
+  description: Test that data-flow does not have a description.
+  content: ../content/ssp-has-data-flow-description-INVALID.xml
+  expectations:
+    - constraint-id: has-data-flow-description
+      result: fail

--- a/src/validations/constraints/unit-tests/has-data-flow-description-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-description-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-data-flow-description
+  description: Test that data-flow does not have a description.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-data-flow-description
+      result: pass

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-data-flow-diagram
+  description: Test that data-flow does not have a diagram.
+  content: ../content/ssp-has-data-flow-diagram-INVALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram
+      result: fail

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-data-flow-diagram
+  description: Test that data-flow has a diagram.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram
+      result: pass

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-caption-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-caption-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-data-flow-diagram-caption
+  description: Test that data-flow diagram does not have a caption.
+  content: ../content/ssp-has-data-flow-diagram-caption-INVALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-caption
+      result: fail

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-caption-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-caption-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-data-flow-diagram-caption
+  description: Test that data-flow diagram has a caption.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-caption
+      result: pass

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-description-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-description-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-data-flow-diagram-description
+  description: Test that data-flow diagram does not have a description.
+  content: ../content/ssp-has-data-flow-diagram-description-INVALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-description
+      result: fail

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-description-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-description-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-data-flow-diagram-description
+  description: Test that data-flow diagram has a description.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-description
+      result: pass

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-data-flow-diagram-link
+  description: Test that data-flow diagram does not have a link.
+  content: ../content/ssp-has-data-flow-diagram-link-INVALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-link
+      result: fail

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-data-flow-diagram-link
+  description: Test that data-flow diagram has a link.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-link
+      result: pass

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-data-flow-diagram-link-rel
+  description: Test that data-flow diagram link does not have a rel attribute.
+  content: ../content/ssp-has-data-flow-diagram-link-rel-INVALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-link-rel
+      result: fail

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-data-flow-diagram-link-rel
+  description: Test that data-flow diagram link has a rel attribute.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-link-rel
+      result: pass

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-allowed-value-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-allowed-value-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-data-flow-diagram-link-rel-allowed-value
+  description: Test that data-flow diagram link rel attribute does not equal "diagram".
+  content: ../content/ssp-has-data-flow-diagram-link-rel-allowed-value-INVALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-link-rel-allowed-value
+      result: fail

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-allowed-value-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-allowed-value-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-data-flow-diagram-link-rel-allowed-value
+  description: Test that data-flow diagram link rel attribute equals "diagram".
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-link-rel-allowed-value
+      result: pass

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-uuid-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-uuid-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-data-flow-diagram-uuid
+  description: Test that data-flow diagram does not have a uuid attribute.
+  content: ../content/ssp-has-data-flow-diagram-uuid-INVALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-uuid
+      result: fail

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-uuid-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-uuid-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-data-flow-diagram-uuid
+  description: Test that data-flow diagram has a uuid attribute.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-data-flow-diagram-uuid
+      result: pass


### PR DESCRIPTION
# Committer Notes
### Description
Added `system-characteristics` `has-data-flow` constraints and tests for each of the constraints. These should be added as they are part of the effort write all of the constraints from the constraint tracker.

### Changes
- Added constraints `has-data-flow`, `has-data-flow-diagram`, `has-data-flow-description`, `has-data-flow-diagram-uuid`, `has-data-flow-diagram-description`, `has-data-flow-diagram-link`, `has-data-flow-diagram-caption`, `has-data-flow-diagram-link-rel`, and `has-data-flow-diagram-link-rel-allowed-value` to fedramp-external-constraints.xml.
- Added pass and fail yaml tests for all of the above constraints.
- Edited `ssp-all-VALID.xml` to ensure all constraints pass correctly.
- Added `-INVALID.xml` file for each constraint.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~~
~~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
