### PR TITLE
Feature oscal server

### DIFF
--- a/features/steps/fedramp_extensions_steps.ts
+++ b/features/steps/fedramp_extensions_steps.ts
@@ -9,12 +9,14 @@ import {
   existsSync,
 } from "fs";
 import { load } from "js-yaml";
-import { executeOscalCliCommand, validateFile, validateWithSarif } from "oscal";
-import { dirname, join,parse } from "path";
+import { executeOscalCliCommand, resolveProfile, resolveProfileDocument, validateDocument } from "oscal";
+import { dirname, join,parse, resolve } from "path";
 import { Exception, Log, Result } from "sarif";
 import { fileURLToPath } from "url";
 import { parseString } from "xml2js";
 import { promisify } from "util";
+
+const executor = 'oscal-server'
 
 const parseXmlString = promisify(parseString);
 const DEFAULT_TIMEOUT = 60000;
@@ -202,12 +204,12 @@ async function processTestCase({ "test-case": testCase }: any) {
   if (testCase.pipeline) {
     for (const step of testCase.pipeline) {
       if (step.action === "resolve-profile") {
-        await executeOscalCliCommand("resolve-profile", [
+        await resolveProfileDocument(
           contentPath,
           processedContentPath,
-          "--to=XML",
-          "--overwrite",
-        ]);
+          {
+            outputFormat:'xml'
+          },executor)
         console.log("Profile resolved");
       }
       // Add other pipeline steps as needed
@@ -225,15 +227,14 @@ async function processTestCase({ "test-case": testCase }: any) {
       console.log("Using cached validation result from "+cacheKey);
       sarifResponse = validationCache.get(cacheKey)!;
     }else{
-      let args = [];
+      let flags = [];
       if(currentTestCaseFileName.includes("FAIL")){
-        args.push("--disable-schema-validation")
+        flags.push("disable-schema")
       }
-    sarifResponse = await validateWithSarif([
-      processedContentPath,
-      ...args,
-      ...metaschemaDocuments.flatMap((x) => ["-c", x]),
-    ]);
+    const {isValid,log} = await validateDocument(resolve(processedContentPath),{
+      extensions:metaschemaDocuments.flatMap((x) => resolve(x)),
+      flags},executor)
+      sarifResponse=log;
     validationCache.set(cacheKey,sarifResponse);
   }
   if (typeof sarifResponse.runs[0].tool.driver.rules === "undefined") {

--- a/features/steps/fedramp_extensions_steps.ts
+++ b/features/steps/fedramp_extensions_steps.ts
@@ -1,4 +1,4 @@
-import { Given, Then, When, setDefaultTimeout } from "@cucumber/cucumber";
+import { BeforeAll, BeforeStep, Given, Then, When, setDefaultTimeout, world } from "@cucumber/cucumber";
 import { expect } from "chai";
 import {
   readFileSync,
@@ -16,7 +16,8 @@ import { fileURLToPath } from "url";
 import { parseString } from "xml2js";
 import { promisify } from "util";
 
-const executor = 'oscal-server'
+let executor:'oscal-cli'|'oscal-server' = 'oscal-cli'
+
 
 const parseXmlString = promisify(parseString);
 const DEFAULT_TIMEOUT = 60000;
@@ -132,6 +133,11 @@ function getConstraintFiles() {
     .join("\n");
   return xmlFiles;
 }
+BeforeStep(()=>{
+  if(world.parameters.executor){
+    executor=world.parameters.executor;
+  }
+})
 
 Given("I have Metaschema extensions documents", function (dataTable) {
   const constraintDir = join(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,12 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.4",
+        "@types/sarif": "^2.1.7",
         "chai": "^5.1.1",
         "inquirer": "^10.1.8",
         "js-yaml": "^4.1.0",
         "jsdom": "^25.0.0",
-        "oscal": "^1.4.7",
+        "oscal": "2.0.0-rc10",
         "ts-node": "^10.9.2",
         "xml-formatter": "^3.6.3",
         "xml2js": "^0.6.2"
@@ -795,14 +796,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
-    "node_modules/@types/adm-zip": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.5.tgz",
-      "integrity": "sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -903,7 +896,8 @@
     "node_modules/@types/sarif": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
-      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ=="
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -2654,6 +2648,21 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.12.5.tgz",
+      "integrity": "sha512-FnAMWLt0MNL6ComcL4q/YbB1tUgyz5YnYtwA1+zlJ5xcucmK5RlWsgH1ynxmEeu8fGJkYjm8armU/HVpORc9lw==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
     "node_modules/ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -2685,14 +2694,12 @@
       }
     },
     "node_modules/oscal": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/oscal/-/oscal-1.4.7.tgz",
-      "integrity": "sha512-jGkQXYzNA+MA2YcxY1ki6YN8+I8nSoq0R0/kTQ6ilANGfARI7CSm5A2zAY9G/jhpEc1scQ3PgdHEafzg1M3gIA==",
+      "version": "2.0.0-rc10",
+      "resolved": "https://registry.npmjs.org/oscal/-/oscal-2.0.0-rc10.tgz",
+      "integrity": "sha512-O8ffTIjJx4B1EH9Ve0PmjJpcJfnyhCqLaleaUNSOxzptkhQsk2AmOXb6f+lDpUosjhhOVPrLFVx//X1ForCd7g==",
       "license": "MIT",
       "dependencies": {
         "@terascope/fetch-github-release": "^0.8.10",
-        "@types/adm-zip": "^0.5.5",
-        "@types/sarif": "^2.1.7",
         "adm-zip": "^0.5.15",
         "ajv": "^8.16.0",
         "ajv-formats": "^3.0.1",
@@ -2703,6 +2710,8 @@
         "inquirer": "^9.2.23",
         "js-yaml": "^4.1.0",
         "openai": "^4.51.0",
+        "openapi-fetch": "^0.12.2",
+        "ps-list": "^8.1.1",
         "uuid": "^10.0.0",
         "xml2js": "^0.6.2",
         "yaml": "^2.4.3"
@@ -2908,6 +2917,18 @@
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
       "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
       "dev": true
+    },
+    "node_modules/ps-list": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-8.1.1.tgz",
+      "integrity": "sha512-OPS9kEJYVmiO48u/B9qneqhkMvgCxT+Tm28VCEJpheTpl8cJ0ffZRRNgS5mrQRTrX5yRTpaJ+hRDeefXYmmorQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "inquirer": "^10.1.8",
         "js-yaml": "^4.1.0",
         "jsdom": "^25.0.0",
-        "oscal": "2.0.0-rc10",
+        "oscal": "^2.0.0",
         "ts-node": "^10.9.2",
         "xml-formatter": "^3.6.3",
         "xml2js": "^0.6.2"
@@ -2694,12 +2694,13 @@
       }
     },
     "node_modules/oscal": {
-      "version": "2.0.0-rc10",
-      "resolved": "https://registry.npmjs.org/oscal/-/oscal-2.0.0-rc10.tgz",
-      "integrity": "sha512-O8ffTIjJx4B1EH9Ve0PmjJpcJfnyhCqLaleaUNSOxzptkhQsk2AmOXb6f+lDpUosjhhOVPrLFVx//X1ForCd7g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/oscal/-/oscal-2.0.0.tgz",
+      "integrity": "sha512-/daAndATgX8Ee052cezpA8UF+CXwAST15XYzPRBPD3pvy6UVI5ssySIZaO5o5JyfAiEhDHHXogt/e5J0mnY4fQ==",
       "license": "MIT",
       "dependencies": {
         "@terascope/fetch-github-release": "^0.8.10",
+        "@types/sarif": "^2.1.7",
         "adm-zip": "^0.5.15",
         "ajv": "^8.16.0",
         "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
   "type": "module",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.6.4",
+    "@types/sarif": "^2.1.7",
     "chai": "^5.1.1",
     "inquirer": "^10.1.8",
     "js-yaml": "^4.1.0",
     "jsdom": "^25.0.0",
-    "oscal": "^1.4.7",
+    "oscal": "2.0.0-rc10",
     "ts-node": "^10.9.2",
     "xml-formatter": "^3.6.3",
     "xml2js": "^0.6.2"

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "federalist": "make init-repo && npm run build:validation-ui && npm run link:validation-ui",
     "link:validation-ui": "ln -sf ./src/web/dist _site",
     "test": "cross-env-shell NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js",
+    "test:server": "cross-env-shell OSCAL_EXECUTOR='oscal-server' NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js",
     "test:parallel": "cross-env-shell NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js  --parallel 4 2>/dev/null 2>NUL",
     "test:failed": "cross-env NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js -p rerun",
     "test:constraints": "cross-env NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js --tags @constraints",
     "test:coverage": "cross-env NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js --tags @full-coverage",
-    "test:server": "cross-env NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js --world-parameters '{\"executor\":\"oscal-server\"}'",
     "mq": "node ./src/scripts/dev-metaschema-eval.js",
     "constraint": "node ./src/scripts/dev-constraint.js"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:failed": "cross-env NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js -p rerun",
     "test:constraints": "cross-env NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js --tags @constraints",
     "test:coverage": "cross-env NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js --tags @full-coverage",
+    "test:server": "cross-env NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js --world-parameters '{\"executor\":\"oscal-server\"}'",
     "mq": "node ./src/scripts/dev-metaschema-eval.js",
     "constraint": "node ./src/scripts/dev-constraint.js"
   },
@@ -23,7 +24,7 @@
     "inquirer": "^10.1.8",
     "js-yaml": "^4.1.0",
     "jsdom": "^25.0.0",
-    "oscal": "2.0.0-rc10",
+    "oscal": "^2.0.0",
     "ts-node": "^10.9.2",
     "xml-formatter": "^3.6.3",
     "xml2js": "^0.6.2"

--- a/src/validations/module.mk
+++ b/src/validations/module.mk
@@ -1,5 +1,5 @@
 # Variables
-OSCAL_CLI = npx oscal@latest
+OSCAL_CLI = npx oscal@next
 SRC_DIR = ./src
 DIST_DIR = ./dist
 REV5_BASELINES = ./dist/content/rev5/baselines
@@ -11,12 +11,15 @@ init-validations:
 	@echo "Installing node modules..."
 	npm install
 	$(OSCAL_CLI) use latest
+	$(OSCAL_CLI) server update
 
 # Validation
 .PHONY: build-validations
 build-validations:
 	@echo "Running Cucumber Tests"
+	$(OSCAL_CLI) server start
 	@npm run test
+	$(OSCAL_CLI) server start
 
 clean-validations:
 	@echo "Nothing to clean"

--- a/src/validations/module.mk
+++ b/src/validations/module.mk
@@ -19,7 +19,7 @@ build-validations:
 	@echo "Running Cucumber Tests"
 	$(OSCAL_CLI) server start
 	@npm run test
-	$(OSCAL_CLI) server start
+	$(OSCAL_CLI) server stop
 
 clean-validations:
 	@echo "Nothing to clean"

--- a/src/validations/module.mk
+++ b/src/validations/module.mk
@@ -1,5 +1,5 @@
 # Variables
-OSCAL_CLI = npx oscal@next
+OSCAL_CLI = npx oscal@2.0.0
 SRC_DIR = ./src
 DIST_DIR = ./dist
 REV5_BASELINES = ./dist/content/rev5/baselines
@@ -17,8 +17,8 @@ init-validations:
 .PHONY: build-validations
 build-validations:
 	@echo "Running Cucumber Tests"
-	$(OSCAL_CLI) server start
-	@npm run test
+	$(OSCAL_CLI) server start -bg
+	@npm run test:server
 	$(OSCAL_CLI) server stop
 
 clean-validations:


### PR DESCRIPTION
# Committer Notes

Using world parameters to toggle oscal server based execution with 

npm run test (oscal-cli)
npm run test:server (oscal-server) execution



also changes github actions to use server because make test will start the server run test:server and then stop it.


### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
