### PR TITLE
Check `fedramp-version` includes minimal `oscal-version` or greater

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -125,6 +125,8 @@ Examples:
   | inventory-item-virtual-PASS.yaml |
   | missing-response-components-FAIL.yaml |
   | missing-response-components-PASS.yaml |
+  | oscal-version-matches-fedramp-version-FAIL.yaml |
+  | oscal-version-matches-fedramp-version-PASS.yaml |
   | privilege-level-FAIL.yaml |
   | privilege-level-PASS.yaml |
   | resource-has-base64-or-rlink-FAIL.yaml |
@@ -219,6 +221,7 @@ Examples:
   | inventory-item-public |
   | inventory-item-virtual |
   | missing-response-components |
+  | oscal-version-matches-fedramp-version |
   | privilege-level |
   | prop-response-point-has-cardinality-one |
   | resource-has-base64-or-rlink |

--- a/src/validations/constraints/content/ssp-oscal-version-matches-fedramp-version-INVALID.xml
+++ b/src/validations/constraints/content/ssp-oscal-version-matches-fedramp-version-INVALID.xml
@@ -1,0 +1,6 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="12345678-1234-4321-8765-123456789012">
+  <metadata>
+    <oscal-version>1.0.6</oscal-version>
+    <prop name="fedramp-version" ns="https://fedramp.gov/ns/oscal" value="fedramp-3.0.0rc1-oscal-1.1.2"/>
+  </metadata>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -32,6 +32,21 @@
         </constraints>
     </context>
     <context>
+        <metapath target="/(assessment-plan|assessment-results|plan-of-action-and-milestones|system-security-plan)/metadata"/>
+        <constraints>
+            <let var="fedramp-version-oscal-part" expression="tokenize(prop[@name='fedramp-version'][@ns='https://fedramp.gov/ns/oscal']/@value, '-')[4]"/>
+            <let var="fedramp-oscal-version-subparts" expression="tokenize($fedramp-version-oscal-part, '\.')"/>
+            <let var="oscal-version-subparts" expression="tokenize(oscal-version, '\.')"/>
+            <let var="major-version-valid" expression="boo$fedramp-oscal-version-subparts[1] >= $oscal-version-subparts[1]"/>
+            <let var="minor-version-valid" expression="$fedramp-oscal-version-subparts[2] >= $oscal-version-subparts[2]"/>
+            <let var="patch-version-valid" expression="$fedramp-oscal-version-subparts[3] >= $oscal-version-subparts[3]"/>
+            <expect id="oscal-version-matches-fedramp-version" target="." test="$major-version-valid and $minor-version-valid and $patch-version-valid" level="WARNING">
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://docs.oasis-open.org/sarif/sarif/v2.1.0"/>                
+                <message>A FedRAMP document SHOULD have an OSCAL version that matches the minimally required FedRAMP guidance version, not {oscal-version}. DEBUG: {$major-version-valid} and {$minor-version-valid} and {$patch-version-valid}</message>
+            </expect>            
+        </constraints>
+    </context>
+    <context>
         <metapath target="/system-security-plan/metadata/location"/>
         <constraints>
             <expect id="data-center-country-code" target="." test="count(address/country) eq 1">
@@ -168,7 +183,7 @@
     </context>
     <context>
         <metapath target="/system-security-plan/metadata"/>
-        <constraints>
+        <constraints>            
             <expect id="data-center-count" target="." test="count(/location/prop[@name eq 'type'][@value eq 'data-center']) &gt; 1">
                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0"  name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-centers" />
                 <message>There must be at least two (2) data centers listed.</message>
@@ -199,7 +214,7 @@
             </expect>
             <expect id="role-defined-information-system-security-officer" target="." test="role[@id eq 'information-system-security-officer']" level="ERROR">
                 <message>A FedRAMP SSP must define a role for the point of contact for an information system security officer.</message>
-            </expect>
+            </expect>        
         </constraints>
     </context>
     <context>

--- a/src/validations/constraints/unit-tests/oscal-version-matches-fedramp-version-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/oscal-version-matches-fedramp-version-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for oscal-version-matches-fedramp-version
+  description: >-
+    This test case validates the behavior of constraint
+    oscal-version-matches-fedramp-version
+  content: ../content/ssp-oscal-version-matches-fedramp-version-INVALID.xml
+  expectations:
+    - constraint-id: oscal-version-matches-fedramp-version
+      result: fail

--- a/src/validations/constraints/unit-tests/oscal-version-matches-fedramp-version-PASS.yaml
+++ b/src/validations/constraints/unit-tests/oscal-version-matches-fedramp-version-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for oscal-version-matches-fedramp-version
+  description: >-
+    This test case validates the behavior of constraint
+    oscal-version-matches-fedramp-version
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: oscal-version-matches-fedramp-version
+      result: pass


### PR DESCRIPTION
# Committer Notes

Check `fedramp-version` includes minimal `oscal-version` or greater. Closes #833.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
