### PR TITLE
Add `Point To` Feature

### DIFF
--- a/src/scripts/dev-constraint.js
+++ b/src/scripts/dev-constraint.js
@@ -164,7 +164,8 @@ async function scaffoldTest(constraintId,context) {
             message: `Choose the content for the negative test:`,
             choices: [
                 { name: `Create new ${constraintId}-INVALID.xml`, value: 'new' },
-                { name: 'Select an existing content file to copy', value: 'select' }
+                { name: 'Select an existing content file to copy', value: 'select' },
+                { name: 'Point to an existing content file', value: 'point' }
             ]
         }
     ]);
@@ -256,7 +257,7 @@ async function scaffoldTest(constraintId,context) {
             fs.copyFileSync(templatePath, newInvalidPath);
             invalidContent = `../content/${model}-${constraintId}-INVALID.xml`;
         }
-    } else {
+    } else if (useTemplate === 'select') {
         const contentDir = path.join(__dirname, '..', '..', 'src', 'validations', 'constraints', 'content');
         const contentFiles = fs.readdirSync(contentDir).filter(file => file.endsWith('.xml'));
         const { selectedContent } = await prompt([
@@ -277,6 +278,22 @@ async function scaffoldTest(constraintId,context) {
         console.log(`Created new ${model}-${constraintId}-INVALID.xml file based on ${selectedContent}`);
         
         invalidContent = `../content/${model}-${constraintId}-INVALID.xml`;
+    }
+    else {
+        const contentDir = path.join(__dirname, '..', '..', 'src', 'validations', 'constraints', 'content');
+        const contentFiles = fs.readdirSync(contentDir).filter(file => file.endsWith('.xml'));
+        const { selectedContent } = await prompt([
+            {
+                type: 'list',
+                name: 'selectedContent',
+                message: 'Select an existing content file to point to:',
+                choices: contentFiles
+            }
+        ]);
+        const selectedContentPath = path.join(contentDir, selectedContent);
+        const selectedContentTarget = selectedContentPath.split("/").pop();
+        console.log(`Pointed invalid test for ${constraintId} to ${selectedContentTarget}`);
+        invalidContent = `../content/${selectedContentTarget}`;
     }
 
     const positivetestCase = {


### PR DESCRIPTION
# Committer Notes
 ## Purpose
This PR aims to add a feature to the test scaffolding that allows you to point to an existing content file to use for the negative test instead of creating a new one. This is useful when writing constraints that can be grouped together and can help cut down the number of content files.

## Changes
- Added `point to` option to the test scaffold. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ Not applicable.
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
