### PR TITLE
Adjust missing-response-components, warn on misplaced response components

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -113,6 +113,7 @@ Examples:
   | leveraged-authorization-has-valid-impact-level |
   | leveraged-authorization-nature-of-agreement |
   | marking |
+  | misplaced-response-components |
   | missing-response-components |
   | network-component-has-connection-security-prop |
   | network-component-has-implementation-point |
@@ -337,6 +338,8 @@ Examples:
   | leveraged-authorization-nature-of-agreement-PASS.yaml |
   | marking-FAIL.yaml |
   | marking-PASS.yaml |
+  | misplaced-response-components-FAIL.yaml |
+  | misplaced-response-components-PASS.yaml |
   | missing-response-components-FAIL.yaml |
   | missing-response-components-PASS.yaml |
   | network-component-has-connection-security-prop-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-control-implementation-status-INVALID.xml
+++ b/src/validations/constraints/content/ssp-control-implementation-status-INVALID.xml
@@ -5,9 +5,11 @@
                       uuid="12345678-1234-4321-8765-123456789012">
   <control-implementation>
     <implemented-requirement uuid="88888888-0000-4000-9000-000000000008" control-id="ac-1">
-      <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="aaaaaaaa-0000-4000-9000-00000000000a">
-        <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="unsupported-status"/>
-      </by-component>
+      <statement statement-id="ac-1_stmt.a" uuid="99999999-0000-4000-9000-000000000009">
+        <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="aaaaaaaa-0000-4000-9000-00000000000a">
+          <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="unsupported-status"/>
+        </by-component>
+      </statement>
     </implemented-requirement>
   </control-implementation>
 </system-security-plan>

--- a/src/validations/constraints/content/ssp-control-implementation-status-VALID.xml
+++ b/src/validations/constraints/content/ssp-control-implementation-status-VALID.xml
@@ -358,6 +358,8 @@
       <prop name="connection-security" value="vpn" ns="https://fedramp.gov/ns/oscal"/>
       <prop name="interconnection-security" value="vpn" ns="https://fedramp.gov/ns/oscal"/>
       <prop name="interconnection-direction" value="in/out" ns="https://fedramp.gov/ns/oscal"/>
+      <prop name="direction" value="incoming" ns="https://fedramp.gov/ns/oscal"/>
+      <prop name="direction" value="outgoing" ns="https://fedramp.gov/ns/oscal"/>
       <prop ns="https://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
         <remarks>
           <p>Some description of the authentication method.</p>
@@ -445,31 +447,31 @@
       <prop name="control-origination" value="sp-system" ns="https://fedramp.gov/ns/oscal"/>
       <prop name="implementation-status" value="partial" ns="https://fedramp.gov/ns/oscal"/>
       <statement statement-id="ac-1_stmt.a" uuid="99999999-0000-4000-9000-000000000009">
+        <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="aaaaaaaa-0000-4000-9000-00000000000a">
+          <description>
+            <p>Access Control Policy and Procedures (AC-1) is fully implemented in our system.</p>
+          </description>
+          <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="implemented"/>
+          <responsible-role role-id="system-admin">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+          </responsible-role>
+        </by-component>      
       </statement>
-      <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="aaaaaaaa-0000-4000-9000-00000000000a">
-        <description>
-          <p>Access Control Policy and Procedures (AC-1) is fully implemented in our system.</p>
-        </description>
-        <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="implemented"/>
-        <responsible-role role-id="system-admin">
-          <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
-        </responsible-role>
-      </by-component>
     </implemented-requirement>
     
     <implemented-requirement uuid="bbbbbbbb-0000-4000-9000-00000000000b" control-id="cm-8">
       <prop name="control-origination" value="sp-system" ns="https://fedramp.gov/ns/oscal"/>
       <statement statement-id="cm-8_stmt.a" uuid="cccccccc-0000-4000-9000-00000000000c">
+        <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="dddddddd-0000-4000-9000-00000000000d">
+          <description>
+            <p>Information System Component Inventory (CM-8) is partially implemented.</p>
+          </description>
+          <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="partial"/>
+          <responsible-role role-id="system-admin">
+            <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+          </responsible-role>
+        </by-component>      
       </statement>
-      <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="dddddddd-0000-4000-9000-00000000000d">
-        <description>
-          <p>Information System Component Inventory (CM-8) is partially implemented.</p>
-        </description>
-        <prop ns="https://fedramp.gov/ns/oscal" name="implementation-status" value="partial"/>
-        <responsible-role role-id="system-admin">
-          <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
-        </responsible-role>
-      </by-component>
     </implemented-requirement>
   </control-implementation>
   

--- a/src/validations/constraints/content/ssp-misplaced-response-components-INVALID.xml
+++ b/src/validations/constraints/content/ssp-misplaced-response-components-INVALID.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
+                      uuid="12345678-1234-4321-8765-123456789012">
+  <system-implementation>
+    <component uuid="55555555-0000-4000-9000-000000000005" type="this-system">
+      <title>System To Be Authorized</title>
+      <description>
+        <p>This component reflects the system to be authorized.</p>
+        <p>A proper SSP should reference this correctly within a given statement to document implemented requirements per FedRAMP requirements.</p>
+        <p>This example SSP does not do that, it's invalid and has some problems.</p>
+      </description>
+    </component>  
+  </system-implementation>
+  <control-implementation>
+    <description>
+      <p>Implementation of controls for the System to be Authorized</p>
+    </description>    
+    <implemented-requirement uuid="bbbbbbbb-0000-4000-9000-00000000000b" control-id="cm-8">
+      <prop name="control-origination" value="unsupported-origination" ns="https://fedramp.gov/ns/oscal"/>
+      <statement statement-id="cm-8_stmt.a" uuid="cccccccc-0000-4000-9000-00000000000c"/>
+      <by-component component-uuid="55555555-0000-4000-9000-000000000005" uuid="ce9c5b13-c9ea-40bb-bd4e-51e1520a4bce">
+          <description>
+            <p>This component reference would be valid if it was within the <code>statement</code> above, but it is not.</p>
+            <p>This constraint violation for the invalid file should warn users and developers repurposing valid syntax for NIST's upstream OSCAL generic use cases is not valid specifically for FedRAMP.</p>
+          </description>        
+      </by-component>
+    </implemented-requirement>
+  </control-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-missing-response-components-INVALID.xml
+++ b/src/validations/constraints/content/ssp-missing-response-components-INVALID.xml
@@ -11,12 +11,14 @@
       <prop name="control-origination" value="unsupported-origination" ns="https://fedramp.gov/ns/oscal"/>
       <prop name="implementation-status" value="unsupported-status" ns="https://fedramp.gov/ns/oscal"/>
       <statement statement-id="ac-1_stmt.a" uuid="99999999-0000-4000-9000-000000000009">
+        <!-- A require by-component reference is missing here, this missing assembly should trigger a constraint violation error. -->
       </statement>
     </implemented-requirement>
     
     <implemented-requirement uuid="bbbbbbbb-0000-4000-9000-00000000000b" control-id="cm-8">
       <prop name="control-origination" value="unsupported-origination" ns="https://fedramp.gov/ns/oscal"/>
       <statement statement-id="cm-8_stmt.a" uuid="cccccccc-0000-4000-9000-00000000000c">
+        <!-- A require by-component reference is missing here, this missing assembly should trigger a constraint violation error. -->
       </statement>
     </implemented-requirement>
   </control-implementation>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -107,7 +107,7 @@
                 <enum value="network">A physical or virtual network.</enum>
             </allowed-values>
 
-            <allowed-values id="control-implementation-status" target="control-implementation/implemented-requirement/by-component/prop[@name='implementation-status']/@value" allow-other="no" level="ERROR">
+            <allowed-values id="control-implementation-status" target="control-implementation/implemented-requirement/statement/by-component/prop[@name='implementation-status']/@value" allow-other="no" level="ERROR">
                 <formal-name>Control Implementation Status</formal-name>
                 <description>The implementation status of the control.</description>
                 <enum value="implemented">Implemented</enum>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -166,10 +166,20 @@
     <context>
         <metapath target="/system-security-plan/control-implementation"/>
         <constraints>
-            <expect id="missing-response-components" target="//statement" test="count(by-component) gt 0" level="ERROR">
-                <formal-name>Missing Response Components</formal-name>
+            <expect id="misplaced-response-components" target="implemented-requirement" test="not(exists(by-component))" level="WARNING">
+                <formal-name>By-Component Reference for Implemented Requirements Misplaced</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/6-security-controls/#response-overview"/>
-                <message>Each implemented requirement MUST have at least one by-component reference to the source component implementing it.</message>
+                <message>A FedRAMP SSP MUST identify how the system implements each control requirement implemented at the per-statement level, not in other locations allowed for non-FedRAMP use cases.</message>
+                <remarks>
+                    <p>NIST maintains OSCAL models that allow implemented requirements for controls to have references to the implementing components in multiple locations to support multiple use cases.</p>
+                    <p>Despite the flexibility of NIST's upstream OSCAL models, FedRAMP only accepts OSCAL-based SSP with the reference in one of those locations, see <code>missing-response-components</code> for more details about this requirement.</p>
+                    <p>A constraint violation with this warning indicates a given SSP uses one of the valid locations for all NIST use cases, not the only one FedRA</p>
+                </remarks>
+            </expect>        
+            <expect id="missing-response-components" target="implemented-requirement/statement" test="count(by-component) ge 1" level="ERROR">
+                <formal-name>By-Component Reference for Implemented Requirements Missing</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/6-security-controls/#response-overview"/>
+                <message>A FedRAMP SSP MUST identify how the system implements each control requirement implemented at the per-statement level and reference any component used to implement it.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -172,8 +172,8 @@
                 <message>A FedRAMP SSP MUST identify how the system implements each control requirement implemented at the per-statement level, not in other locations allowed for non-FedRAMP use cases.</message>
                 <remarks>
                     <p>NIST maintains OSCAL models that allow implemented requirements for controls to have references to the implementing components in multiple locations to support multiple use cases.</p>
-                    <p>Despite the flexibility of NIST's upstream OSCAL models, FedRAMP only accepts OSCAL-based SSP with the reference in one of those locations, see <code>missing-response-components</code> for more details about this requirement.</p>
-                    <p>A constraint violation with this warning indicates a given SSP uses one of the valid locations for all NIST use cases, not the only one FedRA</p>
+                    <p>Despite the flexibility of NIST's upstream OSCAL models, FedRAMP only accepts OSCAL-based SSPs with the reference in one of those locations, see <code>missing-response-components</code> for more details about this requirement.</p>
+                    <p>A constraint violation with this warning indicates a given SSP uses one of the valid locations for all NIST use cases, but not the only FedRAMP required location.</p>
                 </remarks>
             </expect>        
             <expect id="missing-response-components" target="implemented-requirement/statement" test="count(by-component) ge 1" level="ERROR">

--- a/src/validations/constraints/unit-tests/misplaced-response-components-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/misplaced-response-components-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for misplaced-response-components
+  description: >-
+    This test case validates the behavior of constraint
+    misplaced-response-components
+  content: ../content/ssp-misplaced-response-components-INVALID.xml
+  expectations:
+    - constraint-id: misplaced-response-components
+      result: fail

--- a/src/validations/constraints/unit-tests/misplaced-response-components-PASS.yaml
+++ b/src/validations/constraints/unit-tests/misplaced-response-components-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for misplaced-response-components
+  description: >-
+    This test case validates the behavior of constraint
+    misplaced-response-components
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: misplaced-response-components
+      result: pass


### PR DESCRIPTION
# Committer Notes

This is take three after https://github.com/GSA/fedramp-automation/pull/952 and https://github.com/wandmagic/fedramp-automation/pull/18. This tweaks missing-response-components and adds another with `level="WARN"` just to be clear general NIST practice won't work with FedRAMP.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?~ Bug fix for constraint(s) already spec'ed and documented.

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
