### PR TITLE
Constraint Script Fix

### DIFF
--- a/src/scripts/dev-constraint.js
+++ b/src/scripts/dev-constraint.js
@@ -347,7 +347,8 @@ function getScenarioLineNumbers(featureFile, constraintId,tests) {
     const lines = content.split('\n');
     const scenarioLines = [];
     for (let i = 0; i < lines.length; i++) {
-        if (lines[i].includes(`${tests.fail}`) || lines[i].includes(`${tests.pass}`)||lines[i].includes(`${tests.fail_file}`) || lines[i].includes(`${tests.pass_file}`)) {
+        const line = lines[i].replace(/\|/g, '').trim();
+        if (line === tests.fail || line === tests.pass || line === tests.fail_file || line === tests.pass_file) {
             scenarioLines.push(i + 1); // +1 because line numbers start at 1, not 0
         }
     }


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR introduces a fix to ensure that only exact constraint matches are processed during validation. Previously, similar constraint names could inadvertently trigger each other (e.g., cloud-service-model could unintentionally match has-cloud-service-model), leading to unintended results.

## Fix Details
The solution uses regex to remove extra characters (like | and whitespace) from each line before comparison. This allows for exact, cleaned comparisons rather than relying on the `includes()` method, which matched partially similar strings.

## Testing
Verified that:
- Only exact constraint matches are now validated.
- Constraints with similar names (e.g., cloud-service-model vs. has-cloud-service-model) do not interfere with each other.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~~ This is a bug fix on a tool and no documentation update is necessary. 
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
