### PR TITLE
Adjust Catalog Links

### DIFF
--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
@@ -12698,7 +12698,7 @@
 		<resource uuid="051a77c1-b61d-4995-8275-dacfe688d510">
 			<title>NIST Special Publication (SP) 800-53 revision 5</title>
 			<prop name="version" value="5.1.1"/>
-			<rlink media-type="application/oscal+xml" href="https://raw.githubusercontent.com/usnistgov/oscal-content/v1.2.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
+			<rlink media-type="application/oscal+xml" href="https://raw.githubusercontent.com/usnistgov/oscal-content/refs/tags/v1.3.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
 		</resource>
 	</back-matter>
 </profile>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
@@ -2958,7 +2958,7 @@
         <resource uuid="051a77c1-b61d-4995-8275-dacfe688d510">
             <title>NIST Special Publication (SP) 800-53 revision 5</title>
             <prop name="version" value="5.1.1"/>
-            <rlink media-type="application/oscal+xml" href="NIST_SP-800-53_rev5_catalog.xml"/>
+            <rlink media-type="application/oscal+xml" href="https://raw.githubusercontent.com/usnistgov/oscal-content/refs/tags/v1.3.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
         </resource>
     </back-matter>
 </profile>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
@@ -7259,7 +7259,7 @@
         <resource uuid="051a77c1-b61d-4995-8275-dacfe688d510">
             <title>NIST Special Publication (SP) 800-53 revision 5</title>
             <prop name="version" value="5.1.1"/>
-            <rlink media-type="application/oscal+xml" href="NIST_SP-800-53_rev5_catalog.xml"/>
+            <rlink media-type="application/oscal+xml" href="https://raw.githubusercontent.com/usnistgov/oscal-content/refs/tags/v1.3.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
         </resource>
     </back-matter>
 </profile>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
@@ -11217,7 +11217,7 @@
 		<resource uuid="051a77c1-b61d-4995-8275-dacfe688d510">
 			<title>NIST Special Publication (SP) 800-53 revision 5</title>
 			<prop name="version" value="5.1.1"/>
-			<rlink media-type="application/oscal+xml" href="https://raw.githubusercontent.com/usnistgov/oscal-content/v1.2.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
+			<rlink media-type="application/oscal+xml" href="https://raw.githubusercontent.com/usnistgov/oscal-content/refs/tags/v1.3.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"/>
 		</resource>
 	</back-matter>
 </profile>


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to update the baselines to the 1.3.0 version of the NIST SP 800-53 catalog from the 1.2.0 version of the content. 

## Changes
- Changed all baseline catalog links to : `https://raw.githubusercontent.com/usnistgov/oscal-content/refs/tags/v1.3.0/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml`
- Deleted `NIST_SP-800-53_rev5_catalog.xml`.
### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ Not applicable.
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
