### PR TITLE
Fix Constraint Tests

### DIFF
--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -119,33 +119,33 @@
     <context>
         <metapath target="/system-security-plan/back-matter"/>
         <constraints>
-            <expect id="has-configuration-management-plan" target="." test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'configuration-management-plan']]" level="ERROR">
+            <expect id="has-configuration-management-plan" target="." test="exists(resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'configuration-management-plan']])" level="ERROR">
                 <formal-name>Has Configuration Management Plan</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>A FedRAMP SSP MUST have a Configuration Management Plan attached.</message>
             </expect>
-            <expect id="has-incident-response-plan" target="." test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'incident-response-plan']]" level="ERROR">
+            <expect id="has-incident-response-plan" target="." test="exists(resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'incident-response-plan']])" level="ERROR">
                 <formal-name>Has Incident Response Plan</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>A FedRAMP SSP MUST have an Incident Response Plan attached.</message>
             </expect>
-            <expect id="has-information-system-contingency-plan" target="." test="resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'information-system-contingency-plan']]" level="ERROR">
+            <expect id="has-information-system-contingency-plan" target="." test="exists(resource[prop[@name eq 'type' and @value eq 'plan' and @class eq 'information-system-contingency-plan']])" level="ERROR">
                 <formal-name>Has Information System Contingency Plan</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>A FedRAMP SSP MUST have a Contingency Plan attached.</message>
             </expect>
-            <expect id="has-rules-of-behavior" target="." test="resource[prop[@name eq 'type' and @value eq 'rules-of-behavior']]" level="ERROR">
+            <expect id="has-rules-of-behavior" target="." test="exists(resource[prop[@name eq 'type' and @value eq 'rules-of-behavior']])" level="ERROR">
                 <formal-name>Has Rules Of Behavior</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>A FedRAMP SSP MUST have Rules of Behavior.</message>
             </expect>
-            <expect id="has-separation-of-duties-matrix" target="." test="resource[prop[@name eq 'type' and @value eq 'separation-of-duties-matrix']]" level="ERROR">
+            <expect id="has-separation-of-duties-matrix" target="." test="exists(resource[prop[@name eq 'type' and @value eq 'separation-of-duties-matrix']])" level="ERROR">
                 <formal-name>Has Separation Of Duties Matrix</formal-name>
                 <!-- TODO: Add supporting documentation to automate.fedramp.gov -->
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/"/>
                 <message>A FedRAMP SSP MUST have a Separation of Duties Matrix attached.</message>
             </expect>
-            <expect id="has-user-guide" target="." test="resource[prop[@name eq 'type' and @value eq 'users-guide']]" level="ERROR">
+            <expect id="has-user-guide" target="." test="exists(resource[prop[@name eq 'type' and @value eq 'users-guide']])" level="ERROR">
                 <formal-name>Has User Guide</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>A FedRAMP SSP MUST have a User Guide attached.</message>
@@ -155,7 +155,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/oscal-citations-and-attachments/#including-multiple-rlink-and-base64-fields"/>
                 <message>Every supporting artifact found in a citation MUST have at least one base64 or rlink element.</message>
             </expect>
-            <expect id="resource-has-title" target="resource" test="title" level="WARNING">
+            <expect id="resource-has-title" target="resource" test="exists(title)" level="WARNING">
                 <formal-name>Resource Has Title</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/oscal-citations-and-attachments/#citation-and-attachment-details"/>
                 <message>Every supporting artifact found in a citation SHOULD have a title.</message>
@@ -241,13 +241,13 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/#prepared-for-csp"/>
                 <message>A FedRAMP SSP MUST define the address of the responsible party for whom the document was prepared.</message>
             </expect>
-            <expect id="role-defined-authorizing-official-poc" target="." test="role[@id eq 'authorizing-official-poc']" level="ERROR">
+            <expect id="role-defined-authorizing-official-poc" target="." test="exists(role[@id eq 'authorizing-official-poc'])" level="ERROR">
                 <formal-name>Role Defined Authorizing Official POC</formal-name>
                 <!-- TODO: Add supporting documentation to automate.fedramp.gov -->
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/"/>
                 <message>A FedRAMP SSP MUST define a role for the point of contact for an authorizing official.</message>
             </expect>
-            <expect id="role-defined-information-system-security-officer" target="." test="role[@id eq 'information-system-security-officer']" level="ERROR">
+            <expect id="role-defined-information-system-security-officer" target="." test="exists(role[@id eq 'information-system-security-officer'])" level="ERROR">
                 <formal-name>Role Defined Information System Security Officer</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#assignment-of-security-responsibilities"/>
                 <message>A FedRAMP SSP MUST define a role for the point of contact for an information system security officer.</message>
@@ -262,7 +262,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/#prepared-for-csp"/>
                 <message>A FedRAMP SSP MUST define a role for which the document was prepared.</message>
             </expect>
-            <expect id="role-defined-system-owner" target="." test="role[@id eq 'system-owner']" level="ERROR">
+            <expect id="role-defined-system-owner" target="." test="exists(role[@id eq 'system-owner'])" level="ERROR">
                 <formal-name>Role Defined System Owner</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#information-system-owner"/>
                 <message>A FedRAMP SSP MUST define the system owner role.</message>
@@ -285,7 +285,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-information-and-information-types"/>
                 <message>A FedRAMP SSP information-type categorization MUST have a correct system attribute. FedRAMP only supports the system value 'https://doi.org/10.6028/NIST.SP.800-60v2r1'.</message>
             </expect>
-            <expect id="categorization-has-information-type-id" target="system-information/information-type/categorization" test="information-type-id" level="ERROR">
+            <expect id="categorization-has-information-type-id" target="system-information/information-type/categorization" test="exists(information-type-id)" level="ERROR">
                 <formal-name>Categorization Has Information Type ID</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-information-and-information-types"/>
                 <message>A FedRAMP SSP information type categorization MUST have at least one information type identifier.</message>
@@ -315,27 +315,27 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#digital-identity-level-dil-determination"/>
                 <message>A FedRAMP SSP MUST define its NIST SP 800-63 authenticator assurance level (AAL).</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram" target="authorization-boundary" test="diagram" level="WARNING">
+            <expect id="has-authorization-boundary-diagram" target="authorization-boundary" test="exists(diagram)" level="WARNING">
                 <formal-name>Has Authorization Boundary Diagram</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>A FedRAMP SSP MUST have at least one authorization boundary diagram.</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram-caption" target="authorization-boundary/diagram" test="caption" level="ERROR">
+            <expect id="has-authorization-boundary-diagram-caption" target="authorization-boundary/diagram" test="exists(caption)" level="ERROR">
                 <formal-name>Has Authorization Boundary Diagram Caption</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>Each FedRAMP SSP authorization boundary diagram MUST have a caption.</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram-description" target="authorization-boundary/diagram" test="description" level="ERROR">
+            <expect id="has-authorization-boundary-diagram-description" target="authorization-boundary/diagram" test="exists(description)" level="ERROR">
                 <formal-name>Has Authorization Boundary Diagram Description</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>A FedRAMP SSP document authorization boundary diagram MUST have a description.</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram-link" target="authorization-boundary/diagram" test="link" level="ERROR">
+            <expect id="has-authorization-boundary-diagram-link" target="authorization-boundary/diagram" test="exists(link)" level="ERROR">
                 <formal-name>Has Authorization Boundary Diagram Link</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>Each FedRAMP SSP authorization boundary diagram MUST have a link.</message>
             </expect>
-            <expect id="has-authorization-boundary-diagram-link-rel" target="authorization-boundary/diagram/link" test="@rel" level="ERROR">
+            <expect id="has-authorization-boundary-diagram-link-rel" target="authorization-boundary/diagram/link" test="exists(@rel)" level="ERROR">
                 <formal-name>Has Authorization Boundary Diagram Link Rel</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>Each FedRAMP SSP authorization boundary diagram MUST have a link rel attribute.</message>
@@ -345,7 +345,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#authorization-boundary"/>
                 <message>Each FedRAMP SSP authorization boundary diagram MUST have a link rel attribute with the value "diagram".</message>
             </expect>
-            <expect id="has-cloud-deployment-model" target="." test="prop[@name eq 'cloud-deployment-model']" level="ERROR">
+            <expect id="has-cloud-deployment-model" target="." test="exists(prop[@name eq 'cloud-deployment-model'])" level="ERROR">
                 <formal-name>Has Cloud Deployment Model</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#deployment-model"/>
                 <message>A FedRAMP SSP MUST define a cloud deployment model.</message>
@@ -358,7 +358,7 @@
                     <p>A FedRAMP SSP MUST use precise classifications for cloud deployment models. It MUST NOT use generic classifications like "hybrid-cloud".</p>
                 </remarks>
             </expect>
-            <expect id="has-cloud-service-model" target="." test="prop[@name eq 'cloud-service-model']" level="ERROR">
+            <expect id="has-cloud-service-model" target="." test="exists(prop[@name eq 'cloud-service-model'])" level="ERROR">
                 <formal-name>Has Cloud Service Model</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#service-model"/>
                 <message>A FedRAMP SSP MUST define a cloud service model.</message>
@@ -368,37 +368,37 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#service-model"/>
                 <message>A FedRAMP SSP with a cloud service model of "other" MUST supply remarks to explain this choice.</message>
             </expect>
-            <expect id="has-data-flow" target="." test="data-flow" level="WARNING">
+            <expect id="has-data-flow" target="." test="exists(data-flow)" level="WARNING">
                 <formal-name>Has Data Flow</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>A FedRAMP SSP MUST include a data flow section.</message>
             </expect>
-            <expect id="has-data-flow-description" target="data-flow" test="description" level="ERROR">
+            <expect id="has-data-flow-description" target="data-flow" test="exists(description)" level="ERROR">
                 <formal-name>Has Data Flow Description</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>An OSCAL SSP document with a data flow MUST have a description.</message>
             </expect>
-            <expect id="has-data-flow-diagram" target="data-flow" test="diagram" level="WARNING">
+            <expect id="has-data-flow-diagram" target="data-flow" test="exists(diagram)" level="WARNING">
                 <formal-name>Has Data Flow Diagram</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>A FedRAMP SSP MUST have at least one data flow diagram.</message>
             </expect>
-            <expect id="has-data-flow-diagram-caption" target="data-flow/diagram" test="caption" level="ERROR">
+            <expect id="has-data-flow-diagram-caption" target="data-flow/diagram" test="exists(caption)" level="ERROR">
                 <formal-name>Has Data Flow Diagram Caption</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>Each FedRAMP SSP data flow diagram MUST have a caption.</message>
             </expect>
-            <expect id="has-data-flow-diagram-description" target="data-flow/diagram" test="description" level="ERROR">
+            <expect id="has-data-flow-diagram-description" target="data-flow/diagram" test="exists(description)" level="ERROR">
                 <formal-name>Has Data Flow Diagram Description</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>Each FedRAMP SSP data flow diagram MUST have a description.</message>
             </expect>
-            <expect id="has-data-flow-diagram-link" target="data-flow/diagram" test="link" level="ERROR">
+            <expect id="has-data-flow-diagram-link" target="data-flow/diagram" test="exists(link)" level="ERROR">
                 <formal-name>Has Data Flow Diagram Link</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>Each FedRAMP SSP data flow diagram MUST have a link.</message>
             </expect>
-            <expect id="has-data-flow-diagram-link-rel" target="data-flow/diagram/link" test="@rel" level="ERROR">
+            <expect id="has-data-flow-diagram-link-rel" target="data-flow/diagram/link" test="exists(@rel)" level="ERROR">
                 <formal-name>Has Data Flow Diagram Link Rel</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>Each FedRAMP SSP data flow diagram MUST have a link rel attribute.</message>
@@ -408,7 +408,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>Each FedRAMP SSP data flow diagram MUST have a link rel attribute with the value "diagram".</message>
             </expect>
-            <expect id="has-data-flow-diagram-uuid" target="data-flow/diagram" test="@uuid" level="ERROR">
+            <expect id="has-data-flow-diagram-uuid" target="data-flow/diagram" test="exists(@uuid)" level="ERROR">
                 <formal-name>Has Data Flow Diagram Uuid</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#data-flow"/>
                 <message>An OSCAL SSP document with a data flow diagram MUST have a unique identifier.</message>
@@ -428,32 +428,32 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#digital-identity-level-dil-determination"/>
                 <message>A FedRAMP SSP MUST define its NIST SP 800-63 identity assurance level (IAL).</message>
             </expect>
-            <expect id="has-network-architecture" target="." test="network-architecture" level="ERROR">
+            <expect id="has-network-architecture" target="." test="exists(network-architecture)" level="ERROR">
                 <formal-name>Has Network Architecture</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>A FedRAMP SSP MUST include a network architecture.</message>
             </expect>
-            <expect id="has-network-architecture-diagram" target="network-architecture" test="diagram" level="WARNING">
+            <expect id="has-network-architecture-diagram" target="network-architecture" test="exists(diagram)" level="WARNING">
                 <formal-name>Has Network Architecture Diagram</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>A FedRAMP SSP MUST have at least one network architecture diagram.</message>
             </expect>
-            <expect id="has-network-architecture-diagram-caption" target="network-architecture/diagram" test="caption" level="ERROR">
+            <expect id="has-network-architecture-diagram-caption" target="network-architecture/diagram" test="exists(caption)" level="ERROR">
                 <formal-name>Has Network Architecture Diagram Caption</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>Each FedRAMP SSP network architecture diagram MUST have a caption.</message>
             </expect>
-            <expect id="has-network-architecture-diagram-description" target="network-architecture/diagram" test="description" level="ERROR">
+            <expect id="has-network-architecture-diagram-description" target="network-architecture/diagram" test="exists(description)" level="ERROR">
                 <formal-name>Has Network Architecture Diagram Description</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>Each FedRAMP SSP network architecture diagram MUST have a description.</message>
             </expect>
-            <expect id="has-network-architecture-diagram-link" target="network-architecture/diagram" test="link" level="ERROR">
+            <expect id="has-network-architecture-diagram-link" target="network-architecture/diagram" test="exists(link)" level="ERROR">
                 <formal-name>Has Network Architecture Diagram Link</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>Each FedRAMP SSP network architecture diagram MUST have a link.</message>
             </expect>
-            <expect id="has-network-architecture-diagram-link-rel" target="network-architecture/diagram/link" test="@rel" level="ERROR">
+            <expect id="has-network-architecture-diagram-link-rel" target="network-architecture/diagram/link" test="exists(@rel)" level="ERROR">
                 <formal-name>Has Network Architecture Diagram Link Rel</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>Each FedRAMP SSP network architecture diagram MUST have a link rel attribute.</message>
@@ -463,37 +463,37 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#network-architecture"/>
                 <message>Each FedRAMP SSP network architecture diagram MUST have a link rel attribute with the value "diagram".</message>
             </expect>
-            <expect id="has-security-impact-level" target="." test="security-impact-level" level="ERROR">
+            <expect id="has-security-impact-level" target="." test="exists(security-impact-level)" level="ERROR">
                 <formal-name>Has Security Impact Level</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-sensitivity-level"/>
                 <message>A FedRAMP SSP document MUST specify a security impact level.</message>
             </expect>
-            <expect id="has-security-sensitivity-level" target="." test="security-sensitivity-level" level="ERROR">
+            <expect id="has-security-sensitivity-level" target="." test="exists(security-sensitivity-level)" level="ERROR">
                 <formal-name>Has Security Sensitivity Level</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-sensitivity-level"/>
                 <message>A FedRAMP SSP document MUST specify a FIPS 199 categorization.</message>
             </expect>
-            <expect id="has-system-id" target="." test="system-id[@identifier-type eq 'https://fedramp.gov']" level="ERROR">
+            <expect id="has-system-id" target="." test="exists(system-id[@identifier-type eq 'https://fedramp.gov'])" level="ERROR">
                 <formal-name>Has System Id</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-name-abbreviation-and-fedramp-unique-identifier"/>
                 <message>A FedRAMP SSP MUST have a FedRAMP system identifier.</message>
             </expect>
-            <expect id="has-system-name-short" target="." test="system-name-short" level="ERROR">
+            <expect id="has-system-name-short" target="." test="exists(system-name-short)" level="ERROR">
                 <formal-name>Has System Name Short</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-name-abbreviation-and-fedramp-unique-identifier"/>
                 <message>A FedRAMP SSP MUST have a short system name.</message>
             </expect>
-            <expect id="information-type-has-availability-impact" target="system-information/information-type" test="availability-impact" level="ERROR">
+            <expect id="information-type-has-availability-impact" target="system-information/information-type" test="exists(availability-impact)" level="ERROR">
                 <formal-name>Information Type Has Availability Impact</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-information-and-information-types"/>
                 <message>A FedRAMP SSP information type MUST have an availability impact.</message>
             </expect>
-            <expect id="information-type-has-confidentiality-impact" target="system-information/information-type" test="confidentiality-impact" level="ERROR">
+            <expect id="information-type-has-confidentiality-impact" target="system-information/information-type" test="exists(confidentiality-impact)" level="ERROR">
                 <formal-name>Information Type Has Confidentiality Impact</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-information-and-information-types"/>
                 <message>A FedRAMP SSP information type MUST have a confidentiality impact.</message>
             </expect>
-            <expect id="information-type-has-integrity-impact" target="system-information/information-type" test="integrity-impact" level="ERROR">
+            <expect id="information-type-has-integrity-impact" target="system-information/information-type" test="exists(integrity-impact)" level="ERROR">
                 <formal-name>Information Type Has Integrity Impact</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-information-and-information-types"/>
                 <message>A FedRAMP SSP information type MUST have an integrity impact.</message>
@@ -512,18 +512,18 @@
     </context>
 
     <context>
-	<metapath target="/system-security-plan/system-implementation"/>
-	    <constraints>
+        <metapath target="/system-security-plan/system-implementation"/>
+        <constraints>
             <expect id="authentication-method-has-remarks" target="//component[(@type='system' and ./prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]"  test="count(./prop[@name='authentication-method' and @ns='https://fedramp.gov/ns/oscal'])  = count(./prop[@name='authentication-method' and @ns='https://fedramp.gov/ns/oscal']/remarks)" level="ERROR">
                 <formal-name>Authentication Method Has Remarks</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>Each authentication method in a FedRAMP SSP MUST have a remarks field.</message>
             </expect>
-	        <expect id="has-inventory-items" target="." test="count(inventory-item) >= 2" level="ERROR">
-	    	    <formal-name>System Implementation Has Inventory Items</formal-name>
-		        <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
-		        <message>A FedRAMP SSP system implementation section MUST have at least two inventory items.</message>
-	        </expect>
+	    <expect id="has-inventory-items" target="." test="count(inventory-item) >= 2" level="ERROR">
+                <formal-name>System Implementation Has Inventory Items</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>A FedRAMP SSP system implementation section MUST have at least two inventory items.</message>
+	    </expect>
             <expect id="leveraged-authorization-has-authorization-type" target="leveraged-authorization" test="count(prop[@name='authorization-type'][@ns='https://fedramp.gov/ns/oscal']) = 1" level="ERROR">
                 <formal-name>Leveraged Authorization Has Authorization Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
@@ -538,11 +538,16 @@
                 <formal-name>Leveraged Authorization Has System Identifier</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>A FedRAMP SSP MUST define exactly one system identifier for each leveraged authorization entry.</message>
-			</expect>
+	    </expect>
             <expect id="network-component-has-connection-security-prop" target="//component[(@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]" test="count(./prop[@name='connection-security' and @ns='https://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
-				<formal-name>Network Component Has Connection Security Property</formal-name>
-				<prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#ports-protocols-and-services"/>
-				<message>All network components in a FedRAMP SSP system implementation MUST define at least one interconnection security property.</message>
+                <formal-name>Network Component Has Connection Security Property</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#ports-protocols-and-services"/>
+                <message>All network components in a FedRAMP SSP system implementation MUST define at least one interconnection security property.</message>
+            </expect>
+            <expect id="network-component-has-implementation-point" target="component[@type='service' or (@type='software' and ./prop[@name='asset-type' and @value='cli'])]" test="count(./prop[@name='implementation-point']) = 1" level="ERROR">
+                <formal-name>Component Has Implementation Point</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
+                <message>A FedRAMP SSP with service components and CLI software components performing cross-boundary network communication MUST indicate exactly one time if the point of implementation is internal or external to the system.</message>
             </expect>
             <is-unique id="unique-inventory-item-asset-id" target="inventory-item/prop[@name='asset-id']">
                 <formal-name>Unique Asset Identifier</formal-name>
@@ -553,13 +558,13 @@
                     <p>A FedRAMP SSP's inventory item MUST have an Asset ID that is unique across all inventory items in the system and its components.</p>
                 </remarks>
             </is-unique>
-	    </constraints>
-    </context>   
+        </constraints>
+    </context>
 
     <context>
         <metapath target="/(assessment-plan|assessment-results|plan-of-action-and-milestones|system-security-plan)/metadata"/>
         <constraints>
-            <expect id="fedramp-version" target="." test="prop[@name='fedramp-version'][@ns='https://fedramp.gov/ns/oscal']" level="ERROR">
+            <expect id="fedramp-version" target="." test="exists(prop[@name='fedramp-version'][@ns='https://fedramp.gov/ns/oscal'])" level="ERROR">
                 <formal-name>Fedramp Version</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/#fedramp-version"/>
                 <message>A FedRAMP document's metadata MUST define a valid FedRAMP version.</message>
@@ -573,7 +578,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/#title-page"/>
                 <message>All documents submitted to FedRAMP MUST define a valid publication date.</message>
             </expect>
-            <expect id="marking" target="." test="prop[@name='marking']" level="ERROR">
+            <expect id="marking" target="." test="exists(prop[@name='marking'])" level="ERROR">
                 <formal-name>FedRAMP data sensitivity classification identifier.</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal/"/>
             	<message>A FedRAMP document MUST have a marking that defines its data classification.</message>
@@ -591,23 +596,5 @@
             </expect>
         </constraints>
     </context>
-    <context>
-        <metapath target="/system-security-plan/system-implementation"/>
-        <constraints>
-            <is-unique id="unique-inventory-item-asset-id" target="inventory-item/prop[@name='asset-id']">
-                <formal-name>Unique Asset Identifier</formal-name>
-                <description>Ensure each inventory item has a unique asset-id property.</description>
-                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
-                <key-field target="@value"/>
-                <remarks>
-                    <p>A FedRAMP SSP's inventory item MUST have an Asset ID that is unique across all inventory items in the system and its components.</p>
-                </remarks>
-            </is-unique>
-            <expect id="network-component-has-implementation-point" target="component[@type='service' or (@type='software' and ./prop[@name='asset-type' and @value='cli'])]" test="count(./prop[@name='implementation-point']) = 1" level="ERROR">
-                <formal-name>Component Has Implementation Point</formal-name>
-                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
-                <message>A FedRAMP SSP with service components and CLI software components performing cross-boundary network communication MUST indicate exactly one time if the point of implementation is internal or external to the system.</message>
-            </expect>
-        </constraints>
-    </context>
+
 </metaschema-meta-constraints>

--- a/src/validations/constraints/unit-tests/unique-inventory-item-asset-id-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/unique-inventory-item-asset-id-FAIL.yaml
@@ -8,4 +8,4 @@ test-case:
     - constraint-id: unique-inventory-item-asset-id
       fail_count:
         type: "exact"
-        value: 2
+        value: 1


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to fix constraint tests that are checking for existence. Instead of just checking a field, tests have been changed to utilize the `exists()` function. Example: before: `test="selected"` after: `test="exists(selected)"`. The reason for this is to make the intention of the constraint clearer.

## Changes
- Added `exists()` to constraint tests where applicable.
- Removed duplicate constraint `unique-inventory-asset-item-id`.
- Removed duplicate `system-implementation` context block.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ Not applicable.
~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~ Not Applicable.

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
