### PR TITLE
Add  `system-has-id` constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -103,6 +103,8 @@ Examples:
   | has-rules-of-behavior-PASS.yaml |
   | has-separation-of-duties-matrix-FAIL.yaml |
   | has-separation-of-duties-matrix-PASS.yaml |
+  | has-system-id-FAIL.yaml |
+  | has-system-id-PASS.yaml |
   | has-user-guide-FAIL.yaml |
   | has-user-guide-PASS.yaml |
   | information-type-system-FAIL.yaml |
@@ -198,6 +200,7 @@ Examples:
   | has-network-architecture-diagram-link-rel-allowed-value |
   | has-rules-of-behavior |
   | has-separation-of-duties-matrix |
+  | has-system-id |
   | has-user-guide |
   | information-type-system |
   | interconnection-direction |

--- a/src/validations/constraints/content/ssp-has-system-id-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-system-id-INVALID.xml
@@ -1,0 +1,5 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+    <system-id identifier-type="https://not-fedramp.gov">F00000001</system-id>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -137,6 +137,9 @@
             <expect id="has-data-flow-diagram-link-rel-allowed-value" target="system-characteristics/data-flow/diagram/link" test="@rel eq 'diagram'" level="ERROR">
                 <message>Each FedRAMP SSP data flow diagram must have a link rel attribute with the value "diagram".</message>
             </expect>
+            <expect id="has-system-id" target="system-characteristics" test="system-id[@identifier-type eq 'https://fedramp.gov']" level="ERROR">
+                <message>A FedRAMP SSP must have a FedRAMP system identifier.</message>
+            </expect>
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -138,6 +138,7 @@
                 <message>Each FedRAMP SSP data flow diagram must have a link rel attribute with the value "diagram".</message>
             </expect>
             <expect id="has-system-id" target="system-characteristics" test="system-id[@identifier-type eq 'https://fedramp.gov']" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-name-abbreviation-and-fedramp-unique-identifier"/>
                 <message>A FedRAMP SSP must have a FedRAMP system identifier.</message>
             </expect>
         </constraints>

--- a/src/validations/constraints/unit-tests/has-system-id-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-system-id-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-system-id
+  description: Test that a SSP system-characteristics system-id identifier-type attribute is not equal to 'https://fedramp.gov'.
+  content: ../content/ssp-has-system-id-INVALID.xml
+  expectations:
+    - constraint-id: has-system-id
+      result: fail

--- a/src/validations/constraints/unit-tests/has-system-id-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-system-id-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-system-id
+  description: Test that a SSP system-characteristics system-id identifier-type attribute is equal to 'https://fedramp.gov'.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-system-id
+      result: pass


### PR DESCRIPTION
# Committer Notes
### Description
Added `system-characteristics` `has-system-id` constraint and tests for this constraint. These changes should be added as they are part of the effort write all of the constraints from the constraint tracker.

### Changes
- Added constraint `has-system-id` to fedramp-external-constraints.xml.
- Added pass and fail yaml tests for the above constraint.
- Added `ssp-has-system-id-INVALID.xml` file for this constraint's fail case.
### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~~
~~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
