### PR TITLE
Fix `dev-constraints.js` Bug

### DIFF
--- a/src/scripts/dev-constraint.js
+++ b/src/scripts/dev-constraint.js
@@ -171,7 +171,7 @@ async function scaffoldTest(constraintId,context) {
 
     let invalidContent;
     if (useTemplate === 'new') {
-        const templatePath = path.join(__dirname, '..', '..', 'src', 'validations', 'constraints', 'content', `${model}-all-VALID.xml`);
+        const templatePath = model === 'ssp' ? path.join(__dirname, '..', '..', 'src', 'content', 'rev5', 'examples', 'ssp/xml', 'fedramp-ssp-example.oscal.xml') : path.join(__dirname, '..', '..', 'src', 'validations', 'constraints', 'content', `${model}-all-VALID.xml`);
         const newInvalidPath = path.join(__dirname, '..', '..', 'src', 'validations', 'constraints', 'content', `${model}-${constraintId}-INVALID.xml`);
         
         try {


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to fix a bug that occurs when trying to scaffold tests for a constraint. The script is unable to reach the valid test data to copy because of the recent change in #960 to deprecate `ssp-all-VALID.xml`. This bug is fixed by changing to the code to reference the new `fedramp-ssp-example.oscal.xml` file when scaffolding tests for an ssp.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ Not applicable.
~- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~ Not applicable.

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
