### PR TITLE
Add help-url props to constraints

### DIFF
--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -33,24 +33,31 @@
         <metapath target="/system-security-plan"/>
         <constraints>
             <expect id="resource-has-title" target="back-matter/resource" test="title" level="WARNING">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/oscal-citations-and-attachments/#citation-and-attachment-details"/>
                 <message>Every supporting artifact found in a citation should have a title.</message>
             </expect>
             <expect id="resource-has-base64-or-rlink" target="back-matter/resource" test="count(./rlink) >= 1 or count(./base64) >= 1" level="WARNING">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/oscal-citations-and-attachments/#including-multiple-rlink-and-base64-fields"/>
                 <message>Every supporting artifact found in a citation must have at least one base64 or rlink element.</message>
             </expect>
             <expect id="has-user-guide" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'users-guide']]" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>A FedRAMP SSP must have a User Guide attached.</message>
             </expect>
             <expect id="has-rules-of-behavior" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'rules-of-behavior']]" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>A FedRAMP SSP must have Rules of Behavior.</message>
             </expect>
             <expect id="has-information-system-contingency-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'information-system-contingency-plan']]" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>A FedRAMP SSP must have a Contingency Plan attached.</message>
             </expect>
             <expect id="has-configuration-management-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'configuration-management-plan']]" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>A FedRAMP SSP must have a Configuration Management Plan attached.</message>
             </expect>
             <expect id="has-incident-response-plan" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'incident-response-plan']]" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>A FedRAMP SSP must have an Incident Response Plan attached.</message>
             </expect>
             <expect id="has-separation-of-duties-matrix" target="back-matter" test="resource[prop[@name eq 'type' and @value eq 'separation-of-duties-matrix']]" level="ERROR">
@@ -63,78 +70,103 @@
                 <message>A FedRAMP SSP information type categorization must have at least one information type identifier.</message>
             </expect>
             <expect id="has-identity-assurance-level" target="system-characteristics" test="prop[@name eq 'identity-assurance-level']" level="INFORMATIONAL">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#digital-identity-level-dil-determination"/>
                 <message>This FedRAMP SSP does define its NIST SP 800-63 identity assurance level (IAL).</message>
             </expect>
             <expect id="has-authenticator-assurance-level" target="system-characteristics" test="prop[@name eq 'authenticator-assurance-level']" level="INFORMATIONAL">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#digital-identity-level-dil-determination"/>
                 <message>This FedRAMP SSP does define its NIST SP 800-63 authenticator assurance level (AAL).</message>
             </expect>
             <expect id="has-federation-assurance-level" target="system-characteristics" test="prop[@name eq 'federation-assurance-level']" level="INFORMATIONAL">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#digital-identity-level-dil-determination"/>
                 <message>This FedRAMP SSP does define its NIST SP 800-63 federation assurance level (FAL).</message>
             </expect>
             <expect id="has-authorization-boundary-diagram" target="system-characteristics/authorization-boundary" test="diagram" level="WARNING">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>A FedRAMP SSP must have at least one authorization boundary diagram.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-description" target="system-characteristics/authorization-boundary/diagram" test="description" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>A FedRAMP SSP document authorization boundary diagram must have a description.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-link" target="system-characteristics/authorization-boundary/diagram" test="link" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>Each FedRAMP SSP authorization boundary diagram must have a link.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-link-rel" target="system-characteristics/authorization-boundary/diagram/link" test="@rel" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>Each FedRAMP SSP authorization boundary diagram must have a link rel attribute.</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-link-rel-allowed-value" target="system-characteristics/authorization-boundary/diagram/link" test="@rel eq 'diagram'" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>Each FedRAMP SSP authorization boundary diagram must have a link rel attribute with the value "diagram".</message>
             </expect>
             <expect id="has-authorization-boundary-diagram-caption" target="system-characteristics/authorization-boundary/diagram" test="caption" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>Each FedRAMP SSP authorization boundary diagram must have a caption.</message>
             </expect>
             <expect id="has-network-architecture" target="system-characteristics" test="network-architecture" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>A FedRAMP SSP must include a network architecture.</message>
             </expect>
             <expect id="has-network-architecture-diagram" target="system-characteristics/network-architecture" test="diagram" level="WARNING">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>A FedRAMP SSP must have at least one network architecture diagram.</message>
             </expect>
             <expect id="has-network-architecture-diagram-description" target="system-characteristics/network-architecture/diagram" test="description" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>Each FedRAMP SSP network architecture diagram must have a description.</message>
             </expect>
             <expect id="has-network-architecture-diagram-link" target="system-characteristics/network-architecture/diagram" test="link" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>Each FedRAMP SSP network architecture diagram must have a link.</message>
             </expect>
             <expect id="has-network-architecture-diagram-caption" target="system-characteristics/network-architecture/diagram" test="caption" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>Each FedRAMP SSP network architecture diagram must have a caption.</message>
             </expect>
             <expect id="has-network-architecture-diagram-link-rel" target="system-characteristics/network-architecture/diagram/link" test="@rel" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>Each FedRAMP SSP network architecture diagram must have a link rel attribute.</message>
             </expect>
             <expect id="has-network-architecture-diagram-link-rel-allowed-value" target="system-characteristics/network-architecture/diagram/link" test="@rel eq 'diagram'" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>Each FedRAMP SSP network architecture diagram must have a link rel attribute with the value "diagram".</message>
             </expect>
             <expect id="has-data-flow" target="system-characteristics" test="data-flow" level="WARNING">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>A FedRAMP SSP must include a data flow section.</message>
             </expect>
             <expect id="has-data-flow-diagram" target="system-characteristics/data-flow" test="diagram" level="WARNING">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>A FedRAMP SSP must have at least one data flow diagram.</message>
             </expect>
             <expect id="has-data-flow-description" target="system-characteristics/data-flow" test="description" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>An OSCAL SSP document with a data flow must have a description.</message>
             </expect>
             <expect id="has-data-flow-diagram-uuid" target="system-characteristics/data-flow/diagram" test="@uuid" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>An OSCAL SSP document with a data flow diagram must have a unique identifier.</message>
             </expect>
             <expect id="has-data-flow-diagram-description" target="system-characteristics/data-flow/diagram" test="description" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>Each FedRAMP SSP data flow diagram must have a description.</message>
             </expect>
             <expect id="has-data-flow-diagram-link" target="system-characteristics/data-flow/diagram" test="link" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>Each FedRAMP SSP data flow diagram must have a link.</message>
             </expect>
             <expect id="has-data-flow-diagram-caption" target="system-characteristics/data-flow/diagram" test="caption" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>Each FedRAMP SSP data flow diagram must have a caption.</message>
             </expect>
             <expect id="has-data-flow-diagram-link-rel" target="system-characteristics/data-flow/diagram/link" test="@rel" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>Each FedRAMP SSP data flow diagram must have a link rel attribute.</message>
             </expect>
             <expect id="has-data-flow-diagram-link-rel-allowed-value" target="system-characteristics/data-flow/diagram/link" test="@rel eq 'diagram'" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>Each FedRAMP SSP data flow diagram must have a link rel attribute with the value "diagram".</message>
             </expect>
             <expect id="has-system-id" target="system-characteristics" test="system-id[@identifier-type eq 'https://fedramp.gov']" level="ERROR">
@@ -156,12 +188,14 @@
                 <message>There must be one or more alternate data center(s).</message>
             </expect>
             <expect id="role-defined-system-owner" target="." test="role[@id eq 'system-owner']" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#information-system-owner"/>
                 <message>A FedRAMP SSP must define the system owner role.</message>
             </expect>
             <expect id="role-defined-authorizing-official-poc" target="." test="role[@id eq 'authorizing-official-poc']" level="ERROR">
                 <message>A FedRAMP SSP must define a role for the point of contact for an authorizing official.</message>
             </expect>
             <expect id="role-defined-information-system-security-officer" target="." test="role[@id eq 'information-system-security-officer']" level="ERROR">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#assignment-of-security-responsibilities"/>
                 <message>A FedRAMP SSP must define a role for the point of contact for an information system security officer.</message>
             </expect>
         </constraints>
@@ -170,6 +204,7 @@
         <metapath target="/system-security-plan/control-implementation"/>
         <constraints>
             <expect id="missing-response-components" target="implemented-requirement" test="count(./by-component) gt 0">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/6-security-controls/#response-overview"/>
                 <message>Each implemented requirement must have at least one by-component reference to the source component implementing it.</message>
             </expect>
         </constraints>


### PR DESCRIPTION
# Committer Notes
Added help-url props to all of the constraints in `fedramp-external-constraints.xml` that have sufficient documentation.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
