### PR TITLE
Add constraint 'authentication-method-has-remarks'

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -28,6 +28,7 @@ Examples:
 #BEGIN_DYNAMIC_CONSTRAINT_IDS
   | address-type |
   | attachment-type |
+  | authentication-method-has-remarks |
   | authorization-type |
   | categorization-has-correct-system-attribute |
   | categorization-has-information-type-id |
@@ -128,7 +129,6 @@ Examples:
   | security-level |
   | security-sensitivity-level-matches-security-impact-level |
   | unique-inventory-item-asset-id |
-  | unique-inventory-item-asset-id |
   | user-authentication |
   | user-has-authorized-privilege |
   | user-has-privilege-level |
@@ -159,6 +159,8 @@ Examples:
   | address-type-PASS.yaml |
   | attachment-type-FAIL.yaml |
   | attachment-type-PASS.yaml |
+  | authentication-method-has-remarks-FAIL.yaml |
+  | authentication-method-has-remarks-PASS.yaml |
   | authorization-type-FAIL.yaml |
   | authorization-type-PASS.yaml |
   | categorization-has-correct-system-attribute-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-authentication-method-has-remarks-INVALID.xml
+++ b/src/validations/constraints/content/ssp-authentication-method-has-remarks-INVALID.xml
@@ -1,0 +1,11 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="12345678-1234-4321-8765-123456789012">
+  <system-implementation>
+    <component uuid="66666666-0000-4000-9000-000000000006" type="interconnection">
+      <prop ns="https://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
+        <!-- <remarks>
+          <p>Some description of the authentication method.</p>
+        </remarks> Missing remarks field. Authentication method count = 1 and remarks count = 0.-->
+      </prop>
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -563,6 +563,11 @@
     <context>
         <metapath target="/system-security-plan/system-implementation"/>
         <constraints>
+            <expect id="authentication-method-has-remarks" target="//component[(@type='system' and ./prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]"  test="count(./prop[@name='authentication-method' and @ns='https://fedramp.gov/ns/oscal'])  = count(./prop[@name='authentication-method' and @ns='https://fedramp.gov/ns/oscal']/remarks)" level="ERROR">
+                <formal-name>Authentication Method Has Remarks</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
+                <message>Each authentication method in a FedRAMP SSP MUST have a remarks field.</message>
+            </expect>
             <is-unique id="unique-inventory-item-asset-id" target="inventory-item/prop[@name='asset-id']">
                 <formal-name>Unique Asset Identifier</formal-name>
                 <description>Ensure each inventory item has a unique asset-id property.</description>

--- a/src/validations/constraints/unit-tests/authentication-method-has-remarks-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/authentication-method-has-remarks-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for authentication-method-has-remarks
+  description: >-
+    This test case validates the behavior of constraint
+    authentication-method-has-remarks
+  content: ../content/ssp-authentication-method-has-remarks-INVALID.xml
+  expectations:
+    - constraint-id: authentication-method-has-remarks
+      result: fail

--- a/src/validations/constraints/unit-tests/authentication-method-has-remarks-PASS.yaml
+++ b/src/validations/constraints/unit-tests/authentication-method-has-remarks-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for authentication-method-has-remarks
+  description: >-
+    This test case validates the behavior of constraint
+    authentication-method-has-remarks
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: authentication-method-has-remarks
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR introduces a constraint `authentication-method-has-remarks`, which ensures that every `authentication-method` property in components dealing with leveraged systems, interconnections, and authorized services includes a `remarks` field.

## Changes

Added Constraint:
- `authentication-method-has-remarks`: Validates that every `authentication-method` property includes a `remarks` field.

Test Data:
- **Invalid Test Data File**: Demonstrates the case where a component's `authentication-method` count differs from the `remarks` field count.

Added YAML Files
- **2 YAML Files**: Included pass and fail YAML files to validate the constraint:

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
