### PR TITLE
Add security-sensitivity-level-matches-security-impact-level

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -141,6 +141,8 @@ Examples:
   | scan-type-PASS.yaml |
   | security-level-FAIL.yaml |
   | security-level-PASS.yaml |
+  | security-sensitivity-level-matches-security-impact-level-FAIL.yaml |
+  | security-sensitivity-level-matches-security-impact-level-PASS.yaml |
   | user-type-FAIL.yaml |
   | user-type-PASS.yaml |
 #END_DYNAMIC_TEST_CASES
@@ -221,5 +223,6 @@ Examples:
   | role-defined-system-owner |
   | scan-type |
   | security-level |
+  | security-sensitivity-level-matches-security-impact-level |
   | user-type |
 #END_DYNAMIC_CONSTRAINT_IDS

--- a/src/validations/constraints/content/ssp-security-sensitivity-level-matches-security-impact-level-INVALID.xml
+++ b/src/validations/constraints/content/ssp-security-sensitivity-level-matches-security-impact-level-INVALID.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
+                      uuid="12345678-1234-4321-8765-123456789012">
+  
+  <system-characteristics>
+    <security-sensitivity-level>fips-199-low</security-sensitivity-level>
+    <security-impact-level>
+      <security-objective-confidentiality>fips-199-moderate</security-objective-confidentiality>
+      <security-objective-integrity>fips-199-moderate</security-objective-integrity>
+      <security-objective-availability>fips-199-moderate</security-objective-availability>
+    </security-impact-level>
+  </system-characteristics>
+
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -149,7 +149,7 @@
             </expect>
             <expect id="security-sensitivity-level-matches-security-impact-level" target="system-characteristics/security-sensitivity-level" test=". eq $security-impact-level" level="WARNING">
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-sensitivity-level"/>
-                <message>A FedRAMP SSP MUST define its FIPS-199 security sensitivity level to match the highest security impact level for the system's confidentiality, integrity, and availability objectives.</message>
+                <message>A FedRAMP SSP SHOULD define its FIPS-199 security sensitivity level to match the highest security impact level for the system's confidentiality, integrity, and availability objectives.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -32,6 +32,12 @@
     <context>
         <metapath target="/system-security-plan"/>
         <constraints>
+            <let var="security-impact-level" expression=
+                "if (//security-impact-level//* = 'fips-199-high')
+                    then ('fips-199-high')
+                else if (//security-impact-level//* = 'fips-199-moderate')
+                    then ('fips-199-moderate')
+                else ('fips-199-low')"/>
             <expect id="resource-has-title" target="back-matter/resource" test="title" level="WARNING">
                 <message>Every supporting artifact found in a citation should have a title.</message>
             </expect>
@@ -140,6 +146,10 @@
             <expect id="has-system-id" target="system-characteristics" test="system-id[@identifier-type eq 'https://fedramp.gov']" level="ERROR">
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-name-abbreviation-and-fedramp-unique-identifier"/>
                 <message>A FedRAMP SSP must have a FedRAMP system identifier.</message>
+            </expect>
+            <expect id="security-sensitivity-level-matches-security-impact-level" target="system-characteristics/security-sensitivity-level" test=". eq $security-impact-level" level="WARNING">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-sensitivity-level"/>
+                <message>A FedRAMP SSP security sensitivity level must match the highest level within the security impact levels.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -149,7 +149,7 @@
             </expect>
             <expect id="security-sensitivity-level-matches-security-impact-level" target="system-characteristics/security-sensitivity-level" test=". eq $security-impact-level" level="WARNING">
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-sensitivity-level"/>
-                <message>A FedRAMP SSP security sensitivity level must match the highest level within the security impact levels.</message>
+                <message>A FedRAMP SSP MUST define its FIPS-199 security sensitivity level to match the highest security impact level for the system's confidentiality, integrity, and availability objectives.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/unit-tests/security-sensitivity-level-matches-security-impact-level-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/security-sensitivity-level-matches-security-impact-level-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid security-sensitivity-level-matches-security-impact-level constraint unit test.
+test-case:
+  name: The invalid security-sensitivity-level-matches-security-impact-level constraint unit test.
+  description: Test that the SSP "security-sensitivity-level" element value does not match "security-impact-level" values.
+  content: ../content/ssp-security-sensitivity-level-matches-security-impact-level-INVALID.xml
+  expectations:
+  - constraint-id: security-sensitivity-level-matches-security-impact-level
+    result: fail

--- a/src/validations/constraints/unit-tests/security-sensitivity-level-matches-security-impact-level-PASS.yaml
+++ b/src/validations/constraints/unit-tests/security-sensitivity-level-matches-security-impact-level-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid security-sensitivity-level-matches-security-impact-level constraint unit test.
+test-case:
+  name: The valid security-sensitivity-level-matches-security-impact-level constraint unit test.
+  description: Test that the SSP "security-sensitivity-level" element value matches "security-impact-level" values.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+  - constraint-id: security-sensitivity-level-matches-security-impact-level
+    result: pass


### PR DESCRIPTION
# Committer Notes

Add the `security-sensitivity-level-matches-security-impact-level` constraint.

_Note:_ Tested rigorously with various combinations of `security-sensitivity-level` and `security-impact-level` values.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?~ Already addressed in automate.fedramp.gov docs, see `help-url` in constraint.
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
