### PR TITLE
Add has-inventory-items

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -113,6 +113,8 @@ Examples:
   | has-incident-response-plan-PASS.yaml |
   | has-information-system-contingency-plan-FAIL.yaml |
   | has-information-system-contingency-plan-PASS.yaml |
+  | has-inventory-items-FAIL.yaml |
+  | has-inventory-items-PASS.yaml |  
   | has-network-architecture-FAIL.yaml |
   | has-network-architecture-PASS.yaml |
   | has-network-architecture-diagram-FAIL.yaml |
@@ -287,6 +289,7 @@ Examples:
   | has-identity-assurance-level |
   | has-incident-response-plan |
   | has-information-system-contingency-plan |
+  | has-inventory-items |  
   | has-network-architecture |
   | has-network-architecture-diagram |
   | has-network-architecture-diagram-caption |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -316,6 +316,25 @@
         <prop name="asset-id" value="DB-001" ns="http://csrc.nist.gov/ns/oscal"/>
       </implemented-component>
     </inventory-item>
+
+    <inventory-item uuid="77777777-0000-4000-9001-000000000007">
+      <description>
+        <p>Secondary database server</p>
+      </description>
+      <prop name="asset-id" value="DB-002" ns="http://csrc.nist.gov/ns/oscal"/>
+      <prop name="asset-type" value="database"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
+      <prop name="public" value="no"/>
+      <prop name="virtual" value="yes"/>
+      <prop name="scan-type" value="database" ns="https://fedramp.gov/ns/oscal"/>
+      <responsible-party role-id="asset-owner">
+        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-party>
+      <implemented-component component-uuid="55555555-0000-4000-9001-000000000005">
+        <prop name="asset-id" value="DB-002" ns="http://csrc.nist.gov/ns/oscal"/>
+      </implemented-component>
+    </inventory-item>
+
   </system-implementation>
   
   <control-implementation>

--- a/src/validations/constraints/content/ssp-has-inventory-items-INVALID.xml
+++ b/src/validations/constraints/content/ssp-has-inventory-items-INVALID.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
+                      uuid="12345678-1234-4321-8765-123456789012">
+  
+  <system-implementation>
+    <inventory-item uuid="77777777-0000-4000-9000-000000000007">
+      <description>
+        <p>Primary database server</p>
+      </description>
+      <prop name="asset-id" value="DB-001" ns="http://csrc.nist.gov/ns/oscal"/>
+      <prop name="asset-type" value="database"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
+      <prop name="public" value="no"/>
+      <prop name="virtual" value="yes"/>
+      <prop name="scan-type" value="database" ns="https://fedramp.gov/ns/oscal"/>
+      <responsible-party role-id="asset-owner">
+        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-party>
+      <implemented-component component-uuid="55555555-0000-4000-9000-000000000005">
+        <prop name="asset-id" value="DB-001" ns="http://csrc.nist.gov/ns/oscal"/>
+      </implemented-component>
+    </inventory-item>
+  </system-implementation>
+
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -509,6 +509,16 @@
             </expect>
         </constraints>
     </context>
+	<context>
+		<metapath target="/system-security-plan/system-implementation"/>
+		<constraints>
+			<expect id="has-inventory-items" target="." test="count(inventory-item) >= 2" level="ERROR">
+				<formal-name>System Implementation Has Inventory Items</formal-name>
+				<prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+				<message>A FedRAMP SSP system implementation section MUST have at least two inventory items.</message>
+			</expect>
+		</constraints>
+	</context>    
     <context>
         <metapath target="/(assessment-plan|assessment-results|plan-of-action-and-milestones|system-security-plan)/metadata"/>
         <constraints>

--- a/src/validations/constraints/unit-tests/has-inventory-items-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/has-inventory-items-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid has-inventory-items constraint unit test.
+test-case:
+  name: The invalid has-inventory-items constraint unit test.
+  description: Test that the FedRAMP SSP contains only one inventory item.
+  content: ../content/ssp-has-inventory-items-INVALID.xml
+  expectations:
+  - constraint-id: has-inventory-items
+    result: fail

--- a/src/validations/constraints/unit-tests/has-inventory-items-PASS.yaml
+++ b/src/validations/constraints/unit-tests/has-inventory-items-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid has-inventory-items constraint unit test.
+test-case:
+  name: The valid has-inventory-items constraint unit test.
+  description: Test that the FedRAMP SSP contains the two or more inventory items.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+  - constraint-id: has-inventory-items
+    result: pass


### PR DESCRIPTION
# Committer Notes

1. Add the `has-inventory-items` constraint, which checks that a FedRAMP SSP contains two or more inventory items.
2. In the `ssp-all-VALID.xml` file, add the second `<inventory-item>` node to make the SSP valid.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
