### PR TITLE
Add leveraged-authorization-nature-of-agreement

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -73,6 +73,7 @@ Examples:
   | has-identity-assurance-level |
   | has-incident-response-plan |
   | has-information-system-contingency-plan |
+  | has-inventory-items |
   | has-network-architecture |
   | has-network-architecture-diagram |
   | has-network-architecture-diagram-caption |
@@ -101,6 +102,7 @@ Examples:
   | inventory-item-allows-authenticated-scan |
   | inventory-item-public |
   | inventory-item-virtual |
+  | leveraged-authorization-nature-of-agreement |
   | marking |
   | missing-response-components |
   | party-has-name |
@@ -121,6 +123,7 @@ Examples:
   | scan-type |
   | security-level |
   | security-sensitivity-level-matches-security-impact-level |
+  | unique-inventory-item-asset-id |
   | user-has-authorized-privilege |
   | user-has-privilege-level |
   | user-has-role-id |
@@ -298,6 +301,8 @@ Examples:
   | inventory-item-public-PASS.yaml |
   | inventory-item-virtual-FAIL.yaml |
   | inventory-item-virtual-PASS.yaml |
+  | leveraged-authorization-nature-of-agreement-FAIL.yaml |
+  | leveraged-authorization-nature-of-agreement-PASS.yaml |
   | marking-FAIL.yaml |
   | marking-PASS.yaml |
   | missing-response-components-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -266,8 +266,6 @@
       <prop ns="https://fedramp.gov/ns/oscal" name="authorization-type" value="fedramp-agency"/>
       <prop ns="https://fedramp.gov/ns/oscal" name="impact-level" value="moderate"/>
       <link href="//path/to/leveraged_system_ssp.xml"/>
-      <link href="//path/to/leveraged_system_legacy_crm.xslt"/>
-      <link href="//path/to/leveraged_system_responsibility_and_inheritance.xml"/>
       <party-uuid>f0bc13a4-3303-47dd-80d3-380e159c8362</party-uuid>
       <date-authorized>2015-01-01</date-authorized>
       <remarks>

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -287,7 +287,17 @@
         <p>This is the primary application server for the system.</p>
       </remarks>
     </component>
-    
+
+    <component uuid="6ac88fd2-7c7b-4357-af2e-f22ccd3ead26" type="system">
+      <title>An External Leveraged System</title>
+      <description>
+        <p>An external leveraged system.</p>
+      </description>
+      <prop name="leveraged-authorization-uuid" uuid="233e0f09-fe5e-47e2-bca3-5f32df75e57a" value="contract"/>
+      <prop name="nature-of-agreement" uuid="306e68da-86c3-4c18-b559-e95d85fb71e7" ns="https://fedramp.gov/ns/oscal" value="sla"/>
+      <status state="operational"/>
+    </component>
+
     <component uuid="66666666-0000-4000-9000-000000000006" type="interconnection">
       <title>External API Connection</title>
       <description>

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -259,6 +259,23 @@
   </system-characteristics>
   
   <system-implementation>
+
+    <leveraged-authorization uuid="233e0f09-fe5e-47e2-bca3-5f32df75e57a">
+      <title>GovCloud</title>
+      <prop ns="https://fedramp.gov/ns/oscal" name="leveraged-system-identifier" value="F1603047866"/>
+      <prop ns="https://fedramp.gov/ns/oscal" name="authorization-type" value="fedramp-agency"/>
+      <prop ns="https://fedramp.gov/ns/oscal" name="impact-level" value="moderate"/>
+      <link href="//path/to/leveraged_system_ssp.xml"/>
+      <link href="//path/to/leveraged_system_legacy_crm.xslt"/>
+      <link href="//path/to/leveraged_system_responsibility_and_inheritance.xml"/>
+      <party-uuid>f0bc13a4-3303-47dd-80d3-380e159c8362</party-uuid>
+      <date-authorized>2015-01-01</date-authorized>
+      <remarks>
+        <p>Use one leveraged-authorization assembly for each underlying system. In the legacy world, these may be general support systems.</p>
+        <p>The link fields are optional, but preferred when known. Often, a leveraging system's SSP author will not have access to the leveraged system's SSP, but should have access to the leveraged system's CRM.</p>
+      </remarks>
+    </leveraged-authorization>
+
     <user uuid="44444444-0000-4000-9000-000000000004">
       <title>System Administrator</title>
       <prop name="type" value="internal"/>
@@ -270,7 +287,6 @@
         <description><p>admin user</p></description>
         <function-performed>administration</function-performed>
       </authorized-privilege>
-
     </user>
     
     <component uuid="55555555-0000-4000-9000-000000000005" type="this-system">
@@ -293,8 +309,8 @@
       <description>
         <p>An external leveraged system.</p>
       </description>
-      <prop name="leveraged-authorization-uuid" uuid="233e0f09-fe5e-47e2-bca3-5f32df75e57a" value="contract"/>
-      <prop name="nature-of-agreement" uuid="306e68da-86c3-4c18-b559-e95d85fb71e7" ns="https://fedramp.gov/ns/oscal" value="sla"/>
+      <prop name="leveraged-authorization-uuid" value="233e0f09-fe5e-47e2-bca3-5f32df75e57a"/>
+      <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="sla"/>
       <status state="operational"/>
     </component>
 

--- a/src/validations/constraints/content/ssp-leveraged-authorization-nature-of-agreement-INVALID.xml
+++ b/src/validations/constraints/content/ssp-leveraged-authorization-nature-of-agreement-INVALID.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
+                      uuid="12345678-1234-4321-8765-123456789012">
+
+  <system-implementation>
+    <component uuid="6ac88fd2-7c7b-4357-af2e-f22ccd3ead26" type="system">
+      <title>An External Leveraged System</title>
+      <description>
+        <p>An external leveraged system.</p>
+      </description>
+      <prop name="leveraged-authorization-uuid" uuid="233e0f09-fe5e-47e2-bca3-5f32df75e57a" value="contract"/>
+      <prop name="nature-of-agreement" uuid="306e68da-86c3-4c18-b559-e95d85fb71e7" ns="https://fedramp.gov/ns/oscal" value="invalid"/>
+      <status state="operational"/>
+    </component>
+  </system-implementation>
+
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -333,6 +333,17 @@
                 <enum value="other">Other</enum>
             </allowed-values>
 
+        	<allowed-values id="leveraged-authorization-nature-of-agreement" target="system-implementation/component[@type='system'][prop[@name='leveraged-authorization-uuid']]/prop[@name='nature-of-agreement'][@ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
+        		<formal-name>Nature of Agreement for Leveraged Authorizations</formal-name>
+        		<description>Identifies nature of agreement for leveraged authorizations.</description>
+        		<enum value="contract">A contract between the CSP and the organization that owns the leveraged system.</enum>
+        		<enum value="eula">An end-user license agreement between the CSP and the organization that owns the leveraged system.</enum>
+        		<enum value="license">An application license agreement between the CSP and the organization that owns the leveraged system.</enum>
+        		<enum value="mou">A memorandum of understanding between the CSP and the organization that owns the leveraged system.</enum>
+        		<enum value="other">An untypical agreement between the CSP and the organization that owns the leveraged system. Explain in remarks.</enum>
+        		<enum value="sla">A service-level agreement between the CSP and the organization that owns the leveraged system.</enum>
+        	</allowed-values>
+
             <allowed-values id="inventory-item-allows-authenticated-scan" target="(//inventory-item | //component)/prop[@name='allows-authenticated-scan']/@value" allow-other="no" level="ERROR">
                 <formal-name>Allows Authenticated Scan</formal-name>
                 <description>Indicates if the asset is capable of having an authenticated scan.</description>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -336,6 +336,7 @@
         	<allowed-values id="leveraged-authorization-nature-of-agreement" target="system-implementation/component[@type='system'][prop[@name='leveraged-authorization-uuid']]/prop[@name='nature-of-agreement'][@ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
         		<formal-name>Nature of Agreement for Leveraged Authorizations</formal-name>
         		<description>Identifies nature of agreement for leveraged authorizations.</description>
+        		<prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping//#fedramp-allowed-values"/>
         		<enum value="contract">A contract between the CSP and the organization that owns the leveraged system.</enum>
         		<enum value="eula">An end-user license agreement between the CSP and the organization that owns the leveraged system.</enum>
         		<enum value="license">An application license agreement between the CSP and the organization that owns the leveraged system.</enum>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -333,18 +333,6 @@
                 <enum value="other">Other</enum>
             </allowed-values>
 
-        	<allowed-values id="leveraged-authorization-nature-of-agreement" target="system-implementation/component[@type='system'][prop[@name='leveraged-authorization-uuid']]/prop[@name='nature-of-agreement'][@ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
-        		<formal-name>Nature of Agreement for Leveraged Authorizations</formal-name>
-        		<description>Identifies nature of agreement for leveraged authorizations.</description>
-        		<prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping//#fedramp-allowed-values"/>
-        		<enum value="contract">A contract between the CSP and the organization that owns the leveraged system.</enum>
-        		<enum value="eula">An end-user license agreement between the CSP and the organization that owns the leveraged system.</enum>
-        		<enum value="license">An application license agreement between the CSP and the organization that owns the leveraged system.</enum>
-        		<enum value="mou">A memorandum of understanding between the CSP and the organization that owns the leveraged system.</enum>
-        		<enum value="other">An untypical agreement between the CSP and the organization that owns the leveraged system. Explain in remarks.</enum>
-        		<enum value="sla">A service-level agreement between the CSP and the organization that owns the leveraged system.</enum>
-        	</allowed-values>
-
             <allowed-values id="inventory-item-allows-authenticated-scan" target="(//inventory-item | //component)/prop[@name='allows-authenticated-scan']/@value" allow-other="no" level="ERROR">
                 <formal-name>Allows Authenticated Scan</formal-name>
                 <description>Indicates if the asset is capable of having an authenticated scan.</description>
@@ -364,6 +352,18 @@
                 <description>Indicates if the asset is virtual.</description>
                 <enum value="yes">Yes</enum>
                 <enum value="no">No</enum>
+            </allowed-values>
+
+            <allowed-values id="leveraged-authorization-nature-of-agreement" target="system-implementation/component[@type='system'][prop[@name='leveraged-authorization-uuid']]/prop[@name='nature-of-agreement'][@ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
+                <formal-name>Nature of Agreement for Leveraged Authorizations</formal-name>
+                <description>Identifies nature of agreement for leveraged authorizations.</description>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
+                <enum value="contract">A contract between the CSP and the organization that owns the leveraged system.</enum>
+                <enum value="eula">An end-user license agreement between the CSP and the organization that owns the leveraged system.</enum>
+                <enum value="license">An application license agreement between the CSP and the organization that owns the leveraged system.</enum>
+                <enum value="mou">A memorandum of understanding between the CSP and the organization that owns the leveraged system.</enum>
+                <enum value="other">An untypical agreement between the CSP and the organization that owns the leveraged system. Explain in remarks.</enum>
+                <enum value="sla">A service-level agreement between the CSP and the organization that owns the leveraged system.</enum>
             </allowed-values>
 
             <allowed-values id="privilege-level" target="system-implementation/user/prop[@name='privilege-level'][@ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">

--- a/src/validations/constraints/unit-tests/leveraged-authorization-nature-of-agreement-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/leveraged-authorization-nature-of-agreement-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid leveraged-authorization-nature-of-agreement constraint unit test.
+test-case:
+  name: The invalid leveraged-authorization-nature-of-agreement constraint unit test.
+  description: Test that the FedRAMP SSP contains invalid nature-of-agreement value for an external leveraged system.
+  content: ../content/ssp-leveraged-authorization-nature-of-agreement-INVALID.xml
+  expectations:
+  - constraint-id: leveraged-authorization-nature-of-agreement
+    result: fail

--- a/src/validations/constraints/unit-tests/leveraged-authorization-nature-of-agreement-PASS.yaml
+++ b/src/validations/constraints/unit-tests/leveraged-authorization-nature-of-agreement-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid leveraged-authorization-nature-of-agreement constraint unit test.
+test-case:
+  name: The valid leveraged-authorization-nature-of-agreement constraint unit test.
+  description: Test that the FedRAMP SSP contains valid nature-of-agreement value for an external leveraged system.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+  - constraint-id: leveraged-authorization-nature-of-agreement
+    result: pass


### PR DESCRIPTION
# Committer Notes

Add allowed values for SSP `nature-of-agreement` props for leveraged systems.

Related issue: #889

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
