### PR TITLE
Remove FedRAMP namespace from 'data-center' props

### DIFF
--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -37,13 +37,13 @@
       <address >
         <country>US</country>
       </address>
-      <prop name='data-center' value='dc-zone-1' class='primary' ns="https://fedramp.gov/ns/oscal"/>
+      <prop name='data-center' value='dc-zone-1' class='primary'/>
     </location>
     <location uuid="11111112-0000-4000-9000-000000000003">
       <address >
         <country>US</country>
       </address>
-      <prop name='data-center' value='aws-us-west-1' class='alternate' ns="https://fedramp.gov/ns/oscal"/>
+      <prop name='data-center' value='aws-us-west-1' class='alternate'/>
     </location>
     <party uuid="11111111-0000-4000-9000-000000000001" type="organization">
       <name>Example Organization</name>

--- a/src/validations/constraints/content/ssp-data-center-US-INVALID.xml
+++ b/src/validations/constraints/content/ssp-data-center-US-INVALID.xml
@@ -8,7 +8,7 @@
       <address >
         <country>WRONG</country>
       </address>
-      <prop name='data-center' value='dc-zone-1' class='tertiary' ns="https://fedramp.gov/ns/oscal"/>
+      <prop name='data-center' value='dc-zone-1' class='tertiary'/>
     </location>
   </metadata>
 </system-security-plan>

--- a/src/validations/constraints/content/ssp-data-center-alternate-INVALID.xml
+++ b/src/validations/constraints/content/ssp-data-center-alternate-INVALID.xml
@@ -8,7 +8,7 @@
       <address >
         <country>WRONG</country>
       </address>
-      <prop name='data-center' value='dc-zone-1' class='tertiary' ns="https://fedramp.gov/ns/oscal"/>
+      <prop name='data-center' value='dc-zone-1' class='tertiary'/>
     </location>
   </metadata>
 </system-security-plan>

--- a/src/validations/constraints/content/ssp-data-center-count-INVALID.xml
+++ b/src/validations/constraints/content/ssp-data-center-count-INVALID.xml
@@ -8,7 +8,7 @@
       <address >
         <country>WRONG</country>
       </address>
-      <prop name='data-center' value='dc-zone-1' class='tertiary' ns="https://fedramp.gov/ns/oscal"/>
+      <prop name='data-center' value='dc-zone-1' class='tertiary'/>
     </location>
   </metadata>
 </system-security-plan>

--- a/src/validations/constraints/content/ssp-data-center-country-code-INVALID.xml
+++ b/src/validations/constraints/content/ssp-data-center-country-code-INVALID.xml
@@ -7,7 +7,7 @@
     <location uuid="11111112-0000-4000-9001-000000000009">
       <address >
       </address>
-      <prop name='data-center' value='dc-zone-1' class='tertiary' ns="https://fedramp.gov/ns/oscal"/>
+      <prop name='data-center' value='dc-zone-1' class='tertiary'/>
     </location>
   </metadata>
 </system-security-plan>

--- a/src/validations/constraints/content/ssp-data-center-primary-INVALID.xml
+++ b/src/validations/constraints/content/ssp-data-center-primary-INVALID.xml
@@ -8,7 +8,7 @@
       <address >
         <country>WRONG</country>
       </address>
-      <prop name='data-center' value='dc-zone-1' class='tertiary' ns="https://fedramp.gov/ns/oscal"/>
+      <prop name='data-center' value='dc-zone-1' class='tertiary'/>
     </location>
   </metadata>
 </system-security-plan>

--- a/src/validations/constraints/content/ssp-role-defined-authorizing-official-poc-INVALID.xml
+++ b/src/validations/constraints/content/ssp-role-defined-authorizing-official-poc-INVALID.xml
@@ -27,7 +27,7 @@
       <address >
         <country>WRONG</country>
       </address>
-      <prop name='data-center' value='dc-zone-1' class='tertiary' ns="https://fedramp.gov/ns/oscal"/>
+      <prop name='data-center' value='dc-zone-1' class='tertiary'/>
     </location>
     <party uuid="11111111-0000-4000-9000-000000000001" type="organization">
       <name>Example Organization</name>

--- a/src/validations/constraints/content/ssp-role-defined-information-system-security-officer-INVALID.xml
+++ b/src/validations/constraints/content/ssp-role-defined-information-system-security-officer-INVALID.xml
@@ -27,7 +27,7 @@
       <address >
         <country>WRONG</country>
       </address>
-      <prop name='data-center' value='dc-zone-1' class='tertiary' ns="https://fedramp.gov/ns/oscal"/>
+      <prop name='data-center' value='dc-zone-1' class='tertiary'/>
     </location>
     <party uuid="11111111-0000-4000-9000-000000000001" type="organization">
       <name>Example Organization</name>

--- a/src/validations/constraints/content/ssp-role-defined-system-owner-INVALID.xml
+++ b/src/validations/constraints/content/ssp-role-defined-system-owner-INVALID.xml
@@ -27,7 +27,7 @@
       <address >
         <country>WRONG</country>
       </address>
-      <prop name='data-center' value='dc-zone-1' class='tertiary' ns="https://fedramp.gov/ns/oscal"/>
+      <prop name='data-center' value='dc-zone-1' class='tertiary'/>
     </location>
     <party uuid="11111111-0000-4000-9000-000000000001" type="organization">
       <name>Example Organization</name>


### PR DESCRIPTION
# Committer Notes

This PR fixes issue #794 by removing the FedRAMP namespace from 'data-center' props where not needed.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
