### PR TITLE
Add allowed-values metadata fedramp-version

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -43,6 +43,8 @@ Examples:
   | data-center-us-PASS.yaml |
   | deployment-model-FAIL.yaml |
   | deployment-model-PASS.yaml |
+  | fedramp-version-FAIL.yaml |
+  | fedramp-version-PASS.yaml |
   | has-authenticator-assurance-level-FAIL.yaml |
   | has-authenticator-assurance-level-PASS.yaml |
   | has-authorization-boundary-diagram-FAIL.yaml |
@@ -172,6 +174,7 @@ Examples:
   | data-center-country-code |
   | data-center-primary |
   | deployment-model |
+  | fedramp-version |
   | has-authenticator-assurance-level |
   | has-authorization-boundary-diagram |
   | has-authorization-boundary-diagram-caption |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -10,6 +10,7 @@
     <version>1.1</version>
     <oscal-version>1.0.0</oscal-version>
     <document-id scheme="https://example.com/identifiers">SSP-2024-002</document-id>
+    <prop name="fedramp-version" value="fedramp-3.0.0rc1-oscal-1.1.2"/>
     
     <role id="creator">
       <title>Document Creator</title>

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -8,9 +8,9 @@
     <published>2024-08-01T14:30:00Z</published>
     <last-modified>2024-08-01T14:30:00Z</last-modified>
     <version>1.1</version>
-    <oscal-version>1.0.0</oscal-version>
+    <oscal-version>1.1.2</oscal-version>
     <document-id scheme="https://example.com/identifiers">SSP-2024-002</document-id>
-    <prop name="fedramp-version" value="fedramp-3.0.0rc1-oscal-1.1.2"/>
+    <prop name="fedramp-version" ns="https://fedramp.gov/ns/oscal" value="fedramp-3.0.0rc1-oscal-1.1.2"/>
     
     <role id="creator">
       <title>Document Creator</title>

--- a/src/validations/constraints/content/ssp-fedramp-version-INVALID.xml
+++ b/src/validations/constraints/content/ssp-fedramp-version-INVALID.xml
@@ -8,9 +8,8 @@
 		<published>2024-08-01T14:30:00Z</published>
 		<last-modified>2024-08-01T14:30:00Z</last-modified>
 		<version>1.1</version>
-		<oscal-version>1.0.0</oscal-version>
+		<oscal-version>1.1.2</oscal-version>
 		<document-id scheme="https://example.com/identifiers">SSP-2024-002</document-id>
-		<!--prop name="fedramp-version" value="fedramp-3.0.0rc1-oscal-1.1.2"/-->
 	</metadata>
 
 </system-security-plan>

--- a/src/validations/constraints/content/ssp-fedramp-version-INVALID.xml
+++ b/src/validations/constraints/content/ssp-fedramp-version-INVALID.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
+                      uuid="12345678-1234-4321-8765-123456789012">
+	<metadata>
+		<title>Enhanced Example System Security Plan</title>
+		<published>2024-08-01T14:30:00Z</published>
+		<last-modified>2024-08-01T14:30:00Z</last-modified>
+		<version>1.1</version>
+		<oscal-version>1.0.0</oscal-version>
+		<document-id scheme="https://example.com/identifiers">SSP-2024-002</document-id>
+		<!--prop name="fedramp-version" value="fedramp-3.0.0rc1-oscal-1.1.2"/-->
+	</metadata>
+
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -15,9 +15,9 @@
 
         <constraints>
             
-            <allowed-values id="fedramp-version" target="metadata/prop[@name='fedramp-version']/@value" allow-other="no" level="ERROR">
+            <allowed-values id="fedramp-version" target="metadata/prop[@name='fedramp-version'][@ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
                 <formal-name>FedRAMP Version</formal-name>
-                <description>The current FedRAMP version.</description>
+                <description>Identifies the FedRAMP version of the document.</description>
                 <enum value="fedramp-3.0.0rc1-oscal-1.1.2">FedRAMP Version</enum>
             </allowed-values>
             

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -14,6 +14,13 @@
         <metapath target="/plan-of-action-and-milestones"/>
 
         <constraints>
+            
+            <allowed-values id="fedramp-version" target="metadata/prop[@name='fedramp-version']/@value" allow-other="no" level="ERROR">
+                <formal-name>FedRAMP Version</formal-name>
+                <description>The current FedRAMP version.</description>
+                <enum value="fedramp-3.0.0rc1-oscal-1.1.2">FedRAMP Version</enum>
+            </allowed-values>
+            
             <allowed-values id="attachment-type" target="back-matter/resource/prop[@name='type'][@ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
                 <formal-name>Attachment Type</formal-name>
                 <description>Identifies the type of attachment.</description>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -21,8 +21,9 @@
     <context>
         <metapath target="//metadata"/>
         <constraints>
-            <expect id="fedramp-version" target="." test="prop[@name='fedramp-version']">
-                <message>A FedRAMP document metadata MUST contain a FedRAMP version.</message>
+            <expect id="fedramp-version" target="." test="prop[@name='fedramp-version'][@ns='https://fedramp.gov/ns/oscal']">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/"/>
+                <message>A FedRAMP document's metadata MUST define a valid FedRAMP version.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -24,6 +24,10 @@
             <expect id="fedramp-version" target="." test="prop[@name='fedramp-version'][@ns='https://fedramp.gov/ns/oscal']">
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/"/>
                 <message>A FedRAMP document's metadata MUST define a valid FedRAMP version.</message>
+                <remarks>
+                    <p>All documents in a digital authorization package for FedRAMP must specify the version that identifies which FedRAMP policies, guidance, and technical specifications its authors used during the creation and maintenance of the package.</p>
+                    <p>FedRAMP maintains an official list of the versions on <a href="https://github.com/GSA/fedramp-automation/releases">the fedramp-automation releases page</a>. Unless noted otherwise, a valid version is <a href="https://github.com/GSA/fedramp-automation/tags">a published tag name</a>.</p>
+                </remarks>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -19,6 +19,14 @@
         </constraints>
     </context>
     <context>
+        <metapath target="//metadata"/>
+        <constraints>
+            <expect id="fedramp-version" target="." test="prop[@name='fedramp-version']">
+                <message>A FedRAMP document metadata MUST contain a FedRAMP version.</message>
+            </expect>
+        </constraints>
+    </context>
+    <context>
         <metapath target="/system-security-plan/metadata/location"/>
         <constraints>
             <expect id="data-center-country-code" target="." test="count(address/country) eq 1">

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -22,7 +22,7 @@
         <metapath target="//metadata"/>
         <constraints>
             <expect id="fedramp-version" target="." test="prop[@name='fedramp-version'][@ns='https://fedramp.gov/ns/oscal']">
-                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/"/>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/#fedramp-version"/>
                 <message>A FedRAMP document's metadata MUST define a valid FedRAMP version.</message>
                 <remarks>
                     <p>All documents in a digital authorization package for FedRAMP must specify the version that identifies which FedRAMP policies, guidance, and technical specifications its authors used during the creation and maintenance of the package.</p>

--- a/src/validations/constraints/unit-tests/fedramp-version-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/fedramp-version-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid fedramp-version constraint unit test.
+test-case:
+  name: The invalid fedramp-version constraint unit test.
+  description: Test that the SSP metadata does not contain the "fedramp-version" property.
+  content: ../content/ssp-fedramp-version-INVALID.xml
+  expectations:
+  - constraint-id: fedramp-version
+    result: fail

--- a/src/validations/constraints/unit-tests/fedramp-version-PASS.yaml
+++ b/src/validations/constraints/unit-tests/fedramp-version-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid fedramp-version constraint unit test.
+test-case:
+  name: The valid fedramp-version constraint unit test.
+  description: Test that the SSP metadata contains the "fedramp-version" property.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+  - constraint-id: fedramp-version
+    result: pass


### PR DESCRIPTION
# Committer Notes

1. In `fedramp-external-allowed-values.xml`, add the metadata `fedramp-version` prop value.
2. In `ssp-all-VALID.xml`, add the metadata `fedramp-version` prop.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
