### PR TITLE
763 bug fix

### DIFF
--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -62,13 +62,13 @@
             <expect id="categorization-has-information-type-id" target="system-characteristics/system-information/information-type/categorization" test="information-type-id" level="ERROR">
                 <message>A FedRAMP SSP information type categorization must have at least one information type identifier.</message>
             </expect>
-            <expect id="has-identity-assurance-level" target="system-characteristics" test="prop[@name eq 'identity-assurance-level']" level="INFORMATIONAL">
+            <expect id="has-identity-assurance-level" target="system-characteristics" test="not(exists(prop[@name eq 'identity-assurance-level']))" level="INFORMATIONAL">
                 <message>This FedRAMP SSP does define its NIST SP 800-63 identity assurance level (IAL).</message>
             </expect>
-            <expect id="has-authenticator-assurance-level" target="system-characteristics" test="prop[@name eq 'authenticator-assurance-level']" level="INFORMATIONAL">
+            <expect id="has-authenticator-assurance-level" target="system-characteristics" test="not(exists(prop[@name eq 'authenticator-assurance-level']))" level="INFORMATIONAL">
                 <message>This FedRAMP SSP does define its NIST SP 800-63 authenticator assurance level (AAL).</message>
             </expect>
-            <expect id="has-federation-assurance-level" target="system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
+            <expect id="has-federation-assurance-level" target="system-characteristics" test="not(exists(prop[@name eq 'federation-assurance-level']))" level="INFORMATIONAL">
                 <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (FAL).</message>
             </expect>
             <expect id="has-authorization-boundary-diagram" target="system-characteristics/authorization-boundary" test="diagram" level="WARNING">


### PR DESCRIPTION
# Committer Notes

This is a fix for bug 763. I want this to open a conversation about informational level constraints and how we handle them, because metapath behaves differently from schematron and only will return the message if the test conditions fail, which is counterintuitive in the case of reporting/information. This will prove problematic when we implement further informational messages and need to always set the test conditions to be negative.

Additionally, I don't understand why we want an informational message letting people know when something IS implemented, without a corresponding error or warning in the opposite case. Do we care if people do not include IAL, AAL, or FAL levels? If we care, we should at least warn people when they do not include those fields, that way they can rectify the situation. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
