### PR TITLE
Add inter-boundary-communication-has-direction constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -101,6 +101,7 @@ Examples:
   | information-type-has-confidentiality-impact |
   | information-type-has-integrity-impact |
   | information-type-system |
+  | inter-boundary-communication-has-direction |
   | interconnection-direction |
   | interconnection-security |
   | inventory-item-allows-authenticated-scan |
@@ -312,6 +313,8 @@ Examples:
   | information-type-id-PASS.yaml |
   | information-type-system-FAIL.yaml |
   | information-type-system-PASS.yaml |
+  | inter-boundary-communication-has-direction-FAIL.yaml |
+  | inter-boundary-communication-has-direction-PASS.yaml |
   | interconnection-direction-FAIL.yaml |
   | interconnection-direction-PASS.yaml |
   | interconnection-security-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1185,6 +1185,8 @@
          <prop name="implementation-point" value="external"/>
          <prop name="connection-security" value="tls-1.3" ns="https://fedramp.gov/ns/oscal"/>
          <prop name="asset-type" value="saas"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="direction" value="incoming"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="direction" value="outgoing"/>
          <prop ns="https://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
             <remarks>
                <p>If 'yes', describe the authentication method.</p>
@@ -1762,6 +1764,8 @@
             <p>None</p>
          </description>
          <prop name="connection-security" value="tls-1.3" ns="https://fedramp.gov/ns/oscal"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="direction" value="incoming"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="direction" value="outgoing"/>
          <prop name="implementation-point" value="external"/>
          <prop ns="https://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
             <remarks>
@@ -2175,6 +2179,8 @@
             <p>Email Service</p>
          </description>
          <prop name="connection-security" value="tls-1.3" ns="https://fedramp.gov/ns/oscal"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="direction" value="incoming"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="direction" value="outgoing"/>
          <prop name="implementation-point" value="external"/>
          <prop ns="https://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
             <remarks>

--- a/src/validations/constraints/content/ssp-inter-boundary-communication-has-direction-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inter-boundary-communication-has-direction-INVALID.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
+                      uuid="12345678-1234-4321-8765-123456789012">
+  <system-implementation>
+    <component uuid="77777777-0000-4000-9000-000000000008" type="service">
+      <title>Communication Service System</title>
+      <description>
+        <p>A network communication service system.</p>
+      </description>
+      <prop name="inherited-uuid" value="11111111-0000-4000-9001-000000000001"/>
+      <prop name="implementation-point" value="internal"/>
+      <prop name="direction" value="incoming" ns="https://fedramp.gov/ns/oscal"/>
+      <prop name="direction" value="outgoing" ns="https://fedramp.gov/ns/oscal"/>
+      <prop name="direction" value="outgoing" ns="https://fedramp.gov/ns/oscal"/>
+      <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="isa"/>
+      <status state="operational"/>
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -519,11 +519,16 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>Each authentication method in a FedRAMP SSP MUST have a remarks field.</message>
             </expect>
-	    <expect id="has-inventory-items" target="." test="count(inventory-item) >= 2" level="ERROR">
+	        <expect id="has-inventory-items" target="." test="count(inventory-item) >= 2" level="ERROR">
                 <formal-name>System Implementation Has Inventory Items</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>A FedRAMP SSP system implementation section MUST have at least two inventory items.</message>
-	    </expect>
+	        </expect>
+            <expect id="inter-boundary-communication-has-direction" target="component[(@type='service' and not(prop[@name='leveraged-authorization-uuid']) and prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and prop[@name='implementation-point' and @value='internal'] and prop[@name='direction']) or (@type='software' and prop[@name='asset-type' and @value='cli'] and prop[@name='direction'])]" test="count(prop[@name='direction']) >= 1 and count(prop[@name='direction' and @value='incoming']) &lt;= 1 and count(prop[@name='direction' and @value='outgoing']) &lt;= 1" level="ERROR">
+                <formal-name>Inter-Boundary Communication Has Direction</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
+                <message>In an inter-boundary communication component, a FedRAMP SSP MUST have at least one direction property, with no more than one incoming and no more than one outgoing direction.</message>
+            </expect>
             <expect id="leveraged-authorization-has-authorization-type" target="leveraged-authorization" test="count(prop[@name='authorization-type'][@ns='https://fedramp.gov/ns/oscal']) = 1" level="ERROR">
                 <formal-name>Leveraged Authorization Has Authorization Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
@@ -538,7 +543,7 @@
                 <formal-name>Leveraged Authorization Has System Identifier</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>A FedRAMP SSP MUST define exactly one system identifier for each leveraged authorization entry.</message>
-	    </expect>
+	        </expect>
             <expect id="network-component-has-connection-security-prop" target="//component[(@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]" test="count(./prop[@name='connection-security' and @ns='https://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
                 <formal-name>Network Component Has Connection Security Property</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#ports-protocols-and-services"/>

--- a/src/validations/constraints/unit-tests/inter-boundary-communication-has-direction-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inter-boundary-communication-has-direction-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid inter-boundary-communication-has-direction constraint unit test.
+test-case:
+  name: The invalid inter-boundary-communication-has-direction constraint unit test.
+  description: Test that the FedRAMP SSP inter-boundary communication component has more than one incoming or outgoing direction.
+  content: ../content/ssp-inter-boundary-communication-has-direction-INVALID.xml
+  expectations:
+  - constraint-id: inter-boundary-communication-has-direction
+    result: fail

--- a/src/validations/constraints/unit-tests/inter-boundary-communication-has-direction-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inter-boundary-communication-has-direction-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid inter-boundary-communication-has-direction constraint unit test.
+test-case:
+  name: The valid inter-boundary-communication-has-direction constraint unit test.
+  description: Test that the FedRAMP SSP inter-boundary communication component has at least one direction property, with no more than one incoming and no more than one outgoing direction.
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+  - constraint-id: inter-boundary-communication-has-direction
+    result: pass


### PR DESCRIPTION
# Committer Notes

Add the `inter-boundary-communication-has-direction` constraint, which tests the following scenario:
Every inter-boundary communication component has at least one network traffic `direction` property, with no more than one `incoming` and no more than one `outgoing` traffic direction property.

Related issue: [#930](https://github.com/GSA/fedramp-automation/issues/930).

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
