### PR TITLE
Add `saas-has-leveraged-authorization` Constraint 

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -73,6 +73,7 @@ Examples:
   | has-identity-assurance-level |
   | has-incident-response-plan |
   | has-information-system-contingency-plan |
+  | has-inventory-items |
   | has-network-architecture |
   | has-network-architecture-diagram |
   | has-network-architecture-diagram-caption |
@@ -118,9 +119,11 @@ Examples:
   | role-defined-prepared-by |
   | role-defined-prepared-for |
   | role-defined-system-owner |
+  | saas-has-leveraged-authorization |
   | scan-type |
   | security-level |
   | security-sensitivity-level-matches-security-impact-level |
+  | unique-inventory-item-asset-id |
   | user-has-authorized-privilege |
   | user-has-privilege-level |
   | user-has-role-id |
@@ -332,6 +335,8 @@ Examples:
   | role-defined-prepared-for-PASS.yaml |
   | role-defined-system-owner-FAIL.yaml |
   | role-defined-system-owner-PASS.yaml |
+  | saas-has-leveraged-authorization-FAIL.yaml |
+  | saas-has-leveraged-authorization-PASS.yaml |
   | scan-type-FAIL.yaml |
   | scan-type-PASS.yaml |
   | security-level-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-saas-has-leveraged-authorization-INVALID.xml
+++ b/src/validations/constraints/content/ssp-saas-has-leveraged-authorization-INVALID.xml
@@ -1,0 +1,8 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-characteristics>
+    <prop name="cloud-service-model" value="saas"/>
+  </system-characteristics>
+  <system-implementation>
+    <!-- Missing leveraged authorization -->
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-saas-has-leveraged-authorization-VALID.xml
+++ b/src/validations/constraints/content/ssp-saas-has-leveraged-authorization-VALID.xml
@@ -1,0 +1,537 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
+                      uuid="12345678-1234-4321-8765-123456789012">
+  <metadata>
+    <title>Enhanced Example System Security Plan</title>
+    <published>2024-08-01T14:30:00Z</published>
+    <last-modified>2024-08-01T14:30:00Z</last-modified>
+    <version>1.1</version>
+    <oscal-version>1.1.2</oscal-version>
+    <document-id scheme="https://example.com/identifiers">SSP-2024-002</document-id>
+    <prop name="fedramp-version" ns="https://fedramp.gov/ns/oscal" value="fedramp-3.0.0rc1-oscal-1.1.2"/>
+    <prop name="marking" value="cui"/>
+    
+    <role id="prepared-by">
+      <title>Prepared By</title>
+      <description>
+        <p>This party prepared the SSP.</p>
+      </description>
+    </role>
+    <role id="prepared-for">
+      <title>Prepared For</title>
+      <description>
+        <p>The organization for which this SSP was prepared. Typically the CSP.</p>
+      </description>
+    </role>
+    <role id="creator">
+      <title>Document Creator</title>
+    </role>
+    <role id="content-approver">
+      <title>Content Approver</title>
+    </role>
+    <role id="system-admin">
+      <title>System Administrator</title>
+    </role>
+    <role id="asset-owner">
+      <title>Asset Owner</title>
+    </role>
+    <role id="system-owner">
+      <title>System Owner</title>
+    </role>
+     <role id="authorizing-official-poc">
+       <title>Authorizing Official Point of Contact</title>
+     </role>
+     <role id="information-system-security-officer">
+       <title>Information System Security Officer (or Equivalent)</title>
+     </role>
+     <role id="system-poc-management">
+      <title>Information System Management Point of Contact (POC)</title>
+      <description>
+         <p>The highest level manager who is responsible for system operation on behalf of the System Owner.</p>
+      </description>
+      </role>
+      <role id="system-poc-technical">
+          <title>Information System Technical Point of Contact</title>
+          <description>
+            <p>The individual or individuals leading the technical operation of the system.</p>
+          </description>
+      </role>
+      <role id="system-poc-other">
+          <title>General Point of Contact (POC)</title>
+          <description>
+            <p>A general point of contact for the system, designated by the system owner.</p>
+          </description>
+      </role>
+
+    <location uuid="27b78960-59ef-4619-82b0-ae20b9c709ac">
+      <title>CSP HQ</title>
+      <address type="work">
+        <addr-line>Suite 0000</addr-line>
+        <addr-line>1234 Some Street</addr-line>
+        <city>Haven</city>
+        <state>ME</state>
+        <postal-code>00000</postal-code>
+        <country>US</country>
+      </address>
+    </location>
+    <location uuid="11111112-0000-4000-9001-000000000009">
+      <address >
+        <country>US</country>
+      </address>
+      <prop name="type" value="data-center" class="primary"/>
+    </location>
+    <location uuid="11111112-0000-4000-9000-000000000003">
+      <address >
+        <country>US</country>
+      </address>
+      <prop name="type" value="data-center" class="alternate"/>
+    </location>
+    <party uuid="3360e343-9860-4bda-9dfc-ff427c3dfab6" type="person">
+      <name>Person Name 1</name>
+      <prop name="job-title" value="Individual's Title"/>
+      <prop name="mail-stop" value="Mailstop A-1"/>
+      <email-address>name@example.com</email-address>
+      <telephone-number>2020000001</telephone-number>
+      <location-uuid>27b78960-59ef-4619-82b0-ae20b9c709ac</location-uuid>
+      <member-of-organization>6b286b5d-8f07-4fa7-8847-1dd0d88f73fb</member-of-organization>
+    </party>
+    <party uuid="6b286b5d-8f07-4fa7-8847-1dd0d88f73fb" type="organization">
+      <name>Cloud Service Provider (CSP) Name</name>
+      <short-name>CSP Acronym/Short Name</short-name>
+      <link href="#31a46c4f-2959-4287-bc1c-67297d7da60b" rel="logo"/>
+      <location-uuid>27b78960-59ef-4619-82b0-ae20b9c709ac</location-uuid>
+    </party>
+    <party uuid="11111111-0000-4000-9000-000000000001" type="organization">
+      <name>Example Organization</name>
+      <short-name>ExOrg</short-name>
+      <link rel="website" href="https://example.com"/>
+    </party>
+    <party uuid="22222222-0000-4000-9000-000000000002" type="person">
+      <name>Jane Doe</name>
+      <email-address>jane.doe@example.com</email-address>
+    <address type="work"  />
+    </party>
+
+    <responsible-party role-id="prepared-by">
+      <party-uuid>3360e343-9860-4bda-9dfc-ff427c3dfab6</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="prepared-for">
+      <party-uuid>6b286b5d-8f07-4fa7-8847-1dd0d88f73fb</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="creator">
+      <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="content-approver">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+
+    <responsible-party role-id="system-owner">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="authorizing-official">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="authorizing-official-poc">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="system-poc-management">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="system-poc-technical">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="system-poc-other">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+    <responsible-party role-id="information-system-security-officer">
+      <party-uuid>22222222-0000-4000-9000-000000000002</party-uuid>
+    </responsible-party>
+
+    <remarks>
+      <p>This SSP is an example for demonstration purposes.</p>
+    </remarks>
+  </metadata>
+  
+  <import-profile href="../../../../dist/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.xml"/>
+  
+  <system-characteristics>
+    <system-id identifier-type="https://fedramp.gov">F00000001</system-id>
+    <system-name>Enhanced Example System</system-name>
+    <system-name-short>System's Short Name or Acronym</system-name-short>
+    <description>
+      <p>This is an enhanced example system for demonstration purposes, incorporating more FedRAMP-specific elements.</p>
+    </description>
+    <prop name="cloud-deployment-model" value="public-cloud">
+      <remarks>
+        <p>Remarks are required if deployment model is "hybrid-cloud" or "other". Optional otherwise.</p>
+      </remarks>
+    </prop>
+    <prop name="cloud-service-model" value="saas">
+      <remarks>
+        <p>Remarks are required if service model is "other". Optional otherwise.</p>
+      </remarks>
+    </prop>
+    <prop name='authorization-type' value='fedramp-agency' ns="https://fedramp.gov/ns/oscal"/>
+    <prop name="identity-assurance-level" value="2"/>
+    <prop name="authenticator-assurance-level" value="2"/>
+    <prop name="federation-assurance-level" value="2"/>
+    <prop ns="https://fedramp.gov/ns/oscal" name="fully-operational-date" value="2023-01-01+00:00"/>
+    <security-sensitivity-level>fips-199-moderate</security-sensitivity-level>
+    <system-information>
+      <information-type  uuid="33333333-0000-4000-9000-000000000003">
+        <title>Financial Information</title>
+        <description>
+          <p>Contains sensitive financial data related to organizational operations.</p>
+        </description>
+        <categorization system="https://doi.org/10.6028/NIST.SP.800-60v2r1">
+          <information-type-id>C.2.8.12</information-type-id>
+        </categorization>
+        <confidentiality-impact>
+          <base>fips-199-high</base>
+          <selected>fips-199-high</selected>
+          <!-- adjustment-justification removed to ensure cia-impact-has-adjustment-justification passes when base and selected have the same impact level -->
+        </confidentiality-impact>
+        <integrity-impact>
+          <base>fips-199-moderate</base>
+          <selected>fips-199-low</selected>
+          <adjustment-justification>
+            <p>Required if the base and selected values do not match.</p>
+          </adjustment-justification>
+        </integrity-impact>
+        <availability-impact>
+          <base>fips-199-high</base>
+          <selected>fips-199-low</selected>
+          <adjustment-justification>
+            <p>Required if the base and selected values do not match.</p>
+          </adjustment-justification>
+        </availability-impact>
+      </information-type>
+    </system-information>
+    <security-impact-level>
+      <security-objective-confidentiality>fips-199-moderate</security-objective-confidentiality>
+      <security-objective-integrity>fips-199-moderate</security-objective-integrity>
+      <security-objective-availability>fips-199-moderate</security-objective-availability>
+    </security-impact-level>
+    <status state="operational"/>
+    <authorization-boundary>
+      <description>
+        <p>The authorization boundary includes all components within the main data center and the disaster recovery site.</p>
+      </description>
+      <diagram uuid="dbf46c27-52a9-49c4-beb6-b6399cd75497">
+            <description>
+               <p>A diagram-specific explanation.</p>
+            </description>
+            <link href="#d2eb3c18-6754-4e3a-a933-03d289e3fad5" rel="diagram"/>
+            <caption>Authorization Boundary Diagram</caption>
+         </diagram>
+    </authorization-boundary>
+    <network-architecture>
+      <description>
+        <p>A holistic, top-level explanation of the network architecture.</p>
+      </description>
+      <diagram uuid="e97c3395-433a-48c1-8cc7-dd1e1555941c">
+        <description>
+          <p>A diagram-specific explanation.</p>
+        </description>
+        <link href="#61081e81-850b-43c1-bf43-1ecbddcb9e7f" rel="diagram"/>
+        <caption>Network Diagram</caption>
+      </diagram>
+    </network-architecture>
+    <data-flow>
+      <description>
+        <p>A holistic, top-level explanation of the system's data flows.</p>
+      </description>
+      <diagram uuid="e3b98448-4219-46a5-b229-412423c566f3">
+        <description>
+          <p>A diagram-specific explanation.</p>
+        </description>
+        <link href="#ac5d7535-f3b8-45d3-bf3b-735c82c64547" rel="diagram"/>
+        <caption>Data Flow Diagram</caption>
+      </diagram>
+    </data-flow>
+  </system-characteristics>
+  
+  <system-implementation>
+    <leveraged-authorization uuid="5a9c98ab-8e5e-433d-a7bd-515c07cd1497">
+        <title>GovCloud</title>
+        <prop ns="http://fedramp.gov/ns/oscal" name="leveraged-system-identifier" value="F1603047866"/>
+        <prop ns="http://fedramp.gov/ns/oscal" name="authorization-type" value="fedramp-agency"/>
+        <prop ns="http://fedramp.gov/ns/oscal" name="impact-level" value="moderate"/>
+        <prop ns="http://fedramp.gov/ns/oscal" name="user-authentication" value="yes">
+            <remarks>
+                <p>If 'yes', describe the user authentication method.</p>
+                <p>If 'no', explain why no user authentication is used.</p>
+                <p>If 'not-applicable', attest that no users access the leveraged system.</p>
+            </remarks>
+        </prop>
+        <party-uuid>f0bc13a4-3303-47dd-80d3-380e159c8362</party-uuid>
+        <date-authorized>2015-01-01</date-authorized>
+    </leveraged-authorization>
+    <user uuid="44444444-0000-4000-9000-000000000004">
+      <title>System Administrator</title>
+      <prop name="type" value="internal"/>
+      <prop ns="https://fedramp.gov/ns/oscal" name="privilege-level" value="read-write"/>
+      <prop ns="https://fedramp.gov/ns/oscal" name="sensitivity" value="high-risk"/>
+      <role-id>system-admin</role-id>
+      <authorized-privilege>
+        <title>Admin</title>
+        <description><p>admin user</p></description>
+        <function-performed>administration</function-performed>
+      </authorized-privilege>
+
+    </user>
+    
+    <component uuid="55555555-0000-4000-9000-000000000005" type="this-system">
+      <title>Primary Application Server</title>
+      <description>
+        <p>Main application server hosting the core system functionality.</p>
+      </description>
+      <purpose>main line</purpose>
+      <status state="operational"/>
+      <responsible-role role-id="system-admin">
+        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-role>
+      <remarks>
+        <p>This is the primary application server for the system.</p>
+      </remarks>
+    </component>
+    
+    <component uuid="66666666-0000-4000-9000-000000000006" type="interconnection">
+      <title>External API Connection</title>
+      <description>
+        <p>Secure connection to an external API for data enrichment.</p>
+      </description>
+      <prop name="interconnection-security" value="vpn" ns="https://fedramp.gov/ns/oscal"/>
+      <prop name="interconnection-direction" value="in/out" ns="https://fedramp.gov/ns/oscal"/>
+      <status state="operational"/>
+      <responsible-role role-id="system-admin">
+        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-role>
+      <remarks>
+        <p>This connection is used for secure data exchange with external systems.</p>
+      </remarks>
+    </component>
+    
+    <inventory-item uuid="77777777-0000-4000-9000-000000000007">
+      <description>
+        <p>Primary database server</p>
+      </description>
+      <prop name="asset-id" value="DB-001" ns="http://csrc.nist.gov/ns/oscal"/>
+      <prop name="asset-type" value="database"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
+      <prop name="public" value="no"/>
+      <prop name="virtual" value="yes"/>
+      <prop name="scan-type" value="database" ns="https://fedramp.gov/ns/oscal"/>
+      <responsible-party role-id="asset-owner">
+        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-party>
+      <implemented-component component-uuid="55555555-0000-4000-9000-000000000005">
+        <prop name="asset-id" value="DB-001" ns="http://csrc.nist.gov/ns/oscal"/>
+      </implemented-component>
+    </inventory-item>
+
+    <inventory-item uuid="77777777-0000-4000-9001-000000000007">
+      <description>
+        <p>Secondary database server</p>
+      </description>
+      <prop name="asset-id" value="DB-002" ns="http://csrc.nist.gov/ns/oscal"/>
+      <prop name="asset-type" value="database"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
+      <prop name="public" value="no"/>
+      <prop name="virtual" value="yes"/>
+      <prop name="scan-type" value="database" ns="https://fedramp.gov/ns/oscal"/>
+      <responsible-party role-id="asset-owner">
+        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-party>
+      <implemented-component component-uuid="55555555-0000-4000-9001-000000000005">
+        <prop name="asset-id" value="DB-002" ns="http://csrc.nist.gov/ns/oscal"/>
+      </implemented-component>
+    </inventory-item>
+
+  </system-implementation>
+  
+  <control-implementation>
+    <description>
+      <p>Implementation of controls for the Enhanced Example System</p>
+    </description>
+    <implemented-requirement uuid="88888888-0000-4000-9000-000000000008" control-id="ac-1">
+      <prop name="control-origination" value="sp-system" ns="https://fedramp.gov/ns/oscal"/>
+      <prop name="implementation-status" value="partial" ns="https://fedramp.gov/ns/oscal"/>
+      <statement statement-id="ac-1_stmt.a" uuid="99999999-0000-4000-9000-000000000009">
+      </statement>
+      <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="aaaaaaaa-0000-4000-9000-00000000000a">
+        <description>
+          <p>Access Control Policy and Procedures (AC-1) is fully implemented in our system.</p>
+        </description>
+        <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="implemented"/>
+        <responsible-role role-id="system-admin">
+          <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-role>
+      </by-component>
+    </implemented-requirement>
+    
+    <implemented-requirement uuid="bbbbbbbb-0000-4000-9000-00000000000b" control-id="cm-8">
+      <prop name="control-origination" value="sp-system" ns="https://fedramp.gov/ns/oscal"/>
+      <statement statement-id="cm-8_stmt.a" uuid="cccccccc-0000-4000-9000-00000000000c">
+      </statement>
+      <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="dddddddd-0000-4000-9000-00000000000d">
+        <description>
+          <p>Information System Component Inventory (CM-8) is partially implemented.</p>
+        </description>
+        <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="partial"/>
+        <responsible-role role-id="system-admin">
+          <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+        </responsible-role>
+      </by-component>
+    </implemented-requirement>
+  </control-implementation>
+  
+  <back-matter>
+    <resource uuid="eeeeeeee-0000-4000-9000-00000000000e">
+      <title>Access Control Policy</title>
+      <description>
+        <p>Detailed access control policy document</p>
+      </description>
+      <prop name="type" value="policy" ns="https://fedramp.gov/ns/oscal"/>
+      <rlink href="https://example.com/policies/access-control.pdf"/>
+    </resource>
+    <resource uuid="90a128ac-c850-48f6-8fff-a55692f80b41">
+      <title>User's Guide</title>
+      <description>
+         <p>User's Guide</p>
+      </description>
+      <prop name="type" value="users-guide"/>
+      <prop name="published" value="2023-01-01T00:00:00Z"/>
+      <rlink href="./documents/guides/sample_guide.pdf"/>
+      <remarks>
+         <p>Table 12-1 Attachments: User's Guide Attachment</p>
+         <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+      </remarks>
+   </resource>
+   <resource uuid="489112e1-57f2-4c29-8dd0-95b1442fbf3b">
+    <title>Document Title</title>
+    <description>
+       <p>Rules of Behavior</p>
+    </description>
+    <prop name="type" value="rules-of-behavior"/>
+    <prop name="published" value="2023-01-01T00:00:00Z"/>
+    <prop name="version" value="Document Version"/>
+    <rlink href="./documents/rob.docx" media-type="application/msword"/>
+    <base64 filename="rob.docx" media-type="application/msword">00000000</base64>
+    <remarks>
+       <p>Table 12-1 Attachments: Rules of Behavior (ROB)</p>
+       <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+    </remarks>
+ </resource>
+ <resource uuid="c7860916-f2f4-43aa-b578-d48cf8e6d381">
+  <title>Document Title</title>
+  <description>
+     <p>Contingency Plan (CP)</p>
+  </description>
+  <prop name="type" value="plan" class="information-system-contingency-plan"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/cp.docx" media-type="application/msword"/>
+  <base64 filename="cp.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>Table 12-1 Attachments: Contingency Plan (CP) Attachment</p>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
+<resource uuid="ab56cf27-0dae-40d6-89b7-d750137309af">
+  <title>Document Title</title>
+  <description>
+     <p>Configuration Management (CM) Plan</p>
+  </description>
+  <prop name="type" value="plan" class="configuration-management-plan"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/CM_Plan.docx" media-type="application/msword"/>
+  <base64 filename="CM_Plan.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>Table 12-1 Attachments: Configuration Management (CM) Plan Attachment</p>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
+<resource uuid="3f771ab5-8016-4571-98d1-f0fb962e15e2">
+  <title>Document Title</title>
+  <description>
+     <p>Incident Response (IR) Plan</p>
+  </description>
+  <prop name="type" value="plan" class="incident-response-plan"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/IR_Plan.docx" media-type="application/msword"/>
+  <base64 filename="IR_Plan.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>Table 12-1 Attachments: Incident Response (IR) Plan Attachment</p>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
+<resource uuid="49fb4631-1da2-41ca-b0b3-e1b1006d4025">
+  <title>Separation of Duties Matrix</title>
+  <description>
+     <p>Separation of Duties Matrix</p>
+  </description>
+  <prop ns="https://fedramp.gov/ns/oscal" name="type" value="separation-of-duties-matrix"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/Sep_Matrix.docx" media-type="application/msword"/>
+  <base64 filename="Sep_Matrix.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
+
+
+<resource uuid="d2eb3c18-6754-4e3a-a933-03d289e3fad5">
+  <title>Authorization Boundary</title>
+  <description>
+     <p>Authorization Boundary Diagram</p>
+  </description>
+  <prop ns="https://fedramp.gov/ns/oscal" name="type" value="plan"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/AuthBoundary.docx" media-type="application/msword"/>
+  <base64 filename="AuthBoundary.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
+
+<resource uuid="61081e81-850b-43c1-bf43-1ecbddcb9e7f">
+  <title>Network Architecture</title>
+  <description>
+     <p>Network Architecture Diagram</p>
+  </description>
+  <prop ns="https://fedramp.gov/ns/oscal" name="type" value="plan"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/NetworkArchitecture.docx" media-type="application/msword"/>
+  <base64 filename="NetworkArchitecture.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
+
+<resource uuid="ac5d7535-f3b8-45d3-bf3b-735c82c64547">
+  <title>Data Flow</title>
+  <description>
+     <p>Data flow Diagram</p>
+  </description>
+  <prop ns="https://fedramp.gov/ns/oscal" name="type" value="plan"/>
+  <prop name="published" value="2023-01-01T00:00:00Z"/>
+  <prop name="version" value="Document Version"/>
+  <rlink href="./documents/Dataflo.docx" media-type="application/msword"/>
+  <base64 filename="Dataflow.docx" media-type="application/msword">00000000</base64>
+  <remarks>
+     <p>May use <code>rlink</code> with a relative path, or embedded as <code>base64</code>.</p>
+  </remarks>
+</resource>
+
+
+
+  </back-matter>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -502,6 +502,11 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-information-and-information-types"/>
                 <message>A FedRAMP SSP information type MUST have an integrity impact.</message>
             </expect>
+            <expect id="saas-has-leveraged-authorization" target="." test="if (exists(prop[@name='cloud-service-model' and @value='saas'])) then (count(..//leveraged-authorization) >= 1) else (true())" level="ERROR">
+                <formal-name>SaaS Has Leveraged Authorization</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#service-model"/>
+                <message>A FedRAMP SSP that defines a SaaS cloud service model MUST define at least one leveraged authorization.</message>
+            </expect>
             <expect id="security-sensitivity-level-matches-security-impact-level" target="security-sensitivity-level" test=". eq $security-impact-level" level="WARNING">
                 <formal-name>Security Sensitivity Level Matches Security Impact Level</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-sensitivity-level"/>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -293,6 +293,7 @@
     <context>
         <metapath target="/system-security-plan/system-characteristics"/>
         <constraints>
+            <let var="is-saas" expression="exists(prop[@name='cloud-service-model' and @value='saas'])"/>
             <let var="security-impact-level" expression=
                 "if (//security-impact-level//* = 'fips-199-high')
                     then ('fips-199-high')
@@ -502,7 +503,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-information-and-information-types"/>
                 <message>A FedRAMP SSP information type MUST have an integrity impact.</message>
             </expect>
-            <expect id="saas-has-leveraged-authorization" target="." test="if (exists(prop[@name='cloud-service-model' and @value='saas'])) then (count(..//leveraged-authorization) >= 1) else (true())" level="ERROR">
+            <expect id="saas-has-leveraged-authorization" target="." test="if ($is-saas) then (count(..//leveraged-authorization) >= 1) else (true())" level="ERROR">
                 <formal-name>SaaS Has Leveraged Authorization</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#service-model"/>
                 <message>A FedRAMP SSP that defines a SaaS cloud service model MUST define at least one leveraged authorization.</message>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -505,7 +505,7 @@
             </expect>
             <expect id="saas-has-leveraged-authorization" target="." test="if ($is-saas) then (count(..//leveraged-authorization) >= 1) else (true())" level="ERROR">
                 <formal-name>SaaS Has Leveraged Authorization</formal-name>
-                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#service-model"/>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>A FedRAMP SSP that defines a SaaS cloud service model MUST define at least one leveraged authorization.</message>
             </expect>
             <expect id="security-sensitivity-level-matches-security-impact-level" target="security-sensitivity-level" test=". eq $security-impact-level" level="WARNING">

--- a/src/validations/constraints/unit-tests/saas-has-leveraged-authorization-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/saas-has-leveraged-authorization-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for saas-has-leveraged-authorization
+  description: >-
+    This test case validates the behavior of constraint
+    saas-has-leveraged-authorization
+  content: ../content/ssp-saas-has-leveraged-authorization-INVALID.xml
+  expectations:
+    - constraint-id: saas-has-leveraged-authorization
+      result: fail

--- a/src/validations/constraints/unit-tests/saas-has-leveraged-authorization-PASS.yaml
+++ b/src/validations/constraints/unit-tests/saas-has-leveraged-authorization-PASS.yaml
@@ -1,0 +1,12 @@
+test-case:
+  name: Positive Test for saas-has-leveraged-authorization
+  description: >-
+    This test case validates the behavior of constraint saas-has-leveraged-authorization.
+    Scenario 1: SSP does not have a saas cloud service model.
+    Scenario 2: SSP has a saas cloud service model.
+  content: 
+    - ../content/ssp-all-VALID.xml
+    - ../content/ssp-saas-has-leveraged-authorization-VALID.xml
+  expectations:
+    - constraint-id: saas-has-leveraged-authorization
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to ensure that SaaS cloud service offerings include at least one leveraged-authorization. 

## Changes
Added Constraint:
- `saas-has-leveraged-authorization`: Validates that if a SaaS service model is declared, the SSP must include at least one leveraged-authorization.

Added Test Data:
- `1 Invalid Test Data File`: Demonstrates a failure case where a SaaS service model is declared, but no leveraged-authorization elements are provided.

- `2 Valid Test Data Files`: Demonstrate the two ways in which the constraint can pass: A  SaaS service model is declared with one or more leveraged-authorization(s) OR `ssp-all-INVALID.xml` demonstrates no SaaS service model is declared. 

Added YAML Files:
- `2 YAML files`: Included pass and fail YAML files.
### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ Documentation already exists
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
