### PR TITLE
Update CODEOWNERS for more detailed reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # global-owner1 and global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @GSA/fedramp-automation-admins
+*       @GSA/fedramp-oscal-contributors


### PR DESCRIPTION
# Committer Notes

We need to reviews from at least three members of the team, we should reconfigure the repo to use CODEOWNERS with not only admins, but the group that includes all the team.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?~
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
