### PR TITLE
Add more detail to yaml test descriptions

### DIFF
--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -113,7 +113,7 @@
             <expect id="has-data-flow" target="system-characteristics" test="data-flow" level="WARNING">
                 <message>A FedRAMP SSP must include a data flow section.</message>
             </expect>
-            <expect id="has-data-flow-diagram" target="system-characteristics/data-flow" test="diagram" level="ERROR">
+            <expect id="has-data-flow-diagram" target="system-characteristics/data-flow" test="diagram" level="WARNING">
                 <message>A FedRAMP SSP must have at least one data flow diagram.</message>
             </expect>
             <expect id="has-data-flow-description" target="system-characteristics/data-flow" test="description" level="ERROR">

--- a/src/validations/constraints/unit-tests/categorization-has-correct-system-attribute-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/categorization-has-correct-system-attribute-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for categorization-has-correct-system-attribute
-  description: >-
-    This test case validates the behavior of constraint
-    categorization-has-correct-system-attribute
+  description: Test that a SSP system-characteristics categorization element does not have a system attribute equal to "https://doi.org/10.6028/NIST.SP.800-60v2r1".
   content: ../content/ssp-categorization-has-correct-system-attribute-INVALID.xml
   expectations:
     - constraint-id: categorization-has-correct-system-attribute

--- a/src/validations/constraints/unit-tests/categorization-has-correct-system-attribute-PASS.yaml
+++ b/src/validations/constraints/unit-tests/categorization-has-correct-system-attribute-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for categorization-has-correct-system-attribute
-  description: >-
-    This test case validates the behavior of constraint
-    categorization-has-correct-system-attribute
+  description: Test that a SSP system-characteristics categorization element has a system attribute equal to "https://doi.org/10.6028/NIST.SP.800-60v2r1".
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: categorization-has-correct-system-attribute

--- a/src/validations/constraints/unit-tests/categorization-has-information-type-id-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/categorization-has-information-type-id-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for categorization-has-information-type-id
-  description: >-
-    This test case validates the behavior of constraint
-    categorization-has-information-type-id
+  description: Test that a SSP system-characteristics categorization element does not have an information-type-id element.
   content: ../content/ssp-categorization-has-information-type-id-INVALID.xml
   expectations:
     - constraint-id: categorization-has-information-type-id

--- a/src/validations/constraints/unit-tests/categorization-has-information-type-id-PASS.yaml
+++ b/src/validations/constraints/unit-tests/categorization-has-information-type-id-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for categorization-has-information-type-id
-  description: >-
-    This test case validates the behavior of constraint
-    categorization-has-information-type-id
+  description: Test that a SSP system-characteristics categorization element has an information-type-id element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: categorization-has-information-type-id

--- a/src/validations/constraints/unit-tests/has-authenticator-assurance-level-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authenticator-assurance-level-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-authenticator-assurance-level
-  description: >-
-    This test case validates the behavior of constraint
-    has-authenticator-assurance-level
+  description: Test that a SSP system-characteristics element does not have a prop with a name equal to "authenticator-assurance-level".
   content: ../content/ssp-has-authenticator-assurance-level-INVALID.xml
   expectations:
     - constraint-id: has-authenticator-assurance-level

--- a/src/validations/constraints/unit-tests/has-authenticator-assurance-level-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authenticator-assurance-level-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-authenticator-assurance-level
-  description: >-
-    This test case validates the behavior of constraint
-    has-authenticator-assurance-level
+  description: Test that a SSP system-characteristics element does not have a prop with a name equal to "authenticator-assurance-level".
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-authenticator-assurance-level

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-authorization-boundary-diagram
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram
+  description: Test that a SSP authorization-boundary element does not have a diagram element.
   content: ../content/ssp-has-authorization-boundary-diagram-INVALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-authorization-boundary-diagram
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram
+  description: Test that a SSP system-characteristics element has an authorization-boundary diagram element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-caption-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-caption-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-authorization-boundary-diagram-caption
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-caption
+  description: Test that a SSP authorization-boundary diagram element does not have a caption element.
   content: ../content/ssp-has-authorization-boundary-diagram-caption-INVALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-caption

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-caption-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-caption-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-authorization-boundary-diagram-caption
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-caption
+  description: Test that a SSP authorization-boundary diagram element has a caption element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-caption

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-description-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-description-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-authorization-boundary-diagram-description
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-description
+  description: Test that a SSP authorization-boundary diagram element does not have a description element.
   content: ../content/ssp-has-authorization-boundary-diagram-description-INVALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-description

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-description-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-description-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-authorization-boundary-diagram-description
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-description
+  description: Test that a SSP authorization-boundary diagram element has a description element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-description

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-authorization-boundary-diagram-link
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-link
+  description: Test that a SSP authorization-boundary diagram element does not have a link element.
   content: ../content/ssp-has-authorization-boundary-diagram-link-INVALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-link

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-authorization-boundary-diagram-link
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-link
+  description: Test that a SSP authorization-boundary diagram element does not have a link element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-link

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-authorization-boundary-diagram-link-rel
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-link-rel
+  description: Test that a SSP authorization-boundary diagram link element does not have a rel attribute.
   content: ../content/ssp-has-authorization-boundary-diagram-link-rel-INVALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-link-rel

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-authorization-boundary-diagram-link-rel
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-link-rel
+  description: Test that a SSP authorization-boundary diagram link element has a rel attribute.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-link-rel

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-authorization-boundary-diagram-link-rel-allowed-value
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-link-rel-allowed-value
+  description: Test that a SSP authorization-boundary diagram link rel attribute does not equal "diagram".
   content: ../content/ssp-has-authorization-boundary-diagram-link-rel-allowed-value-INVALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-link-rel-allowed-value

--- a/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-allowed-value-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-authorization-boundary-diagram-link-rel-allowed-value-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-authorization-boundary-diagram-link-rel-allowed-value
-  description: >-
-    This test case validates the behavior of constraint
-    has-authorization-boundary-diagram-link-rel-allowed-value
+  description: Test that a SSP authorization-boundary diagram link rel attribute equals "diagram".
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-authorization-boundary-diagram-link-rel-allowed-value

--- a/src/validations/constraints/unit-tests/has-configuration-management-plan-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-configuration-management-plan-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-configuration-management-plan
-  description: >-
-    This test case validates the behavior of constraint
-    has-configuration-management-plan
+  description: Test that a SSP back-matter resource element does not have a configuration-management-plan element.
   content: ../content/ssp-has-configuration-management-plan-INVALID.xml
   expectations:
     - constraint-id: has-configuration-management-plan

--- a/src/validations/constraints/unit-tests/has-configuration-management-plan-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-configuration-management-plan-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-configuration-management-plan
-  description: >-
-    This test case validates the behavior of constraint
-    has-configuration-management-plan
+  description: Test that a SSP back-matter resource element has a configuration-management-plan element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-configuration-management-plan

--- a/src/validations/constraints/unit-tests/has-data-flow-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-data-flow
-  description: Test that system-characteristics does not have a data-flow element.
+  description: Test that a SSP system-characteristics element does not have a data-flow element.
   content: ../content/ssp-has-data-flow-INVALID.xml
   expectations:
     - constraint-id: has-data-flow

--- a/src/validations/constraints/unit-tests/has-data-flow-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-data-flow
-  description: Test that system-characteristics has a data-flow element.
+  description: Test that a SSP system-characteristics element has a data-flow element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-data-flow

--- a/src/validations/constraints/unit-tests/has-data-flow-description-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-description-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-data-flow-description
-  description: Test that data-flow does not have a description.
+  description: Test that a SSP data-flow element does not have a description element.
   content: ../content/ssp-has-data-flow-description-INVALID.xml
   expectations:
     - constraint-id: has-data-flow-description

--- a/src/validations/constraints/unit-tests/has-data-flow-description-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-description-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-data-flow-description
-  description: Test that data-flow does not have a description.
+  description: Test that a SSP data-flow element does not have a description element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-data-flow-description

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-data-flow-diagram
-  description: Test that data-flow does not have a diagram.
+  description: Test that a SSP data-flow element does not have a diagram element.
   content: ../content/ssp-has-data-flow-diagram-INVALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-data-flow-diagram
-  description: Test that data-flow has a diagram.
+  description: Test that a SSP data-flow element has a diagram element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-caption-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-caption-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-data-flow-diagram-caption
-  description: Test that data-flow diagram does not have a caption.
+  description: Test that a SSP data-flow diagram element does not have a caption element.
   content: ../content/ssp-has-data-flow-diagram-caption-INVALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-caption

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-caption-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-caption-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-data-flow-diagram-caption
-  description: Test that data-flow diagram has a caption.
+  description: Test that a SSP data-flow diagram element has a caption element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-caption

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-description-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-description-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-data-flow-diagram-description
-  description: Test that data-flow diagram does not have a description.
+  description: Test that a SSP data-flow diagram element does not have a description element.
   content: ../content/ssp-has-data-flow-diagram-description-INVALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-description

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-description-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-description-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-data-flow-diagram-description
-  description: Test that data-flow diagram has a description.
+  description: Test that a SSP data-flow diagram element has a description element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-description

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-data-flow-diagram-link
-  description: Test that data-flow diagram does not have a link.
+  description: Test that a SSP data-flow diagram element does not have a link element.
   content: ../content/ssp-has-data-flow-diagram-link-INVALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-link

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-data-flow-diagram-link
-  description: Test that data-flow diagram has a link.
+  description: Test that a SSP data-flow diagram element has a link element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-link

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-data-flow-diagram-link-rel
-  description: Test that data-flow diagram link does not have a rel attribute.
+  description: Test that a SSP data-flow diagram link element does not have a rel attribute.
   content: ../content/ssp-has-data-flow-diagram-link-rel-INVALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-link-rel

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-data-flow-diagram-link-rel
-  description: Test that data-flow diagram link has a rel attribute.
+  description: Test that a SSP data-flow diagram link element has a rel attribute.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-link-rel

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-allowed-value-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-allowed-value-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-data-flow-diagram-link-rel-allowed-value
-  description: Test that data-flow diagram link rel attribute does not equal "diagram".
+  description: Test that a SSP data-flow diagram link rel attribute does not equal "diagram".
   content: ../content/ssp-has-data-flow-diagram-link-rel-allowed-value-INVALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-link-rel-allowed-value

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-allowed-value-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-link-rel-allowed-value-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-data-flow-diagram-link-rel-allowed-value
-  description: Test that data-flow diagram link rel attribute equals "diagram".
+  description: Test that a SSP data-flow diagram link rel attribute equals "diagram".
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-link-rel-allowed-value

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-uuid-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-uuid-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-data-flow-diagram-uuid
-  description: Test that data-flow diagram does not have a uuid attribute.
+  description: Test that a SSP data-flow diagram element does not have a uuid attribute.
   content: ../content/ssp-has-data-flow-diagram-uuid-INVALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-uuid

--- a/src/validations/constraints/unit-tests/has-data-flow-diagram-uuid-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-data-flow-diagram-uuid-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-data-flow-diagram-uuid
-  description: Test that data-flow diagram has a uuid attribute.
+  description: Test that a SSP data-flow diagram element has a uuid attribute.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-data-flow-diagram-uuid

--- a/src/validations/constraints/unit-tests/has-federation-assurance-level-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-federation-assurance-level-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-federation-assurance-level
-  description: >-
-    This test case validates the behavior of constraint
-    has-federation-assurance-level
+  description: Test that a SSP system-characteristics element does not have a prop with a name equal to "federation-assurance-level".
   content: ../content/ssp-has-federation-assurance-level-INVALID.xml
   expectations:
     - constraint-id: has-federation-assurance-level

--- a/src/validations/constraints/unit-tests/has-federation-assurance-level-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-federation-assurance-level-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-federation-assurance-level
-  description: >-
-    This test case validates the behavior of constraint
-    has-federation-assurance-level
+  description: Test that a SSP system-characteristics element has a prop with a name equal to "federation-assurance-level".
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-federation-assurance-level

--- a/src/validations/constraints/unit-tests/has-identity-assurance-level-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-identity-assurance-level-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-identity-assurance-level
-  description: >-
-    This test case validates the behavior of constraint
-    has-identity-assurance-level
+  description: Test that a SSP system-characteristics element does not have a prop with a name equal to "identity-assurance-level".
   content: ../content/ssp-has-identity-assurance-level-INVALID.xml
   expectations:
     - constraint-id: has-identity-assurance-level

--- a/src/validations/constraints/unit-tests/has-identity-assurance-level-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-identity-assurance-level-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-identity-assurance-level
-  description: >-
-    This test case validates the behavior of constraint
-    has-identity-assurance-level
+  description: Test that a SSP system-characteristics element has a prop with a name equal to "identity-assurance-level".
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-identity-assurance-level

--- a/src/validations/constraints/unit-tests/has-incident-response-plan-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-incident-response-plan-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-incident-response-plan
-  description: >-
-    This test case validates the behavior of constraint
-    has-incident-response-plan
+  description: Test that a SSP back-matter resource element does not have an incident-response-plan element.
   content: ../content/ssp-has-incident-response-plan-INVALID.xml
   expectations:
     - constraint-id: has-incident-response-plan

--- a/src/validations/constraints/unit-tests/has-incident-response-plan-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-incident-response-plan-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-incident-response-plan
-  description: >-
-    This test case validates the behavior of constraint
-    has-incident-response-plan
+  description: Test that a SSP back-matter resource element has an incident-response-plan element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-incident-response-plan

--- a/src/validations/constraints/unit-tests/has-information-system-contingency-plan-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-information-system-contingency-plan-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-information-system-contingency-plan
-  description: >-
-    This test case validates the behavior of constraint
-    has-information-system-contingency-plan
+  description: Test that a SSP back-matter resource element does not have an information-system-contigency-plan element.
   content: ../content/ssp-has-information-system-contingency-plan-INVALID.xml
   expectations:
     - constraint-id: has-information-system-contingency-plan

--- a/src/validations/constraints/unit-tests/has-information-system-contingency-plan-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-information-system-contingency-plan-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-information-system-contingency-plan
-  description: >-
-    This test case validates the behavior of constraint
-    has-information-system-contingency-plan
+  description: Test that a SSP back-matter resource element has a information-system-contigency-plan element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-information-system-contingency-plan

--- a/src/validations/constraints/unit-tests/has-network-architecture-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-network-architecture
-  description: This test case validates the behavior of constraint has-network-architecture
+  description: Test that a SSP system-characteristics element does not have a network-architecture element.
   content: ../content/ssp-has-network-architecture-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture

--- a/src/validations/constraints/unit-tests/has-network-architecture-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-network-architecture
-  description: This test case validates the behavior of constraint has-network-architecture
+  description: Test that a SSP system-characteristics element has a network-architecture element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-network-architecture

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-network-architecture-diagram
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram
+  description: Test that a SSP network-architecture element does not have a diagram element.
   content: ../content/ssp-has-network-architecture-diagram-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-network-architecture-diagram
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram
+  description: Test that a SSP network-architecture element has a diagram element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-caption-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-caption-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-network-architecture-diagram-caption
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-caption
+  description: Test that a SSP network-architecture diagram element does not have a caption element.
   content: ../content/ssp-has-network-architecture-diagram-caption-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-caption

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-caption-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-caption-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-network-architecture-diagram-caption
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-caption
+  description: Test that a SSP network-architecture diagram element has a caption element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-caption

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-description-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-description-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-network-architecture-diagram-description
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-description
+  description: Test that a SSP network-architecture diagram element does not have a description element.
   content: ../content/ssp-has-network-architecture-diagram-description-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-description

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-description-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-description-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-network-architecture-diagram-description
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-description
+  description: Test that a SSP network-architecture diagram element has a description element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-description

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-network-architecture-diagram-link
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-link
+  description: Test that a SSP network-architecture diagram element does not have a link element.
   content: ../content/ssp-has-network-architecture-diagram-link-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-link

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-network-architecture-diagram-link
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-link
+  description: Test that a SSP network-architecture diagram element has a link element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-link

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-network-architecture-diagram-link-rel
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-link-rel
+  description: Test that a SSP network-architecture diagram link element does not have a rel attribute.
   content: ../content/ssp-has-network-architecture-diagram-link-rel-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-link-rel

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-network-architecture-diagram-link-rel
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-link-rel
+  description: Test that a SSP network-architecture diagram link element has a rel attribute.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-link-rel

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-allowed-value-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-allowed-value-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-network-architecture-diagram-link-rel-allowed-value
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-link-rel-allowed-value
+  description: Test that a SSP network-architecture diagram link rel attribute does not equal "diagram".
   content: ../content/ssp-has-network-architecture-diagram-link-rel-allowed-value-INVALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-link-rel-allowed-value

--- a/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-allowed-value-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-network-architecture-diagram-link-rel-allowed-value-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-network-architecture-diagram-link-rel-allowed-value
-  description: >-
-    This test case validates the behavior of constraint
-    has-network-architecture-diagram-link-rel-allowed-value
+  description: Test that a SSP network-architecture diagram link rel attribute equals "diagram".
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-network-architecture-diagram-link-rel-allowed-value

--- a/src/validations/constraints/unit-tests/has-rules-of-behavior-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-rules-of-behavior-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-rules-of-behavior
-  description: This test case validates the behavior of constraint has-rules-of-behavior
+  description: Test that a SSP back-matter resource element does not have a rules-of-behavior element.
   content: ../content/ssp-has-rules-of-behavior-INVALID.xml
   expectations:
     - constraint-id: has-rules-of-behavior

--- a/src/validations/constraints/unit-tests/has-rules-of-behavior-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-rules-of-behavior-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-rules-of-behavior
-  description: This test case validates the behavior of constraint has-rules-of-behavior
+  description: Test that a SSP back-matter resource element has a rules-of-behavior element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-rules-of-behavior

--- a/src/validations/constraints/unit-tests/has-separation-of-duties-matrix-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-separation-of-duties-matrix-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for has-separation-of-duties-matrix
-  description: >-
-    This test case validates the behavior of constraint
-    has-separation-of-duties-matrix
+  description: Test that a SSP back-matter resource element does not have a separation-of-duties-matrix element.
   content: ../content/ssp-has-separation-of-duties-matrix-INVALID.xml
   expectations:
     - constraint-id: has-separation-of-duties-matrix

--- a/src/validations/constraints/unit-tests/has-separation-of-duties-matrix-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-separation-of-duties-matrix-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for has-separation-of-duties-matrix
-  description: >-
-    This test case validates the behavior of constraint
-    has-separation-of-duties-matrix
+  description: Test that a SSP back-matter resource element has a separation-of-duties-matrix element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-separation-of-duties-matrix

--- a/src/validations/constraints/unit-tests/has-user-guide-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-user-guide-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for has-user-guide
-  description: This test case validates the behavior of constraint has-user-guide
+  description: Test that a SSP back-matter resource element does not have a user-guide element.
   content: ../content/ssp-has-user-guide-INVALID.xml
   expectations:
     - constraint-id: has-user-guide

--- a/src/validations/constraints/unit-tests/has-user-guide-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-user-guide-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for has-user-guide
-  description: This test case validates the behavior of constraint has-user-guide
+  description: Test that a SSP back-matter resource element has a user-guide element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: has-user-guide

--- a/src/validations/constraints/unit-tests/resource-has-base64-or-rlink-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/resource-has-base64-or-rlink-FAIL.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Negative Test for resource-has-base64-or-rlink
-  description: >-
-    This test case validates the behavior of constraint
-    resource-has-base64-or-rlink
+  description: Test that a SSP back-matter resource element does not have a base64 or rlink element.
   content: ../content/ssp-resource-has-base64-or-rlink-INVALID.xml
   expectations:
     - constraint-id: resource-has-base64-or-rlink

--- a/src/validations/constraints/unit-tests/resource-has-base64-or-rlink-PASS.yaml
+++ b/src/validations/constraints/unit-tests/resource-has-base64-or-rlink-PASS.yaml
@@ -1,8 +1,6 @@
 test-case:
   name: Positive Test for resource-has-base64-or-rlink
-  description: >-
-    This test case validates the behavior of constraint
-    resource-has-base64-or-rlink
+  description: Test that a SSP back-matter resource element has a base64 or rlink element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: resource-has-base64-or-rlink

--- a/src/validations/constraints/unit-tests/resource-has-title-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/resource-has-title-FAIL.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Negative Test for resource-has-title
-  description: This test case validates the behavior of constraint resource-has-title
+  description: Test that a SSP back-matter resource element does not have a title element.
   content: ../content/ssp-resource-has-title-INVALID.xml
   expectations:
     - constraint-id: resource-has-title

--- a/src/validations/constraints/unit-tests/resource-has-title-PASS.yaml
+++ b/src/validations/constraints/unit-tests/resource-has-title-PASS.yaml
@@ -1,6 +1,6 @@
 test-case:
   name: Positive Test for resource-has-title
-  description: This test case validates the behavior of constraint resource-has-title
+  description: Test that a SSP back-matter resource element has a title element.
   content: ../content/ssp-all-VALID.xml
   expectations:
     - constraint-id: resource-has-title


### PR DESCRIPTION
# Committer Notes
### Description 
Added more detail to yaml test descriptions. These changes should be added as they are part of the effort write all of the constraints from the constraint tracker.

### Changes
- Modified yaml tests to add more detail to the test description. 
- Modified `feature-external-constraints.xml` to change `has-data-flow-diagram` level from `ERROR` to `WARNING` (correction).

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~~
~~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
