### PR TITLE
Correct repo with official release strategy on website

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you are developing on Windows, [msys2](https://www.msys2.org/) may be used fo
 This section details the version of OSCAL our tooling supports. 
 <details>
 
-FedRAMP has [a release strategy and versioning procedure](./documents/adr/0002-git-release-version-strategy.md). FedRAMP has a minimally supported version of OSCAL, unless explicitly noted otherwise in specific documents or source code in this repository. Data, software, and documentation in this repository will only support digital authorization package documents with a version number no lower than specified by FedRAMP version tags. A version tag that ends in `-oscal2.0.0` will only support data with `oscal-version` equal to `2.0.0` or newer, it will not support `1.0.1`, `1.0.2`, `1.0.3`, `1.0.4`, etc. A future version tag ending in `-oscal1.1.0` indicates FedRAMP source code and guides will support data with `oscal-version` equal to `1.1.0` or newer, but not `1.0.0`.
+FedRAMP has [a release strategy and versioning procedure](https://automate.fedramp.gov/about/release/). FedRAMP has a minimally supported version of OSCAL, unless explicitly noted otherwise in specific documents or source code in this repository. Data, software, and documentation in this repository will only support digital authorization package documents with a version number no lower than specified by FedRAMP's OSCAL data and supporting documentation for each release.
 
 Changes to the minimally supported version and deprecation notices will be made in advance of a release.
 


### PR DESCRIPTION
# Committer Notes

As part of #847, we need to correct the release information to point to the new canonical release strategy on automate.fedramp.gov as part of #847.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.? Needs this PR and notehr to merge, but this is the purpose of coordinated updates with https://github.com/GSA/automate.fedramp.gov/pull/104.
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
