### PR TITLE
Fix by-component implemented requirement checks

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -21,6 +21,8 @@ Examples:
   | attachment-type-PASS.yaml |
   | authorization-type-FAIL.yaml |
   | authorization-type-PASS.yaml |
+  | by-component-requirement-not-inside-statement-FAIL.yaml |
+  | by-component-requirement-not-inside-statement-PASS.yaml |
   | categorization-has-correct-system-attribute-FAIL.yaml |
   | categorization-has-correct-system-attribute-PASS.yaml |
   | categorization-has-information-type-id-FAIL.yaml |
@@ -165,6 +167,7 @@ Examples:
   | address-type |
   | attachment-type |
   | authorization-type |
+  | by-component-requirement-not-inside-statement |
   | categorization-has-correct-system-attribute |
   | categorization-has-information-type-id |
   | cloud-service-model |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -213,31 +213,31 @@
       <prop name="control-origination" value="sp-system" ns="https://fedramp.gov/ns/oscal"/>
       <prop name="implementation-status" value="partial" ns="https://fedramp.gov/ns/oscal"/>
       <statement statement-id="ac-1_stmt.a" uuid="99999999-0000-4000-9000-000000000009">
+        <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="aaaaaaaa-0000-4000-9000-00000000000a">
+          <description>
+            <p>Access Control Policy and Procedures (AC-1) is fully implemented in our system.</p>
+          </description>
+          <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="implemented"/>
+          <responsible-role role-id="system-admin">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+          </responsible-role>
+        </by-component>        
       </statement>
-      <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="aaaaaaaa-0000-4000-9000-00000000000a">
-        <description>
-          <p>Access Control Policy and Procedures (AC-1) is fully implemented in our system.</p>
-        </description>
-        <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="implemented"/>
-        <responsible-role role-id="system-admin">
-          <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
-        </responsible-role>
-      </by-component>
     </implemented-requirement>
     
     <implemented-requirement uuid="bbbbbbbb-0000-4000-9000-00000000000b" control-id="cm-8">
       <prop name="control-origination" value="sp-system" ns="https://fedramp.gov/ns/oscal"/>
       <statement statement-id="cm-8_stmt.a" uuid="cccccccc-0000-4000-9000-00000000000c">
+        <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="dddddddd-0000-4000-9000-00000000000d">
+          <description>
+            <p>Information System Component Inventory (CM-8) is partially implemented.</p>
+          </description>
+          <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="partial"/>
+          <responsible-role role-id="system-admin">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+          </responsible-role>
+        </by-component>        
       </statement>
-      <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="dddddddd-0000-4000-9000-00000000000d">
-        <description>
-          <p>Information System Component Inventory (CM-8) is partially implemented.</p>
-        </description>
-        <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="partial"/>
-        <responsible-role role-id="system-admin">
-          <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
-        </responsible-role>
-      </by-component>
     </implemented-requirement>
   </control-implementation>
   

--- a/src/validations/constraints/content/ssp-by-component-requirement-not-inside-statement-INVALID.xml
+++ b/src/validations/constraints/content/ssp-by-component-requirement-not-inside-statement-INVALID.xml
@@ -1,0 +1,36 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="12345678-1234-4321-8765-123456789012">
+  <control-implementation>
+    <description>
+      <p>Implementation of controls for the Enhanced Example System</p>
+    </description>
+    <implemented-requirement uuid="88888888-0000-4000-9000-000000000008" control-id="ac-1">
+      <prop name="control-origination" value="sp-system" ns="https://fedramp.gov/ns/oscal"/>
+      <prop name="implementation-status" value="partial" ns="https://fedramp.gov/ns/oscal"/>
+      <statement statement-id="ac-1_stmt.a" uuid="99999999-0000-4000-9000-000000000009">
+      </statement>
+      <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="aaaaaaaa-0000-4000-9000-00000000000a">
+        <description>
+          <p>Access Control Policy and Procedures (AC-1) is fully implemented in our system.</p>
+        </description>
+        <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="implemented"/>
+        <responsible-role role-id="system-admin">
+          <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-role>
+      </by-component>
+    </implemented-requirement>
+    <implemented-requirement uuid="bbbbbbbb-0000-4000-9000-00000000000b" control-id="cm-8">
+      <prop name="control-origination" value="sp-system" ns="https://fedramp.gov/ns/oscal"/>
+      <statement statement-id="cm-8_stmt.a" uuid="cccccccc-0000-4000-9000-00000000000c">
+      </statement>
+      <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="dddddddd-0000-4000-9000-00000000000d">
+        <description>
+          <p>Information System Component Inventory (CM-8) is partially implemented.</p>
+        </description>
+        <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="partial"/>
+        <responsible-role role-id="system-admin">
+          <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-role>
+      </by-component>
+    </implemented-requirement>
+  </control-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -192,7 +192,10 @@
     <context>
         <metapath target="/system-security-plan/control-implementation"/>
         <constraints>
-            <expect id="missing-response-components" target="implemented-requirement" test="count(./by-component) gt 0">
+            <expect id="by-component-requirement-not-inside-statement" target="implemented-requirement" test="not(exists(by-component))">
+                <message>A FedRAMP SSP MUST document only a component-based implemented requirement within a specific statement, not at the control level.</message>
+            </expect>
+            <expect id="missing-response-components" target="implemented-requirement/statement" test="count(./by-component) gt 0">
                 <message>Each implemented requirement must have at least one by-component reference to the source component implementing it.</message>
             </expect>
         </constraints>

--- a/src/validations/constraints/unit-tests/by-component-requirement-not-inside-statement-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/by-component-requirement-not-inside-statement-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for by-component-requirement-not-inside-statement
+  description: >-
+    This test case validates the behavior of constraint
+    by-component-requirement-not-inside-statement
+  content: ../content/ssp-by-component-requirement-not-inside-statement-INVALID.xml
+  expectations:
+    - constraint-id: by-component-requirement-not-inside-statement
+      result: fail

--- a/src/validations/constraints/unit-tests/by-component-requirement-not-inside-statement-PASS.yaml
+++ b/src/validations/constraints/unit-tests/by-component-requirement-not-inside-statement-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for by-component-requirement-not-inside-statement
+  description: >-
+    This test case validates the behavior of constraint
+    by-component-requirement-not-inside-statement
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: by-component-requirement-not-inside-statement
+      result: pass


### PR DESCRIPTION
# Committer Notes

Fixes #770.

- Add new constraint to report against bad practice FedRAMP will not accept for requirements outside of statement.
- Fix current constraint and correct the test, target, and wording.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?~
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
