### PR TITLE
Add `has-published-date` constraint 

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -123,6 +123,8 @@ Examples:
   | has-network-architecture-diagram-link-rel-PASS.yaml |
   | has-network-architecture-diagram-link-rel-allowed-value-FAIL.yaml |
   | has-network-architecture-diagram-link-rel-allowed-value-PASS.yaml |
+  | has-published-date-FAIL.yaml |
+  | has-published-date-PASS.yaml |
   | has-rules-of-behavior-FAIL.yaml |
   | has-rules-of-behavior-PASS.yaml |
   | has-security-impact-level-FAIL.yaml |
@@ -270,6 +272,7 @@ Examples:
   | has-network-architecture-diagram-link |
   | has-network-architecture-diagram-link-rel |
   | has-network-architecture-diagram-link-rel-allowed-value |
+  | has-published-date |
   | has-rules-of-behavior |
   | has-security-impact-level |
   | has-security-sensitivity-level |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "inquirer": "^10.1.8",
         "js-yaml": "^4.1.0",
         "jsdom": "^25.0.0",
-        "oscal": "^2.0.5-rc-3",
+        "oscal": "2.0.5",
         "ts-node": "^10.9.2",
         "xml-formatter": "^3.6.3",
         "xml2js": "^0.6.2"
@@ -2694,9 +2694,9 @@
       }
     },
     "node_modules/oscal": {
-      "version": "2.0.5-rc-3",
-      "resolved": "https://registry.npmjs.org/oscal/-/oscal-2.0.5-rc-3.tgz",
-      "integrity": "sha512-cbJb+XX//rt5WuLxCBmYKA2huSLh560O3Z0jmqLjWxuh+Tb0T+zndZVQ6YvjIJo2rmASCVdjGKdBm4lok8epEQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/oscal/-/oscal-2.0.5.tgz",
+      "integrity": "sha512-S19CxjK9dYAE/5CYGFF/M1J9z24oIA/WX5Lkk84BzTvmeAa6qWzwIYEnmoeXRCnJnsLP5sNh/9VSFGfvY97omw==",
       "license": "MIT",
       "dependencies": {
         "@terascope/fetch-github-release": "^0.8.10",

--- a/src/validations/constraints/content/ssp-has-published-date-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-published-date-INVALID.xml
@@ -1,0 +1,5 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="12345678-1234-4321-8765-123456789012">
+  <metadata>
+    <!-- <published>2024-08-01T14:30:00Z</published> No published date-->
+  </metadata>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -449,6 +449,16 @@
         </constraints>
     </context>
     <context>
+        <metapath target="/(assessment-plan|assessment-results|plan-of-action-and-milestones|system-security-plan)/metadata"/>
+        <constraints>
+            <expect id="has-published-date" target="." test="exists(published)" level="ERROR">
+                <formal-name>Has Published Date</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/#title-page"/>
+                <message>All documents submitted to FedRAMP MUST define a valid publication date.</message>
+            </expect>
+        </constraints>
+    </context>    
+    <context>
         <metapath target="/(assessment-plan|assessment-results|plan-of-action-and-milestones|system-security-plan)/metadata/party"/>
         <constraints>
             <expect id="party-has-name" target="." test="exists(name)" level="ERROR">

--- a/src/validations/constraints/unit-tests/has-published-date-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-published-date-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for has-published-date
+  description: This test case validates the behavior of constraint has-published-date
+  content: ../content/ssp-has-published-date-INVALID.xml
+  expectations:
+    - constraint-id: has-published-date
+      result: fail

--- a/src/validations/constraints/unit-tests/has-published-date-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-published-date-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for has-published-date
+  description: This test case validates the behavior of constraint has-published-date
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: has-published-date
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR introduces a validation constraint to ensure that each document submitted for FedRAMP authorization contains a valid publication date.

## Changes
Constraint: `has-published-date`
- Validates that a `published` element exists.

## Tests
- Added an invalid test data file for the above constraint. 
- Added pass/fail YAML files for the above constraint to verify their functionality.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ No updates needed. Documentation exists.
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
