### PR TITLE
Add missing levels to constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -114,7 +114,7 @@ Examples:
   | has-information-system-contingency-plan-FAIL.yaml |
   | has-information-system-contingency-plan-PASS.yaml |
   | has-inventory-items-FAIL.yaml |
-  | has-inventory-items-PASS.yaml |  
+  | has-inventory-items-PASS.yaml |
   | has-network-architecture-FAIL.yaml |
   | has-network-architecture-PASS.yaml |
   | has-network-architecture-diagram-FAIL.yaml |
@@ -291,7 +291,7 @@ Examples:
   | has-identity-assurance-level |
   | has-incident-response-plan |
   | has-information-system-contingency-plan |
-  | has-inventory-items |  
+  | has-inventory-items |
   | has-network-architecture |
   | has-network-architecture-diagram |
   | has-network-architecture-diagram-caption |

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -7,7 +7,7 @@
     <context>
     	<metapath target="/(assessment-plan|assessment-results|plan-of-action-and-milestones|system-security-plan)/metadata"/>
         <constraints>
-            <expect id="fedramp-version" target="." test="prop[@name='fedramp-version'][@ns='https://fedramp.gov/ns/oscal']">
+            <expect id="fedramp-version" target="." test="prop[@name='fedramp-version'][@ns='https://fedramp.gov/ns/oscal']" level="ERROR">
                 <formal-name>Fedramp Version</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/#fedramp-version"/>
                 <message>A FedRAMP document's metadata MUST define a valid FedRAMP version.</message>
@@ -27,27 +27,27 @@
     <context>
         <metapath target="//user"/>
         <constraints>
-            <expect id="user-has-authorized-privilege" target="." test="count(authorized-privilege) gt 0">
+            <expect id="user-has-authorized-privilege" target="." test="count(authorized-privilege) gt 0" level="ERROR">
                 <formal-name>User Has Authorized Privilege</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#user"/>
                 <message>A FedRAMP document MUST define a user with at least one authorized privilege by a privilege identifier.</message>
             </expect>
-            <expect id="user-has-privilege-level" target="." test="count(prop[@name='privilege-level'][@ns='https://fedramp.gov/ns/oscal']) = 1">
+            <expect id="user-has-privilege-level" target="." test="count(prop[@name='privilege-level'][@ns='https://fedramp.gov/ns/oscal']) = 1" level="ERROR">
                 <formal-name>User Has Privilege Level</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#user"/>
                 <message>A FedRAMP document MUST define a user with a privilege for their use of the system.</message>
             </expect>
-            <expect id="user-has-role-id" target="." test="count(role-id) gt 0">
+            <expect id="user-has-role-id" target="." test="count(role-id) gt 0" level="ERROR">
                 <formal-name>User Has Role ID</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#user"/>
                 <message>A FedRAMP document MUST define a user with at least one role by a role identifier.</message>
             </expect>
-            <expect id="user-has-sensitivity-level" target="." test="count(prop[@name='sensitivity']) = 1">
+            <expect id="user-has-sensitivity-level" target="." test="count(prop[@name='sensitivity']) = 1" level="ERROR">
                 <formal-name>User Has Sensitivity Level</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#user"/>
                 <message>A FedRAMP document MUST define a user with a sensitivity level of their use of the system.</message>
             </expect>
-            <expect id="user-has-user-type" target="." test="count(prop[@name='type']) = 1">
+            <expect id="user-has-user-type" target="." test="count(prop[@name='type']) = 1" level="ERROR">
                 <formal-name>User Has User Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#user"/>
                 <message>A FedRAMP document MUST define a user with a type.</message>
@@ -60,7 +60,7 @@
         <metapath target="/assessment-plan/local-definitions/objectives-and-methods"/>
         <metapath target="/assessment-results/local-definitions/objectives-and-methods"/>
         <constraints>
-            <expect id="prop-response-point-has-cardinality-one" target=".//part" test="count(prop[@ns='https://fedramp.gov/ns/oscal' and @name='response-point']) &lt;= 1">
+            <expect id="prop-response-point-has-cardinality-one" target=".//part" test="count(prop[@ns='https://fedramp.gov/ns/oscal' and @name='response-point']) &lt;= 1" level="ERROR">
                 <formal-name>Prop Response Point Has Cardinality One</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/6-security-controls/#control-implementation-descriptions"/>
                 <message>MUST NOT have Duplicate response point at '{ path(.) }'.</message>
@@ -162,7 +162,7 @@
     <context>
         <metapath target="/system-security-plan/control-implementation"/>
         <constraints>
-            <expect id="missing-response-components" target="implemented-requirement" test="count(./by-component) gt 0">
+            <expect id="missing-response-components" target="implemented-requirement" test="count(./by-component) gt 0" level="ERROR">
                 <formal-name>Missing Response Components</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/6-security-controls/#response-overview"/>
                 <message>Each implemented requirement MUST have at least one by-component reference to the source component implementing it.</message>

--- a/src/validations/styleguides/fedramp-constraint-style.xml
+++ b/src/validations/styleguides/fedramp-constraint-style.xml
@@ -31,7 +31,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://github.com/GSA/fedramp-automation/blob/develop/src/validations/styleguides/STYLE.md#frr106"/>
                 <message>A FedRAMP constraint id MUST only consist of lowercase letters, numbers 0-9, or "-" characters.</message>
             </expect>
-            <expect id="frr107" target="//expect | //allowed-values | //index-has-key" test="matches(@level, '\b(CRITICAL|ERROR|WARNING|INFORMATIONAL|DEBUG)\b')" level="ERROR">
+            <expect id="frr107" target="//expect | //allowed-values | //index-has-key" test="matches(@level, '(CRITICAL|ERROR|WARNING|INFORMATIONAL|DEBUG)')" level="ERROR">
                 <formal-name>Constraints Have an Explicit Severity Level</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://github.com/GSA/fedramp-automation/blob/develop/src/validations/styleguides/STYLE.md#frr107"/>
                 <message>A FedRAMP constraint MUST specify a valid severity level.</message>


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the missing `@level` attribute to several constraints in the `fedramp-external-constraints.xml` file.

## Changes
- Added `level="ERROR"` to constraints that were missing the `@level` attribute.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ No documentation is needed for this change as it is a minor correction to a file.
~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~ No issues necessary. 

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
