### PR TITLE
Add Constraints For Issue #942

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -100,8 +100,10 @@ Examples:
   | import-profile-has-available-document |
   | import-profile-resolves-to-fedramp-content |
   | incomplete-implemented-requirements |
+  | information-type |
   | information-type-800-60-v2r1 |
   | information-type-has-availability-impact |
+  | information-type-has-class |
   | information-type-has-confidentiality-impact |
   | information-type-has-integrity-impact |
   | information-type-system |
@@ -318,8 +320,12 @@ Examples:
   | import-profile-resolves-to-fedramp-content-PASS.yaml |
   | incomplete-implemented-requirements-FAIL.yaml |
   | incomplete-implemented-requirements-PASS.yaml |
+  | information-type-FAIL.yaml |
+  | information-type-PASS.yaml |
   | information-type-has-availability-impact-FAIL.yaml |
   | information-type-has-availability-impact-PASS.yaml |
+  | information-type-has-class-FAIL.yaml |
+  | information-type-has-class-PASS.yaml |
   | information-type-has-confidentiality-impact-FAIL.yaml |
   | information-type-has-confidentiality-impact-PASS.yaml |
   | information-type-has-integrity-impact-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -922,8 +922,8 @@
                <p>If 'not-applicable', attest explain why authentication is not applicable in the remarks.</p>
             </remarks>
          </prop>
-         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.1"/>
-         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.8"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/>
          <status state="operational"/>
 
          <responsible-role role-id="provider">
@@ -1028,8 +1028,8 @@
          </description>
          <prop name="leveraged-authorization-uuid" value="11111111-2222-4000-8000-019000000001"/>
          <prop name="implementation-point" value="external"/>
-         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.1"/>
-         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.8"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/>
          <link rel="provided-by" href="#11111111-2222-4000-8000-009000100001"/>
          <status state="operational"/>
          <responsible-role role-id="administrator">
@@ -1099,8 +1099,8 @@
                <p>If 'not-applicable', attest explain why authentication is not applicable in the remarks.</p>
             </remarks>
          </prop>
-         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.1" />
-         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.8" />
+         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1" />
+         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8" />
          <prop name="poam-item-uuid" ns="https://fedramp.gov/ns/oscal" value="11111111-3333-4000-8000-000000000001" />
          <prop name="poam-id" ns="https://fedramp.gov/ns/oscal" value="ID-0001" />
          <link rel="provided-by" href="#11111111-2222-4000-8000-009000100001" />
@@ -1277,8 +1277,8 @@
                <p>If 'not-applicable', attest explain why authentication is not applicable in the remarks.</p>
             </remarks>
          </prop>
-         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.1"/>
-         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.8"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/>
          <prop ns="https://fedramp.gov/ns/oscal" name="compliance" value="soc-2-type-1"/>
          <prop ns="https://fedramp.gov/ns/oscal" name="compliance" value="pci-dss"/>
          <prop ns="https://fedramp.gov/ns/oscal" name="compliance" value="iso-27001"/>
@@ -1422,8 +1422,8 @@
                <p>If 'not-applicable', attest explain why authentication is not applicable in the remarks.</p>
             </remarks>
          </prop>
-         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.1"/>
-         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.8"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/>
          <prop name="inherited-uuid" value="22222222-0000-4000-9001-009000000001">
             <remarks>
                <p>This can only be known if provided by the leveraged system.

--- a/src/validations/constraints/content/ssp-information-type-INVALID.xml
+++ b/src/validations/constraints/content/ssp-information-type-INVALID.xml
@@ -1,0 +1,9 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000100001" type="system">
+      <!-- The information type props don't have one of the correct allowed-values (incoming/outgoing) -->
+      <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="neither" value="C.3.5.1"/>
+      <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="neither" value="C.3.5.8"/>
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-information-type-has-class-INVALID.xml
+++ b/src/validations/constraints/content/ssp-information-type-has-class-INVALID.xml
@@ -1,0 +1,13 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000100001" type="system">
+      <!-- 
+      <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
+      <prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/> 
+      -->
+      <!-- The information-type props are missing the @class attribute. -->
+      <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.1"/>
+      <prop ns="https://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.8"/>
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -146,6 +146,14 @@
                 <enum value="fedramp-3.0.0rc1-oscal-1.1.2">FedRAMP Version</enum>
             </allowed-values>
 
+            <allowed-values id="information-type" target="//component/prop[@name='information-type' and @ns='https://fedramp.gov/ns/oscal']/@class" allow-other="no" level="ERROR">
+                <formal-name>Information Type</formal-name>
+                <description>Contains the list of supported values for information type props.</description>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
+                <enum value="incoming">Incoming</enum>
+                <enum value="outgoing">Outgoing</enum>
+            </allowed-values>
+
             <allowed-values id="information-type-800-60-v2r1" target="(system-characteristics/system-information/information-type/categorization[@system='https://doi.org/10.6028/NIST.SP.800-60v2r1']/information-type-id | //component[(@type='system' and prop[@name='leveraged-authorization-uuid']) or (@type=('service', 'software') and not(prop[@name='leveraged-authorization-uuid']) and  prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type=('service', 'software') and prop[@name='implementation-point' and @value='internal'] and prop[@name='communicates-externally' and @value='yes' and @ns='https://fedramp.gov/ns/oscal'])]/prop[@ns='https://fedramp.gov/ns/oscal' and @name='information-type']/@value)" allow-other="no" level="ERROR">
                 <formal-name>NIST SP 800-60 Volume 2 Revision 1 Information Types</formal-name>
                 <description>Contains a list of all supported information types from NIST SP 800-60 Volume 2 Revision 1.</description>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -148,10 +148,10 @@
 
             <allowed-values id="information-type" target="//component/prop[@name='information-type' and @ns='https://fedramp.gov/ns/oscal']/@class" allow-other="no" level="ERROR">
                 <formal-name>Information Type</formal-name>
-                <description>Contains the list of supported values for information type props.</description>
+                <description>The class of an information type property categorizes the direction of the data flow relative to the system described in the SSP.</description>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
-                <enum value="incoming">Incoming</enum>
-                <enum value="outgoing">Outgoing</enum>
+                <enum value="incoming">An incoming data flow to the system for this information type</enum>
+                <enum value="outgoing">An outgoing data flow from the system for this information type</enum>
             </allowed-values>
 
             <allowed-values id="information-type-800-60-v2r1" target="(system-characteristics/system-information/information-type/categorization[@system='https://doi.org/10.6028/NIST.SP.800-60v2r1']/information-type-id | //component[(@type='system' and prop[@name='leveraged-authorization-uuid']) or (@type=('service', 'software') and not(prop[@name='leveraged-authorization-uuid']) and  prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type=('service', 'software') and prop[@name='implementation-point' and @value='internal'] and prop[@name='communicates-externally' and @value='yes' and @ns='https://fedramp.gov/ns/oscal'])]/prop[@ns='https://fedramp.gov/ns/oscal' and @name='information-type']/@value)" allow-other="no" level="ERROR">

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -553,7 +553,7 @@
                 <message>In a FedRAMP SSP, each information type property in a component MUST categorize the class of data flow as incoming to the system, outgoing from the system, or both.</message>
             </expect>
             <expect id="inter-boundary-component-direction-incoming-has-ipv-uri" target="$inter-boundary-component" test="if (prop[@name='direction' and @value='incoming']) then exists(prop[@class='local' and @name=('ipv4-address','ipv6-address')]) or exists(link[@rel='uri']) else true()" level="ERROR">
-               <formal-name>Inter-Boundary Incoming Communication Direction Has an IPV Address or a URI</formal-name>
+               <formal-name>Inter-Boundary Incoming Communication Direction Has an IP Address or a URI</formal-name>
                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
                <message>Component {@uuid} ({path(.)}) MUST have at least one local ipv4 address, ipv6 address, or a URI to an API.</message>
             </expect>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -550,7 +550,7 @@
             <expect id="information-type-has-class" target="component/prop[@name='information-type' and @ns='https://fedramp.gov/ns/oscal']" test="exists(@class)" level="ERROR">
                 <formal-name>Information Type Has Class</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
-                <message>In a FedRAMP SSP, each information type property in a component MUST have a class attribute.</message>
+                <message>In a FedRAMP SSP, each information type property in a component MUST categorize the class of data flow as incoming to the system, outgoing from the system, or both.</message>
             </expect>
             <expect id="inter-boundary-component-direction-incoming-has-ipv-uri" target="$inter-boundary-component" test="if (prop[@name='direction' and @value='incoming']) then exists(prop[@class='local' and @name=('ipv4-address','ipv6-address')]) or exists(link[@rel='uri']) else true()" level="ERROR">
                <formal-name>Inter-Boundary Incoming Communication Direction Has an IPV Address or a URI</formal-name>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -547,6 +547,11 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>A FedRAMP SSP system implementation section MUST have at least two inventory items.</message>
             </expect>
+            <expect id="information-type-has-class" target="component/prop[@name='information-type' and @ns='https://fedramp.gov/ns/oscal']" test="exists(@class)" level="ERROR">
+                <formal-name>Information Type Has Class</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
+                <message>In a FedRAMP SSP, each information type property in a component MUST have a class attribute.</message>
+            </expect>
             <expect id="inter-boundary-component-direction-incoming-has-ipv-uri" target="$inter-boundary-component" test="if (prop[@name='direction' and @value='incoming']) then exists(prop[@class='local' and @name=('ipv4-address','ipv6-address')]) or exists(link[@rel='uri']) else true()" level="ERROR">
                <formal-name>Inter-Boundary Incoming Communication Direction Has an IPV Address or a URI</formal-name>
                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>

--- a/src/validations/constraints/unit-tests/information-type-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/information-type-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for information-type
+  description: This test case validates the behavior of constraint information-type
+  content: ../content/ssp-information-type-INVALID.xml
+  expectations:
+    - constraint-id: information-type
+      result: fail

--- a/src/validations/constraints/unit-tests/information-type-PASS.yaml
+++ b/src/validations/constraints/unit-tests/information-type-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for information-type
+  description: This test case validates the behavior of constraint information-type
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: information-type
+      result: pass

--- a/src/validations/constraints/unit-tests/information-type-has-class-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/information-type-has-class-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for information-type-has-class
+  description: >-
+    This test case validates the behavior of constraint
+    information-type-has-class
+  content: ../content/ssp-information-type-has-class-INVALID.xml
+  expectations:
+    - constraint-id: information-type-has-class
+      result: fail

--- a/src/validations/constraints/unit-tests/information-type-has-class-PASS.yaml
+++ b/src/validations/constraints/unit-tests/information-type-has-class-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for information-type-has-class
+  description: >-
+    This test case validates the behavior of constraint
+    information-type-has-class
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: information-type-has-class
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the constraints in issue #942, specifically [this comment](https://github.com/GSA/fedramp-automation/issues/942#issuecomment-2542082724). The goal of these constraints (`information-type-has-class`, `information-type`) is to ensure that every "information-type" property/extension has an @class attribute and that the allowed values for the @class attribute are `incoming/outgoing`. 

## Changes
Added constraints: 
- `information-type`
- `information-type-has-class`

Added valid/invalid test content:
- `ssp-information-type-INVALID.xml`
- `ssp-information-has-class-type-INVALID.xml`
- Made changes to `fedramp-ssp-example.oscal.xml` to align with constraints.

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
