### PR TITLE
hotfix constraint script for windows

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Read node version from `.nvmrc` file
         id: nvmrc
@@ -32,7 +32,7 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Install required node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7
         with:
           node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
 

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,4 +1,4 @@
-name: "OSCAL Validations: Unit Tests"
+name: "Cross platform script test"
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 jobs:
-  run-tests:
+  test-scripts:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
 
       - name: Install OSCAL CLI
-        run: make init-validations
+        run: make configure
 
       - name: Run Constraint script tests
         shell: bash

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,48 @@
+name: "OSCAL Validations: Unit Tests"
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - 'feature/**'
+  pull_request:
+
+jobs:
+  run-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, windows-2022]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Read node version from `.nvmrc` file
+        id: nvmrc
+        shell: bash
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+
+      - name: Install required node.js version
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
+
+      - name: Install OSCAL CLI
+        run: make init-validations
+
+      - name: Run Constraint script tests
+        shell: bash
+        run: |
+          set -e
+          npm run constraint resource-has-title
+        env:
+          CI: true

--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -45,38 +45,38 @@ Examples:
   | deployment-model-PASS.yaml |
   | has-authenticator-assurance-level-FAIL.yaml |
   | has-authenticator-assurance-level-PASS.yaml |
+  | has-authorization-boundary-diagram-FAIL.yaml |
+  | has-authorization-boundary-diagram-PASS.yaml |
   | has-authorization-boundary-diagram-caption-FAIL.yaml |
   | has-authorization-boundary-diagram-caption-PASS.yaml |
   | has-authorization-boundary-diagram-description-FAIL.yaml |
   | has-authorization-boundary-diagram-description-PASS.yaml |
-  | has-authorization-boundary-diagram-FAIL.yaml |
   | has-authorization-boundary-diagram-link-FAIL.yaml |
   | has-authorization-boundary-diagram-link-PASS.yaml |
-  | has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml |
-  | has-authorization-boundary-diagram-link-rel-allowed-value-PASS.yaml |
   | has-authorization-boundary-diagram-link-rel-FAIL.yaml |
   | has-authorization-boundary-diagram-link-rel-PASS.yaml |
-  | has-authorization-boundary-diagram-PASS.yaml |
+  | has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml |
+  | has-authorization-boundary-diagram-link-rel-allowed-value-PASS.yaml |
   | has-configuration-management-plan-FAIL.yaml |
   | has-configuration-management-plan-PASS.yaml |
+  | has-data-flow-FAIL.yaml |
+  | has-data-flow-PASS.yaml |
   | has-data-flow-description-FAIL.yaml |
   | has-data-flow-description-PASS.yaml |
+  | has-data-flow-diagram-FAIL.yaml |
+  | has-data-flow-diagram-PASS.yaml |
   | has-data-flow-diagram-caption-FAIL.yaml |
   | has-data-flow-diagram-caption-PASS.yaml |
   | has-data-flow-diagram-description-FAIL.yaml |
   | has-data-flow-diagram-description-PASS.yaml |
-  | has-data-flow-diagram-FAIL.yaml |
   | has-data-flow-diagram-link-FAIL.yaml |
   | has-data-flow-diagram-link-PASS.yaml |
-  | has-data-flow-diagram-link-rel-allowed-value-FAIL.yaml |
-  | has-data-flow-diagram-link-rel-allowed-value-PASS.yaml |
   | has-data-flow-diagram-link-rel-FAIL.yaml |
   | has-data-flow-diagram-link-rel-PASS.yaml |
-  | has-data-flow-diagram-PASS.yaml |
+  | has-data-flow-diagram-link-rel-allowed-value-FAIL.yaml |
+  | has-data-flow-diagram-link-rel-allowed-value-PASS.yaml |
   | has-data-flow-diagram-uuid-FAIL.yaml |
   | has-data-flow-diagram-uuid-PASS.yaml |
-  | has-data-flow-FAIL.yaml |
-  | has-data-flow-PASS.yaml |
   | has-federation-assurance-level-FAIL.yaml |
   | has-federation-assurance-level-PASS.yaml |
   | has-identity-assurance-level-FAIL.yaml |
@@ -85,20 +85,20 @@ Examples:
   | has-incident-response-plan-PASS.yaml |
   | has-information-system-contingency-plan-FAIL.yaml |
   | has-information-system-contingency-plan-PASS.yaml |
+  | has-network-architecture-FAIL.yaml |
+  | has-network-architecture-PASS.yaml |
+  | has-network-architecture-diagram-FAIL.yaml |
+  | has-network-architecture-diagram-PASS.yaml |
   | has-network-architecture-diagram-caption-FAIL.yaml |
   | has-network-architecture-diagram-caption-PASS.yaml |
   | has-network-architecture-diagram-description-FAIL.yaml |
   | has-network-architecture-diagram-description-PASS.yaml |
-  | has-network-architecture-diagram-FAIL.yaml |
   | has-network-architecture-diagram-link-FAIL.yaml |
   | has-network-architecture-diagram-link-PASS.yaml |
-  | has-network-architecture-diagram-link-rel-allowed-value-FAIL.yaml |
-  | has-network-architecture-diagram-link-rel-allowed-value-PASS.yaml |
   | has-network-architecture-diagram-link-rel-FAIL.yaml |
   | has-network-architecture-diagram-link-rel-PASS.yaml |
-  | has-network-architecture-diagram-PASS.yaml |
-  | has-network-architecture-FAIL.yaml |
-  | has-network-architecture-PASS.yaml |
+  | has-network-architecture-diagram-link-rel-allowed-value-FAIL.yaml |
+  | has-network-architecture-diagram-link-rel-allowed-value-PASS.yaml |
   | has-rules-of-behavior-FAIL.yaml |
   | has-rules-of-behavior-PASS.yaml |
   | has-separation-of-duties-matrix-FAIL.yaml |

--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -45,38 +45,38 @@ Examples:
   | deployment-model-PASS.yaml |
   | has-authenticator-assurance-level-FAIL.yaml |
   | has-authenticator-assurance-level-PASS.yaml |
-  | has-authorization-boundary-diagram-FAIL.yaml |
-  | has-authorization-boundary-diagram-PASS.yaml |
   | has-authorization-boundary-diagram-caption-FAIL.yaml |
   | has-authorization-boundary-diagram-caption-PASS.yaml |
   | has-authorization-boundary-diagram-description-FAIL.yaml |
   | has-authorization-boundary-diagram-description-PASS.yaml |
+  | has-authorization-boundary-diagram-FAIL.yaml |
   | has-authorization-boundary-diagram-link-FAIL.yaml |
   | has-authorization-boundary-diagram-link-PASS.yaml |
-  | has-authorization-boundary-diagram-link-rel-FAIL.yaml |
-  | has-authorization-boundary-diagram-link-rel-PASS.yaml |
   | has-authorization-boundary-diagram-link-rel-allowed-value-FAIL.yaml |
   | has-authorization-boundary-diagram-link-rel-allowed-value-PASS.yaml |
+  | has-authorization-boundary-diagram-link-rel-FAIL.yaml |
+  | has-authorization-boundary-diagram-link-rel-PASS.yaml |
+  | has-authorization-boundary-diagram-PASS.yaml |
   | has-configuration-management-plan-FAIL.yaml |
   | has-configuration-management-plan-PASS.yaml |
-  | has-data-flow-FAIL.yaml |
-  | has-data-flow-PASS.yaml |
   | has-data-flow-description-FAIL.yaml |
   | has-data-flow-description-PASS.yaml |
-  | has-data-flow-diagram-FAIL.yaml |
-  | has-data-flow-diagram-PASS.yaml |
   | has-data-flow-diagram-caption-FAIL.yaml |
   | has-data-flow-diagram-caption-PASS.yaml |
   | has-data-flow-diagram-description-FAIL.yaml |
   | has-data-flow-diagram-description-PASS.yaml |
+  | has-data-flow-diagram-FAIL.yaml |
   | has-data-flow-diagram-link-FAIL.yaml |
   | has-data-flow-diagram-link-PASS.yaml |
-  | has-data-flow-diagram-link-rel-FAIL.yaml |
-  | has-data-flow-diagram-link-rel-PASS.yaml |
   | has-data-flow-diagram-link-rel-allowed-value-FAIL.yaml |
   | has-data-flow-diagram-link-rel-allowed-value-PASS.yaml |
+  | has-data-flow-diagram-link-rel-FAIL.yaml |
+  | has-data-flow-diagram-link-rel-PASS.yaml |
+  | has-data-flow-diagram-PASS.yaml |
   | has-data-flow-diagram-uuid-FAIL.yaml |
   | has-data-flow-diagram-uuid-PASS.yaml |
+  | has-data-flow-FAIL.yaml |
+  | has-data-flow-PASS.yaml |
   | has-federation-assurance-level-FAIL.yaml |
   | has-federation-assurance-level-PASS.yaml |
   | has-identity-assurance-level-FAIL.yaml |
@@ -85,20 +85,20 @@ Examples:
   | has-incident-response-plan-PASS.yaml |
   | has-information-system-contingency-plan-FAIL.yaml |
   | has-information-system-contingency-plan-PASS.yaml |
-  | has-network-architecture-FAIL.yaml |
-  | has-network-architecture-PASS.yaml |
-  | has-network-architecture-diagram-FAIL.yaml |
-  | has-network-architecture-diagram-PASS.yaml |
   | has-network-architecture-diagram-caption-FAIL.yaml |
   | has-network-architecture-diagram-caption-PASS.yaml |
   | has-network-architecture-diagram-description-FAIL.yaml |
   | has-network-architecture-diagram-description-PASS.yaml |
+  | has-network-architecture-diagram-FAIL.yaml |
   | has-network-architecture-diagram-link-FAIL.yaml |
   | has-network-architecture-diagram-link-PASS.yaml |
-  | has-network-architecture-diagram-link-rel-FAIL.yaml |
-  | has-network-architecture-diagram-link-rel-PASS.yaml |
   | has-network-architecture-diagram-link-rel-allowed-value-FAIL.yaml |
   | has-network-architecture-diagram-link-rel-allowed-value-PASS.yaml |
+  | has-network-architecture-diagram-link-rel-FAIL.yaml |
+  | has-network-architecture-diagram-link-rel-PASS.yaml |
+  | has-network-architecture-diagram-PASS.yaml |
+  | has-network-architecture-FAIL.yaml |
+  | has-network-architecture-PASS.yaml |
   | has-rules-of-behavior-FAIL.yaml |
   | has-rules-of-behavior-PASS.yaml |
   | has-separation-of-duties-matrix-FAIL.yaml |

--- a/features/steps/fedramp_extensions_steps.ts
+++ b/features/steps/fedramp_extensions_steps.ts
@@ -81,7 +81,7 @@ function getConstraintTests() {
   );
   const files = readdirSync(constraintTestDir);
   const filteredFiles = files
-    .filter((file) => file.endsWith(".yaml") || file.endsWith(".yml"))
+    .filter((file) => file.endsWith(".yaml") || file.endsWith(".yml")).sort()
     .map((file) => `  | ${file} |`)
     .join("\n");
   return filteredFiles;
@@ -97,7 +97,7 @@ async function getConstraintIds() {
   );
   const files = readdirSync(constraintDir);
   const xmlFiles = files
-    .filter((file) => file.endsWith(".xml"))
+    .filter((file) => file.endsWith(".xml")).sort()
     .filter((file) => !file.endsWith(ignoreDocument));
   let allConstraintIds = [];
 
@@ -142,7 +142,7 @@ Given("I have Metaschema extensions documents", function (dataTable) {
   );
   const files = readdirSync(constraintDir);
   metaschemaDocuments = files
-    .filter((file) => file.endsWith(".xml"))
+    .filter((file) => file.endsWith(".xml")).sort()
     .filter((x) => !x.startsWith("oscal")) //temporary
     .map((file) => join(constraintDir, file));
 });
@@ -431,8 +431,8 @@ Given("I have loaded all Metaschema extensions documents", function () {
   );
   const files = readdirSync(constraintDir);
   metaschemaDocuments = files
-    .filter((file) => file.endsWith(".xml"))
-    .map((file) => join(constraintDir, file));
+    .filter((file) => file.endsWith(".xml")).sort()
+    .map((file) => join(constraintDir, file))
   console.log(
     `Loaded ${metaschemaDocuments.length} Metaschema extension documents`
   );
@@ -545,7 +545,7 @@ Given(
       "unit-tests"
     );
     yamlTestFiles = readdirSync(testDir)
-      .filter((file) => file.endsWith(".yaml") || file.endsWith(".yml"))
+      .filter((file) => file.endsWith(".yaml") || file.endsWith(".yml")).sort()
       .map((file) => join(testDir, file));
     console.log(`Collected ${yamlTestFiles.length} YAML test files`);
   }

--- a/src/scripts/dev-constraint.js
+++ b/src/scripts/dev-constraint.js
@@ -6,14 +6,16 @@ import {JSDOM} from "jsdom"
 import { execSync } from 'child_process';
 import inquirer from 'inquirer';
 import xmlFormatter from 'xml-formatter';
+import { fileURLToPath } from 'url';
 
 const prompt = inquirer.createPromptModule();
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
-const constraintsDir = path.join(__dirname, '../../src', 'validations', 'constraints');
-const testDir = path.join(__dirname, '../../src', 'validations', 'constraints', 'unit-tests');
-const featureFile = path.join(__dirname,"../../features/", 'fedramp_extensions.feature');
+const constraintsDir = path.join(__dirname, '..','..','src', 'validations', 'constraints');
+const testDir = path.join(__dirname, '..','..','src', 'validations', 'constraints', 'unit-tests');
+const featureFile = path.join(__dirname,'..','..',"features", 'fedramp_extensions.feature');
 
 
 const ignoreDocument = "oscal-external-constraints.xml";

--- a/src/scripts/dev-constraint.js
+++ b/src/scripts/dev-constraint.js
@@ -88,7 +88,6 @@ async function getAllConstraints() {
                 allConstraints.push(id);
                 allContext[id] = context;
 
-                console.log(`Constraint ${id} context: ${context}`); // Debug log
             } else {
                 console.log(`Warning: No context found for constraint ${id}`);
             }

--- a/src/scripts/dev-constraint.js
+++ b/src/scripts/dev-constraint.js
@@ -407,8 +407,11 @@ async function runCucumberTest(constraintId, testFiles) {
     }
 
     try {
+        const isWindows = process.platform === 'win32';
         for (const line of scenarioLines) {
-            const command = `set NODE_OPTIONS=${nodeOptions} && ${cucumberCommand} ${featureFile}:${line}`;
+            const command = isWindows
+            ? `set "NODE_OPTIONS=${nodeOptions}" && ${cucumberCommand} "${featureFile}:${line}"`
+            : `NODE_OPTIONS="${nodeOptions}" ${cucumberCommand} "${featureFile}:${line}"`;
             execSync(command, { stdio: 'inherit', shell: true });
         }
         console.log(`Cucumber tests for ${constraintId} passed successfully.`);

--- a/src/scripts/dev-constraint.js
+++ b/src/scripts/dev-constraint.js
@@ -346,8 +346,9 @@ function getScenarioLineNumbers(featureFile, constraintId,tests) {
     const content = fs.readFileSync(featureFile, 'utf8');
     const lines = content.split('\n');
     const scenarioLines = [];
+    console.log(featureFile,tests,constraintId);
     for (let i = 0; i < lines.length; i++) {
-        if (lines[i].includes(`${tests.fail_file}`) || lines[i].includes(`${tests.pass_file}`)) {
+        if (lines[i].includes(`${tests.fail}`) || lines[i].includes(`${tests.pass}`)||lines[i].includes(`${tests.fail_file}`) || lines[i].includes(`${tests.pass_file}`)) {
             scenarioLines.push(i + 1); // +1 because line numbers start at 1, not 0
         }
     }
@@ -388,9 +389,9 @@ async function runCucumberTest(constraintId, testFiles) {
     }
 
     const nodeOptions = '--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node';
-    const cucumberCommand = `NODE_OPTIONS="${nodeOptions}" npx cucumber-js`;
+    const cucumberCommand = `npx cucumber-js`;
 
-    let scenarioLines = getScenarioLineNumbers(featureFile, constraintId,testFiles);
+    let scenarioLines = getScenarioLineNumbers(featureFile, constraintId, testFiles);
 
     if (scenarioLines.length === 0) {
         console.error(`No scenarios found for constraintId: ${constraintId}`);
@@ -398,17 +399,17 @@ async function runCucumberTest(constraintId, testFiles) {
             shell: true,
             stdio: 'ignore',
             cwd: path.join(__dirname, '..', '..') 
-          });     
-        scenarioLines = getScenarioLineNumbers(featureFile, constraintId,testFiles);
-        if(scenarioLines.length===0){
-        return false;
+        });     
+        scenarioLines = getScenarioLineNumbers(featureFile, constraintId, testFiles);
+        if (scenarioLines.length === 0) {
+            return false;
         }
     }
 
     try {
         for (const line of scenarioLines) {
-            const command = `${cucumberCommand} ${featureFile}:${line}`;
-            execSync(command, { stdio: 'inherit' });
+            const command = `set NODE_OPTIONS=${nodeOptions} && ${cucumberCommand} ${featureFile}:${line}`;
+            execSync(command, { stdio: 'inherit', shell: true });
         }
         console.log(`Cucumber tests for ${constraintId} passed successfully.`);
         return true;


### PR DESCRIPTION
# Committer Notes

After switching the run environment of the dev-constraint script we neglected to update our method of finding the constraint directory path for windows.

this adds a github action to assure that the test script runs correctly in windows and linux


### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
