### PR TITLE
Remove obsolete `Makefile` target reference to `make` module that doesn't exist anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ configure: init-validations
 init-repo:
 	git submodule update --init --recursive
 
-clean: clean-dist clean-validations clean-web  ## Clean all
+clean: clean-dist clean-validations ## Clean all
 
 clean-dist:  ## Clean non-RCS-tracked dist files
 	@echo "Cleaning dist..."


### PR DESCRIPTION
# Committer Notes

This work relates to #841 as part of the work to finalize transitions in repo part of #738.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
