### PR TITLE
Create run-lint.yml

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -16,8 +16,6 @@ on:
 jobs:
   # one job that runs tests
   run-tests:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-20.04
     # Checkout repository and its submodules
     steps:

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -1,0 +1,56 @@
+# This action runs unit tests for the OSCAL (schematron) validations to ensure validations
+# are working against known samples
+name: "OSCAL Validations: Style test"
+
+# Triggered when code is pushed to master and on pull requests
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - 'feature/**'  # This will match any branch starting with "feature"
+
+  pull_request:
+
+# the job requires some dependencies to be installed (including submodules), runs the tests, and then reports results
+jobs:
+  # one job that runs tests
+  run-tests:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-20.04
+    # Checkout repository and its submodules
+    steps:
+      # Check-out the repository under $GITHUB_WORKSPACE
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Set up Java
+        uses: actions/setup-java@67fbd726daaf08212a7b021c1c4d117f94a81dd3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+      - name: Read node version from `.nvmrc` file
+        id: nvmrc
+        shell: bash
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Install required node.js version
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with:
+          node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
+      - name: Install OSCAL CLI
+        run: |
+          make init-validations
+          npx oscal use 2.2.0
+      - name: Run Lint tests
+        shell: bash
+        run: |
+          make lint
+      - name : Publish all Junit XML tests results in Github Summary
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
+        if: always()
+        with:
+            paths: |
+              **/reports/junit-*.xml
+      

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -39,10 +39,9 @@ jobs:
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
           node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
-      - name: Install OSCAL CLI
+      - name: Install OSCAL CLI 
         run: |
-          make init-validations
-          npx oscal use 2.2.0
+          npm install && npx oscal use 2.2.0
       - name: Run Lint tests
         shell: bash
         run: |

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -33,12 +33,12 @@ jobs:
       - name: Read node version from `.nvmrc` file
         id: nvmrc
         shell: bash
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
 
       - name: Install required node.js version
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
-          node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
       - name: Install OSCAL CLI 
         run: |
           npm install && npx oscal use 2.2.0


### PR DESCRIPTION
# Committer Notes

metaschema validate command doesn't accept external modules correctly since version 2.3.0
so we run it seperately and run in its own context

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
