### PR TITLE
Add `used-by-link-references-component` constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -137,6 +137,7 @@ Examples:
   | security-level |
   | security-sensitivity-level-matches-security-impact-level |
   | unique-inventory-item-asset-id |
+  | used-by-link-references-component |
   | user-authentication |
   | user-has-authorized-privilege |
   | user-has-role-id |
@@ -385,6 +386,8 @@ Examples:
   | security-sensitivity-level-matches-security-impact-level-PASS.yaml |
   | unique-inventory-item-asset-id-FAIL.yaml |
   | unique-inventory-item-asset-id-PASS.yaml |
+  | used-by-link-references-component-FAIL.yaml |
+  | used-by-link-references-component-PASS.yaml |
   | user-authentication-FAIL.yaml |
   | user-authentication-PASS.yaml |
   | user-has-authorized-privilege-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-used-by-link-references-component-INVALID.xml
+++ b/src/validations/constraints/content/ssp-used-by-link-references-component-INVALID.xml
@@ -1,0 +1,11 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <!-- <component uuid="11111111-2222-4000-8000-009000000000" type="service">
+    </component> Missing the referenced component in the used-by link.-->
+    <component uuid="11111111-2222-4000-8000-009000200001" type="service">
+      <link rel="used-by" href="#11111111-2222-4000-8000-009000000000"/>
+      <protocol name="ftp" uuid="11111111-2222-4000-8000-010000000001">
+      </protocol>
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -564,6 +564,11 @@
                     <p>A FedRAMP SSP's inventory item MUST have an Asset ID that is unique across all inventory items in the system and its components.</p>
                 </remarks>
             </is-unique>
+            <expect id="used-by-link-references-component" target="component[protocol]/link[@rel='used-by']" test="some $uuid in ../../component/@uuid satisfies $uuid = substring-after(@href, '#')" level="ERROR">
+                <formal-name>Used-By Link References Component</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#ports-protocols-and-services"/>
+                <message>A FedRAMP SSP's component MUST reference components that use it via network communication. Component "{ string(../@uuid) }" references a nonexistent component "{@href}".</message>
+            </expect>
         </constraints>
     </context>
 

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -567,7 +567,7 @@
             <expect id="used-by-link-references-component" target="component[protocol]/link[@rel='used-by']" test="some $uuid in ../../component/@uuid satisfies $uuid = substring-after(@href, '#')" level="ERROR">
                 <formal-name>Used-By Link References Component</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#ports-protocols-and-services"/>
-                <message>A FedRAMP SSP's component MUST reference components that use it via network communication. Component "{ string(../@uuid) }" references a nonexistent component "{@href}".</message>
+                <message>A FedRAMP SSP's component MUST reference the existing component(s) that use it via network communication. However, component "{ string(../@uuid) }" references a nonexistent component "{@href}".</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -567,7 +567,7 @@
             <expect id="used-by-link-references-component" target="component[protocol]/link[@rel='used-by']" test="some $uuid in ../../component/@uuid satisfies $uuid = substring-after(@href, '#')" level="ERROR">
                 <formal-name>Used-By Link References Component</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#ports-protocols-and-services"/>
-                <message>A FedRAMP SSP's component MUST reference the existing component(s) that use it via network communication. However, component "{ string(../@uuid) }" references a nonexistent component "{@href}".</message>
+                <message>A FedRAMP SSP's component MUST reference the existing component(s) that use it via network communication. However, component "{../@uuid}" references a nonexistent component "{@href}".</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/unit-tests/used-by-link-references-component-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/used-by-link-references-component-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for used-by-link-references-component
+  description: >-
+    This test case validates the behavior of constraint
+    used-by-link-references-component
+  content: ../content/ssp-used-by-link-references-component-INVALID.xml
+  expectations:
+    - constraint-id: used-by-link-references-component
+      result: fail

--- a/src/validations/constraints/unit-tests/used-by-link-references-component-PASS.yaml
+++ b/src/validations/constraints/unit-tests/used-by-link-references-component-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for used-by-link-references-component
+  description: >-
+    This test case validates the behavior of constraint
+    used-by-link-references-component
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: used-by-link-references-component
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR introduces a constraint `used-by-link-references-component`, which ensures that each component with a protocol assembly and a `used-by` link references an existent component.

## Changes

Added Constraint:
- `used-by-link-references-component: Ensures that each component with a protocol assembly and a `used-by` link references an existent component.

Test Data:
- **Invalid Test Data File**: Demonstrates the case where there the component referenced by the `used-by` link isn't included.
- **Valid Test Data File**: Demonstrates the case where the components referenced by the `used-by` links are included.

Added YAML Files
- **2 YAML Files**: Included pass and fail YAML files to validate the constraint:

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
