### PR TITLE
Update oscal-cli from 2.1.0->2.2.0 in Docker install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG TEMURIN_APK_KEY_URL=https://packages.adoptium.net/artifactory/api/security/k
 ARG TEMURIN_APK_REPO_URL=https://packages.adoptium.net/artifactory/apk/alpine/main
 ARG TEMURIN_APK_VERSION=temurin-22-jdk
 ARG MAVEN_DEP_PLUGIN_VERSION=3.8.0
-ARG OSCAL_CLI_VERSION=2.1.0
+ARG OSCAL_CLI_VERSION=2.2.0
 # Current public key ID for maintainers@metaschema.dev releases of oscal-cli
 # Static analysis from docker build and push warns this is a secret, it is not
 # and is necessary to cross-ref the Maven GPG key for checking build signatures.


### PR DESCRIPTION
# Committer Notes

I worked on the metaschema-framework/oscal-cli release but I was unable to finish a native OCI container build there. So, we need to update here manually again. This PR quickly addresses that.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?~
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
