### PR TITLE
Add external-system-nature-of-agreement

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -42,6 +42,7 @@ Examples:
   | data-center-primary |
   | data-center-us |
   | deployment-model |
+  | external-system-nature-of-agreement |
   | fedramp-version |
   | fully-operational-date-is-valid |
   | fully-operational-date-type |
@@ -181,6 +182,8 @@ Examples:
   | data-center-us-PASS.yaml |
   | deployment-model-FAIL.yaml |
   | deployment-model-PASS.yaml |
+  | external-system-nature-of-agreement-FAIL.yaml |
+  | external-system-nature-of-agreement-PASS.yaml |
   | fedramp-version-FAIL.yaml |
   | fedramp-version-PASS.yaml |
   | fully-operational-date-is-valid-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -327,6 +327,17 @@
         <p>This connection is used for secure data exchange with external systems.</p>
       </remarks>
     </component>
+
+    <component uuid="77777777-0000-4000-9000-000000000007" type="system">
+      <title>Name of External System</title>
+      <description>
+          <p>Briefly describe the external system.</p>
+      </description>
+      <prop name="inherited-uuid" value="11111111-0000-4000-9001-000000000001"/>
+      <prop name="implementation-point" value="external"/>
+      <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="isa"/>
+      <status state="operational"/>
+    </component>
     
     <inventory-item uuid="77777777-0000-4000-9000-000000000007">
       <description>

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -328,13 +328,13 @@
       </remarks>
     </component>
 
-    <component uuid="77777777-0000-4000-9000-000000000007" type="system">
+    <component uuid="77777777-0000-4000-9000-000000000007" type="software">
       <title>Name of External System</title>
       <description>
           <p>Briefly describe the external system.</p>
       </description>
-      <prop name="inherited-uuid" value="11111111-0000-4000-9001-000000000001"/>
-      <prop name="implementation-point" value="external"/>
+      <prop name="asset-type" value="cli"/>
+      <prop name="direction" value="in/out" ns="https://fedramp.gov/ns/oscal"/>
       <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="isa"/>
       <status state="operational"/>
     </component>

--- a/src/validations/constraints/content/ssp-external-system-nature-of-agreement-INVALID.xml
+++ b/src/validations/constraints/content/ssp-external-system-nature-of-agreement-INVALID.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
+                      uuid="12345678-1234-4321-8765-123456789012">
+  
+  <system-implementation>
+
+    <component uuid="77777777-0000-4000-9000-000000000007" type="system">
+      <title>Name of External System</title>
+      <description>
+          <p>Briefly describe the external system.</p>
+      </description>
+      <prop name="inherited-uuid" value="11111111-0000-4000-9001-000000000001"/>
+      <prop name="implementation-point" value="external"/>
+      <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="invalid"/>
+      <status state="operational"/>
+    </component>
+
+  </system-implementation>
+
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-external-system-nature-of-agreement-INVALID.xml
+++ b/src/validations/constraints/content/ssp-external-system-nature-of-agreement-INVALID.xml
@@ -6,13 +6,13 @@
   
   <system-implementation>
 
-    <component uuid="77777777-0000-4000-9000-000000000007" type="system">
+    <component uuid="77777777-0000-4000-9000-000000000007" type="software">
       <title>Name of External System</title>
       <description>
           <p>Briefly describe the external system.</p>
       </description>
-      <prop name="inherited-uuid" value="11111111-0000-4000-9001-000000000001"/>
-      <prop name="implementation-point" value="external"/>
+      <prop name="asset-type" value="cli"/>
+      <prop name="direction" value="in/out" ns="https://fedramp.gov/ns/oscal"/>
       <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="invalid"/>
       <status state="operational"/>
     </component>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -127,7 +127,7 @@
                 <enum value="other">Other</enum>
             </allowed-values>
 
-            <allowed-values id="external-system-nature-of-agreement" target="system-implementation/component[@type='system'][not(prop[@name='leveraged-authorization-uuid'])][prop[@name='implementation-point' and @value='external']]/prop[@name='nature-of-agreement' and @ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
+            <allowed-values id="external-system-nature-of-agreement" target="system-implementation/component[(@type='service' and not(prop[@name='leveraged-authorization-uuid']) and prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and prop[@name='implementation-point' and @value='internal'] and prop[@name='direction']) or (@type='software' and prop[@name='asset-type' and @value='cli'] and prop[@name='direction'])]/prop[@name='nature-of-agreement' and @ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
                 <formal-name>Nature of Agreement for External Systems</formal-name>
                 <description>Identifies nature of agreement for external systems.</description>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -130,7 +130,7 @@
             <allowed-values id="external-system-nature-of-agreement" target="system-implementation/component[@type='system'][not(prop[@name='leveraged-authorization-uuid'])][prop[@name='implementation-point' and @value='external']]/prop[@name='nature-of-agreement' and @ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
                 <formal-name>Nature of Agreement for External Systems</formal-name>
                 <description>Identifies nature of agreement for external systems.</description>
-                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems"/>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
                 <enum value="contract">A contract between the CSP and the organization that owns the external system.</enum>
                 <enum value="eula">An end-user license agreement between the CSP and the organization that owns the external system.</enum>
                 <enum value="isa">An interconnection security agreement between the CSP and the organization that owns the external system.</enum>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -127,6 +127,19 @@
                 <enum value="other">Other</enum>
             </allowed-values>
 
+            <allowed-values id="external-system-nature-of-agreement" target="system-implementation/component[@type='system'][not(prop[@name='leveraged-authorization-uuid'])][prop[@name='implementation-point' and @value='external']]/prop[@name='nature-of-agreement' and @ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
+                <formal-name>Nature of Agreement for External Systems</formal-name>
+                <description>Identifies nature of agreement for external systems.</description>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems"/>
+                <enum value="contract">A contract between the CSP and the organization that owns the external system.</enum>
+                <enum value="eula">An end-user license agreement between the CSP and the organization that owns the external system.</enum>
+                <enum value="isa">An interconnection security agreement between the CSP and the organization that owns the external system.</enum>
+                <enum value="license">An application license agreement between the CSP and the organization that owns the external system.</enum>
+                <enum value="mou">A memorandum of understanding between the CSP and the organization that owns the external system.</enum>
+                <enum value="other">An non-typical agreement between the CSP and the organization that owns the external system. Explain in remarks.</enum>
+                <enum value="sla">A service-level agreement between the CSP and the organization that owns the external system.</enum>
+            </allowed-values>
+
             <allowed-values id="fedramp-version" target="metadata/prop[@name='fedramp-version'][@ns='https://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
                 <formal-name>FedRAMP Version</formal-name>
                 <description>Identifies the FedRAMP version of the document.</description>

--- a/src/validations/constraints/unit-tests/external-system-nature-of-agreement-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/external-system-nature-of-agreement-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid external-system-nature-of-agreement constraint unit test.
+test-case:
+  name: The invalid external-system-nature-of-agreement constraint unit test.
+  description: Test that the FedRAMP SSP contains an invalid nature-of-agreement value for an external system.
+  content: ../content/ssp-external-system-nature-of-agreement-INVALID.xml
+  expectations:
+  - constraint-id: external-system-nature-of-agreement
+    result: fail

--- a/src/validations/constraints/unit-tests/external-system-nature-of-agreement-PASS.yaml
+++ b/src/validations/constraints/unit-tests/external-system-nature-of-agreement-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid external-system-nature-of-agreement constraint unit test.
+test-case:
+  name: The valid external-system-nature-of-agreement constraint unit test.
+  description: Test that the FedRAMP SSP contains valid nature-of-agreement value for an external system.
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+  - constraint-id: external-system-nature-of-agreement
+    result: pass


### PR DESCRIPTION
# Committer Notes

Add the `external-system-nature-of-agreement` constraint, which tests the `nature-of-agreement` values for external systems.

Related issue #907 

Related PR [#125](https://github.com/GSA/automate.fedramp.gov/pull/125)

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
