### PR TITLE
Fix `ssp-all-VALID.xml`

### DIFF
--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -309,7 +309,11 @@
       </description>
       <prop name="leveraged-authorization-uuid" value="233e0f09-fe5e-47e2-bca3-5f32df75e57a"/>
       <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="sla"/>
-      <prop ns="https://fedramp.gov/ns/oscal" name="authentication-method" value="yes"/>
+      <prop ns="https://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
+        <remarks>
+          <p>Some description of the authentication method.</p>
+        </remarks>
+      </prop>
      <status state="operational"/>
      </component>
 
@@ -342,6 +346,11 @@
       <prop name="asset-type" value="cli"/>
       <prop name="direction" value="in/out" ns="https://fedramp.gov/ns/oscal"/>
       <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="isa"/>
+      <prop ns="https://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
+        <remarks>
+          <p>Some description of the authentication method.</p>
+        </remarks>
+      </prop>
       <status state="operational"/>
     </component>
     


### PR DESCRIPTION
# Committer Notes
## Purpose
The goal of this PR is to add missing content to `ssp-all-VALID.xml` that is causing tests to fail. PRs #927 and #929 were merged one right after the other. PR #929 added data that breaks the constraint added in #927. That is fixed in this PR. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~
~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
