### PR TITLE
Add `issue-893` Constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -36,6 +36,7 @@ Examples:
   | cia-impact-has-selected |
   | cloud-service-model |
   | component-has-authentication-method |
+  | component-has-non-provider-responsible-role |
   | component-has-provider-responsible-role |
   | component-type |
   | control-implementation-status |
@@ -180,6 +181,8 @@ Examples:
   | cloud-service-model-PASS.yaml |
   | component-has-authentication-method-FAIL.yaml |
   | component-has-authentication-method-PASS.yaml |
+  | component-has-non-provider-responsible-role-FAIL.yaml |
+  | component-has-non-provider-responsible-role-PASS.yaml |
   | component-responsible-role-references-party-FAIL.yaml |
   | component-responsible-role-references-party-PASS.yaml |
   | component-type-FAIL.yaml |

--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -115,6 +115,7 @@ Examples:
   | marking |
   | missing-response-components |
   | network-component-has-implementation-point |
+  | non-provider-responsible-role-references-user |
   | party-has-name |
   | privilege-level |
   | prop-response-point-has-cardinality-one |
@@ -339,6 +340,8 @@ Examples:
   | missing-response-components-PASS.yaml |
   | network-component-has-implementation-point-FAIL.yaml |
   | network-component-has-implementation-point-PASS.yaml |
+  | non-provider-responsible-role-references-user-FAIL.yaml |
+  | non-provider-responsible-role-references-user-PASS.yaml |
   | party-has-name-FAIL.yaml |
   | party-has-name-PASS.yaml |
   | privilege-level-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -341,6 +341,9 @@
       <responsible-role role-id="provider">
         <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
       </responsible-role>
+     <responsible-role role-id="system-admin">
+        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-role>
     </component>
 
     <component uuid="66666666-0000-4000-9000-000000000006" type="interconnection">
@@ -384,6 +387,9 @@
       </prop>
       <status state="operational"/>
       <responsible-role role-id="provider">
+        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-role>
+      <responsible-role role-id="system-admin">
         <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
       </responsible-role>
     </component>

--- a/src/validations/constraints/content/ssp-all-VALID.xml
+++ b/src/validations/constraints/content/ssp-all-VALID.xml
@@ -337,12 +337,15 @@
           <p>Some description of the external authentication method.</p>
         </remarks>
       </prop>
-     <status state="operational"/>
+      <status state="operational"/>
       <responsible-role role-id="provider">
         <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
       </responsible-role>
-     <responsible-role role-id="system-admin">
+      <responsible-role role-id="system-admin">
         <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-role>
+      <responsible-role role-id="administrator">
+        <prop name="privilege-uuid" value="44444444-0000-4000-9000-000000000004" ns="https://fedramp.gov/ns/oscal" />
       </responsible-role>
     </component>
 

--- a/src/validations/constraints/content/ssp-component-has-non-provider-responsible-role-INVALID.xml
+++ b/src/validations/constraints/content/ssp-component-has-non-provider-responsible-role-INVALID.xml
@@ -1,0 +1,12 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="12345678-1234-4321-8765-123456789012">
+  <system-implementation>
+    <component uuid="66666666-0000-4000-9000-000000000006" type="interconnection">
+      <responsible-role role-id="provider">
+        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-role>
+      <!-- <responsible-role role-id="system-admin">
+        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+      </responsible-role> Missing at least 1 responsible role that isn't "provider". -->
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-non-provider-responsible-role-references-user-INVALID.xml
+++ b/src/validations/constraints/content/ssp-non-provider-responsible-role-references-user-INVALID.xml
@@ -1,0 +1,14 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <system-implementation>
+    <user uuid="44444444-0000-4000-9000-000000000004">
+      <authorized-privilege>
+        <!-- <function-performed>administration</function-performed> Missing at least one function performed-->
+      </authorized-privilege>
+    </user>
+    <component uuid="6ac88fd2-7c7b-4357-af2e-f22ccd3ead26" type="system">
+      <responsible-role role-id="administrator">
+        <prop name="privilege-uuid" value="44444444-0000-4000-9000-000000000004" ns="https://fedramp.gov/ns/oscal"/>
+      </responsible-role>
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -78,7 +78,7 @@
             <expect id="component-has-non-provider-responsible-role" target="//component[(@type='system' and prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(prop[@name='leveraged-authorization-uuid']) and prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and prop[@name='implementation-point' and @value='internal'] and prop[@name='direction']) or (@type='software' and prop[@name='asset-type' and @value='cli'] and prop[@name='direction'])]" test="count(responsible-role[not(@role-id='provider')]) >= 1" level="ERROR">
                 <formal-name>Component Has Non-Provider Responsible Role</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
-                <message>Each component dealing with leveraged systems, interconnections, or authorized services MUST have at least one responsible role other than "provider".</message>
+                <message>A FedRAMP SSP MUST have each component describing leveraged systems, interconnections, or authorized services identify at least one responsible role other than "provider".</message>
             </expect>
             <expect id="component-has-provider-responsible-role" target="//component[(@type='system' and ./prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]" test="count(responsible-role[@role-id='provider']/party-uuid) = 1" level="ERROR">
                 <formal-name>Component Has Provider Responsible Role</formal-name>
@@ -121,7 +121,7 @@
             <expect id="non-provider-responsible-role-references-user" target="." test="$non-provider-user-has-function-performed" level="ERROR">
                 <formal-name>Non-Provider Responsible Role References User</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
-                <message>Each non-provider responsible role MUST reference at least one user with an authorized privilege and function performed via the "privilege-uuid" property.</message>
+                <message>A FedRAMP SSP MUST have each component describing leveraged systems, interconnections, or authorized services reference at least one user with an authorized privilege and function performed via the "privilege-uuid" property.</message>
             </expect>         
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -516,6 +516,11 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>Each authentication method in a FedRAMP SSP MUST have a remarks field.</message>
             </expect>
+            <expect id="component-has-non-provider-responsible-role" target="//component[(@type='system' and ./prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]" test="count(responsible-role[not(@role-id='provider')]) >= 1" level="ERROR">
+                <formal-name>Component Has Non-Provider Responsible Role</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
+                <message>Each component dealing with leveraged systems, interconnections, or authorized services MUST have at least one responsible role other than "provider".</message>
+            </expect>
 	    <expect id="has-inventory-items" target="." test="count(inventory-item) >= 2" level="ERROR">
 	    	<formal-name>System Implementation Has Inventory Items</formal-name>
 		<prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -67,10 +67,18 @@
                 else if (system-characteristics/security-sensitivity-level = 'fips-199-moderate')
                     then ('fips-199-moderate', 'fips-199-high')
                 else ('fips-199-low', 'fips-199-moderate', 'fips-199-high')"/>
+            <let var="non-authorized-components" expression="system-implementation/component[(@type='system' and prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(prop[@name='leveraged-authorization-uuid']) and prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and prop[@name='implementation-point' and @value='internal'] and prop[@name='direction']) or (@type='software' and prop[@name='asset-type' and @value='cli'] and prop[@name='direction'])]"/>
+            <let var="system-implementation-users" expression="system-implementation/user"/>
+            <let var="non-provider-user-has-function-performed" expression="count($system-implementation-users[@uuid = $non-authorized-components/responsible-role/prop[@name='privilege-uuid' and @ns='https://fedramp.gov/ns/oscal']/@value]/authorized-privilege/function-performed) >= 1"/>
             <expect id="component-has-authentication-method" target="//component[(@type='system' and ./prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]" test="count(prop[@ns='https://fedramp.gov/ns/oscal' and @name='authentication-method']) >= 1" level="ERROR">
                 <formal-name>Component Has Authentication Method</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>A FedRAMP SSP MUST include at least one authentication method for each leveraged system.</message>
+            </expect>
+            <expect id="component-has-non-provider-responsible-role" target="//component[(@type='system' and prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(prop[@name='leveraged-authorization-uuid']) and prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and prop[@name='implementation-point' and @value='internal'] and prop[@name='direction']) or (@type='software' and prop[@name='asset-type' and @value='cli'] and prop[@name='direction'])]" test="count(responsible-role[not(@role-id='provider')]) >= 1" level="ERROR">
+                <formal-name>Component Has Non-Provider Responsible Role</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
+                <message>Each component dealing with leveraged systems, interconnections, or authorized services MUST have at least one responsible role other than "provider".</message>
             </expect>
             <expect id="component-has-provider-responsible-role" target="//component[(@type='system' and ./prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]" test="count(responsible-role[@role-id='provider']/party-uuid) = 1" level="ERROR">
                 <formal-name>Component Has Provider Responsible Role</formal-name>
@@ -109,7 +117,12 @@
                 <formal-name>Leveraged Authorization Has Valid Impact Level</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>A FedRAMP SSP MUST define the appropriate FIPS-199 impact level (low, moderate, or high) for each leveraged authorization.</message>
-            </expect>             
+            </expect>    
+            <expect id="non-provider-responsible-role-references-user" target="." test="$non-provider-user-has-function-performed" level="ERROR">
+                <formal-name>Non-Provider Responsible Role References User</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
+                <message>Each non-provider responsible role MUST reference at least one user with an authorized privilege and function performed via the "privilege-uuid" property.</message>
+            </expect>         
         </constraints>
     </context>
 
@@ -510,22 +523,17 @@
 
     <context>
 	<metapath target="/system-security-plan/system-implementation"/>
-	<constraints>
+	    <constraints>
             <expect id="authentication-method-has-remarks" target="//component[(@type='system' and ./prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]"  test="count(./prop[@name='authentication-method' and @ns='https://fedramp.gov/ns/oscal'])  = count(./prop[@name='authentication-method' and @ns='https://fedramp.gov/ns/oscal']/remarks)" level="ERROR">
                 <formal-name>Authentication Method Has Remarks</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>Each authentication method in a FedRAMP SSP MUST have a remarks field.</message>
             </expect>
-            <expect id="component-has-non-provider-responsible-role" target="//component[(@type='system' and ./prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]" test="count(responsible-role[not(@role-id='provider')]) >= 1" level="ERROR">
-                <formal-name>Component Has Non-Provider Responsible Role</formal-name>
-                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
-                <message>Each component dealing with leveraged systems, interconnections, or authorized services MUST have at least one responsible role other than "provider".</message>
-            </expect>
-	    <expect id="has-inventory-items" target="." test="count(inventory-item) >= 2" level="ERROR">
-	    	<formal-name>System Implementation Has Inventory Items</formal-name>
-		<prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
-		<message>A FedRAMP SSP system implementation section MUST have at least two inventory items.</message>
-	    </expect>
+	        <expect id="has-inventory-items" target="." test="count(inventory-item) >= 2" level="ERROR">
+	    	    <formal-name>System Implementation Has Inventory Items</formal-name>
+		        <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+		        <message>A FedRAMP SSP system implementation section MUST have at least two inventory items.</message>
+	        </expect>
             <expect id="leveraged-authorization-has-authorization-type" target="leveraged-authorization" test="count(prop[@name='authorization-type'][@ns='https://fedramp.gov/ns/oscal']) = 1" level="ERROR">
                 <formal-name>Leveraged Authorization Has Authorization Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
@@ -550,7 +558,7 @@
                     <p>A FedRAMP SSP's inventory item MUST have an Asset ID that is unique across all inventory items in the system and its components.</p>
                 </remarks>
             </is-unique>
-	</constraints>
+	    </constraints>
     </context>   
 
     <context>

--- a/src/validations/constraints/unit-tests/component-has-non-provider-responsible-role-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/component-has-non-provider-responsible-role-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for component-has-non-provider-responsible-role
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-non-provider-responsible-role
+  content: ../content/ssp-component-has-non-provider-responsible-role-INVALID.xml
+  expectations:
+    - constraint-id: component-has-non-provider-responsible-role
+      result: fail

--- a/src/validations/constraints/unit-tests/component-has-non-provider-responsible-role-PASS.yaml
+++ b/src/validations/constraints/unit-tests/component-has-non-provider-responsible-role-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for component-has-non-provider-responsible-role
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-non-provider-responsible-role
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: component-has-non-provider-responsible-role
+      result: pass

--- a/src/validations/constraints/unit-tests/non-provider-responsible-role-references-user-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/non-provider-responsible-role-references-user-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for non-provider-responsible-role-references-user
+  description: >-
+    This test case validates the behavior of constraint
+    non-provider-responsible-role-references-user
+  content: ../content/ssp-non-provider-responsible-role-references-user-INVALID.xml
+  expectations:
+    - constraint-id: non-provider-responsible-role-references-user
+      result: fail

--- a/src/validations/constraints/unit-tests/non-provider-responsible-role-references-user-PASS.yaml
+++ b/src/validations/constraints/unit-tests/non-provider-responsible-role-references-user-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for non-provider-responsible-role-references-user
+  description: >-
+    This test case validates the behavior of constraint
+    non-provider-responsible-role-references-user
+  content: ../content/ssp-all-VALID.xml
+  expectations:
+    - constraint-id: non-provider-responsible-role-references-user
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR introduces two constraints `component-has-non-provider-responsible-role` and `non-provider-responsible-role-references-user`, which ensures that each component dealing with leveraged systems, interconnections, or authorized services has at least one non-provider role and each non-provider responsible role references at least one user/authorized-privilege/function-performed via the "privilege-uuid" property/extension respectively. 
## Changes

Added Constraints:
- `component-has-non-provider-responsible-role`: Ensures that each component dealing with leveraged systems, interconnections, or authorized services has at least one non-provider role.

- `non-provider-responsible-role-references-user`: each non-provider responsible role references at least one user/authorized-privilege/function-performed via the "privilege-uuid" property/extension.

Test Data:
- **Invalid Test Data File**: Demonstrates the case where the fail case.
- **Valid Test Data File**: Demonstrates the case where the pass case. 

Added YAML Files
- **4 YAML Files**: Included pass and fail YAML files to validate the above constraints.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
