### PR TITLE
Add `by-component-has-responsible-role` Constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -29,6 +29,7 @@ Examples:
   | attachment-type |
   | authentication-method-has-remarks |
   | authorization-type |
+  | by-component-has-responsible-role |
   | categorization-has-correct-system-attribute |
   | categorization-has-information-type-id |
   | cia-impact-has-adjustment-justification |
@@ -177,6 +178,8 @@ Examples:
   | authentication-method-has-remarks-PASS.yaml |
   | authorization-type-FAIL.yaml |
   | authorization-type-PASS.yaml |
+  | by-component-has-responsible-role-FAIL.yaml |
+  | by-component-has-responsible-role-PASS.yaml |
   | categorization-has-correct-system-attribute-FAIL.yaml |
   | categorization-has-correct-system-attribute-PASS.yaml |
   | categorization-has-information-type-id-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -83,6 +83,9 @@
             <p>The individual representing the authorizing official.</p>
          </description>
       </role>
+      <role id="system-admin">
+        <title>System Administrator</title>
+      </role>
       <role id="system-poc-management">
          <title>Information System Management Point of Contact (POC)</title>
          <description>
@@ -174,6 +177,9 @@
             <p>Represents any customers of this system as may be necessary for assigning customer
                responsibility.</p>
          </description>
+      </role>
+      <role id="creator">
+        <title>Document Creator</title>
       </role>
       <role id="provider">
          <title>Provider</title>
@@ -275,6 +281,11 @@
             <p>The type property must also have a class of "primary" or "alternate".</p>
          </remarks>
       </location>
+      <party uuid="11111111-0000-4000-9000-000000000001" type="organization">
+      <name>Example Organization</name>
+      <short-name>ExOrg</short-name>
+      <link rel="website" href="https://example.com"/>
+      </party>
       <party uuid="11111111-2222-4000-8000-004000000001" type="organization">
          <!-- CSP Name - referenced in Table 3.1 -->
          <name>Cloud Service Provider (CSP) Name</name>
@@ -486,6 +497,9 @@
       </party>
       <responsible-party role-id="provider">
          <party-uuid>11111111-2222-4000-8000-004000000018</party-uuid>
+      </responsible-party>
+      <responsible-party role-id="creator">
+      <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
       </responsible-party>
       <responsible-party role-id="cloud-service-provider">
          <party-uuid>11111111-2222-4000-8000-004000000001</party-uuid>
@@ -2469,6 +2483,9 @@
                     <link href="#11111111-2222-4000-8000-001000000005" rel="policy"/>
                     <link href="#11111111-2222-4000-8000-001000000023" rel="procedure"/>
                     <implementation-status state="operational"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                     <remarks>
                         <p>The specified component is the system itself.</p>
                         <p>Any control implementation response that can not be associated with another component is associated with the component representing the system.</p>
@@ -2481,6 +2498,9 @@
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
                     <implementation-status state="operational"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ac-1_smt.a.2" uuid="11111111-2222-4000-8000-013000000002">
@@ -2494,6 +2514,9 @@
                             <p>Describe the plan to complete the implementation.</p>
                         </remarks>
                     </implementation-status>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000004">
                     <description>
@@ -2509,6 +2532,9 @@
                             <p>Identify what is currently missing from this policy.</p>
                         </remarks>
                     </implementation-status>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ac-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000003">
@@ -2517,6 +2543,9 @@
                         <p>Describe how Part b-1 is satisfied.</p>
                     </description>
                     <implementation-status state="operational"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ac-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000004">
@@ -2525,6 +2554,9 @@
                         <p>Describe how Part b-2 is satisfied.</p>
                     </description>
                     <implementation-status state="operational"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -2564,6 +2596,9 @@
                     <set-parameter param-id="ac-2_prm_4">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ac-2_smt.a" uuid="11111111-2222-4000-8000-013000000006">
@@ -2589,6 +2624,9 @@
                             </responsible-role>
                         </responsibility>
                     </export>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000014" uuid="11111111-2222-4000-8000-014000000009">
                     <description>
@@ -2614,6 +2652,9 @@
                             </responsible-role>
                         </responsibility>
                     </export>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                     <remarks>
                         <p>The component-uuid above points to the <q>this system</q> component.</p>
                         <p>Any control response content that does not cleanly fit another system component is placed here. This includes customer responsibility content.</p>
@@ -2643,6 +2684,9 @@
                             <p>Tool developers should be mindful that</p>
                         </description>
                     </satisfied>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -2673,6 +2717,9 @@
                     <set-parameter param-id="at-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="at-1_smt.a" uuid="11111111-2222-4000-8000-013000000008">
@@ -2680,6 +2727,9 @@
                     <description>
                         <p>Describe how Part a is satisfied.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000013">
                     <description>
@@ -2687,6 +2737,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000014">
                     <description>
@@ -2694,6 +2747,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="at-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000009">
@@ -2701,6 +2757,9 @@
                     <description>
                         <p>Describe how Part b-1 is satisfied.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="at-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000010">
@@ -2708,6 +2767,9 @@
                     <description>
                         <p>Describe how Part b-2 is satisfied.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -2738,6 +2800,9 @@
                     <set-parameter param-id="au-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="au-1_smt.a" uuid="11111111-2222-4000-8000-013000000012">
@@ -2746,6 +2811,9 @@
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
                     <link href="#11111111-2222-4000-8000-001000000007" rel="policy"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000019">
                     <description>
@@ -2753,6 +2821,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000020">
                     <description>
@@ -2760,6 +2831,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="au-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000013">
@@ -2768,6 +2842,9 @@
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
                     <link href="#11111111-2222-4000-8000-001000000007" rel="policy"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="au-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000014">
@@ -2776,6 +2853,9 @@
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
                     <link href="#11111111-2222-4000-8000-001000000007" rel="policy"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -2806,6 +2886,9 @@
                     <set-parameter param-id="ca-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ca-1_smt.a" uuid="11111111-2222-4000-8000-013000000016">
@@ -2813,6 +2896,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000025">
                     <description>
@@ -2820,6 +2906,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000026">
                     <description>
@@ -2827,6 +2916,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ca-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000017">
@@ -2834,6 +2926,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ca-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000018">
@@ -2841,6 +2936,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -2871,6 +2969,9 @@
                     <set-parameter param-id="cm-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="cm-1_smt.a" uuid="11111111-2222-4000-8000-013000000020">
@@ -2878,6 +2979,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000031">
                     <description>
@@ -2885,6 +2989,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000032">
                     <description>
@@ -2892,6 +2999,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="cm-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000021">
@@ -2899,6 +3009,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="cm-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000022">
@@ -2906,6 +3019,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -2934,6 +3050,9 @@
                     <set-parameter param-id="cp-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="cp-1_smt.a" uuid="11111111-2222-4000-8000-013000000024">
@@ -2941,6 +3060,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000037">
                     <description>
@@ -2948,6 +3070,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000038">
                     <description>
@@ -2955,6 +3080,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="cp-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000025">
@@ -2962,6 +3090,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="cp-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000026">
@@ -2969,6 +3100,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -2982,6 +3116,9 @@
                         <p>The organization coordinates contingency plan development with organizational elements responsible for related plans.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -2998,6 +3135,9 @@
                         <value>within 24 hours</value>
                     </set-parameter>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3011,6 +3151,9 @@
                         <p>The organization identifies critical system assets supporting essential missions and business functions.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3024,6 +3167,9 @@
                         <p>The organization coordinates contingency plan testing with organizational elements responsible for related plans.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3037,6 +3183,9 @@
                         <p>The organization conducts an assessment of the alternate storage site at least annually to determine its availability and readiness for operation.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3050,6 +3199,9 @@
                         <p>The organization identifies potential accessibility problems to the alternate storage site in the event of an area-wide disruption or disaster and outlines explicit mitigation actions.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3063,6 +3215,9 @@
                         <p>The organization conducts an assessment of the alternate processing site at least annually to determine its availability and readiness for operation.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3076,6 +3231,9 @@
                         <p>The organization identifies potential accessibility problems to the alternate processing site in the event of an area-wide disruption or disaster and outlines explicit mitigation actions.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3089,6 +3247,9 @@
                         <p>The organization develops alternate processing site agreements that contain priority-of-service provisions in accordance with organizational availability requirements (including recovery time objectives).</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3102,6 +3263,9 @@
                         <p>The organization identifies primary and alternate telecommunications services supporting the system and documents provider contingency plans and recovery time objectives to ensure the availability of telecommunication services.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3115,6 +3279,9 @@
                         <p>The organization obtains alternate telecommunications services to reduce the likelihood of sharing a single point of failure with primary telecommunications services.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3128,6 +3295,9 @@
                         <p>The organization conducts backups of user-level information contained in the system at least weekly.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3141,6 +3311,9 @@
                         <p>The organization provides a means to restore system functions without loading backups (e.g., through system reinstallation).</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3154,6 +3327,9 @@
                         <p>The organization implements transaction recovery for systems that are transaction-based.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3184,6 +3360,9 @@
                     <set-parameter param-id="ia-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ia-1_smt.a" uuid="11111111-2222-4000-8000-013000000028">
@@ -3191,6 +3370,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000043">
                     <description>
@@ -3198,6 +3380,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000044">
                     <description>
@@ -3205,6 +3390,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ia-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000029">
@@ -3212,6 +3400,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ia-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000030">
@@ -3219,6 +3410,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3249,6 +3443,9 @@
                     <set-parameter param-id="ir-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ir-1_smt.a" uuid="11111111-2222-4000-8000-013000000032">
@@ -3256,6 +3453,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000049">
                     <description>
@@ -3263,6 +3463,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000050">
                     <description>
@@ -3270,6 +3473,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ir-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000033">
@@ -3277,6 +3483,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ir-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000034">
@@ -3284,6 +3493,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3314,6 +3526,9 @@
                     <set-parameter param-id="ma-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ma-1_smt.a" uuid="11111111-2222-4000-8000-013000000036">
@@ -3321,6 +3536,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000055">
                     <description>
@@ -3328,6 +3546,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000056">
                     <description>
@@ -3335,6 +3556,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ma-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000037">
@@ -3342,6 +3566,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ma-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000038">
@@ -3349,6 +3576,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3368,6 +3598,9 @@
                         <value>at least annually</value>
                     </set-parameter>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3383,6 +3616,9 @@
                         <p>b. Controls maintenance tools through one or more of the following: removal, disabling, preventing unauthorized removal.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3396,6 +3632,9 @@
                         <p>The organization inspects the maintenance tools used by maintenance personnel for improper or unauthorized modifications.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3409,6 +3648,9 @@
                         <p>The organization checks media containing diagnostic and test programs for malicious code before the media are used in the system.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3426,6 +3668,9 @@
                         <p>(d) Obtaining an exemption from the authorizing official explicitly authorizing removal of the equipment from the facility.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3446,6 +3691,9 @@
                         <value>System Administrators, Security Administrators</value>
                     </set-parameter>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3462,6 +3710,9 @@
                         <p>c. Designates organizational personnel with required access authorizations and technical competence to supervise the maintenance activities of personnel who do not possess the required access authorizations.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3481,6 +3732,9 @@
                         <p>b. Develops and implements alternate security safeguards in the event a system component cannot be sanitized, removed, or disconnected from the system.</p>
                     </description>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3500,6 +3754,9 @@
                         <value>within 24 hours of failure</value>
                     </set-parameter>
                     <implementation-status state="implemented"/>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3530,6 +3787,9 @@
                     <set-parameter param-id="mp-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="mp-1_smt.a" uuid="11111111-2222-4000-8000-013000000040">
@@ -3537,6 +3797,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000061">
                     <description>
@@ -3544,6 +3807,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000062">
                     <description>
@@ -3551,6 +3817,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="mp-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000041">
@@ -3558,6 +3827,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="mp-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000042">
@@ -3565,6 +3837,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3595,6 +3870,9 @@
                     <set-parameter param-id="pe-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="pe-1_smt.a" uuid="11111111-2222-4000-8000-013000000044">
@@ -3602,6 +3880,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000067">
                     <description>
@@ -3609,6 +3890,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000068">
                     <description>
@@ -3616,6 +3900,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="pe-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000045">
@@ -3623,6 +3910,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="pe-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000046">
@@ -3630,6 +3920,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3660,6 +3953,9 @@
                     <set-parameter param-id="pl-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="pl-1_smt.a" uuid="11111111-2222-4000-8000-013000000048">
@@ -3667,6 +3963,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000073">
                     <description>
@@ -3674,6 +3973,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000074">
                     <description>
@@ -3681,6 +3983,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="pl-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000049">
@@ -3688,6 +3993,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="pl-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000050">
@@ -3695,6 +4003,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3725,6 +4036,9 @@
                     <set-parameter param-id="ps-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ps-1_smt.a" uuid="11111111-2222-4000-8000-013000000052">
@@ -3732,6 +4046,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000079">
                     <description>
@@ -3739,6 +4056,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000080">
                     <description>
@@ -3746,6 +4066,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ps-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000053">
@@ -3753,6 +4076,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ps-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000054">
@@ -3760,6 +4086,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3790,6 +4119,9 @@
                     <set-parameter param-id="ra-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ra-1_smt.a" uuid="11111111-2222-4000-8000-013000000056">
@@ -3797,6 +4129,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000085">
                     <description>
@@ -3804,6 +4139,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000086">
                     <description>
@@ -3811,6 +4149,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ra-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000057">
@@ -3818,6 +4159,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="ra-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000058">
@@ -3825,6 +4169,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3855,6 +4202,9 @@
                     <set-parameter param-id="sa-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="sa-1_smt.a" uuid="11111111-2222-4000-8000-013000000060">
@@ -3862,6 +4212,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000091">
                     <description>
@@ -3869,6 +4222,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000092">
                     <description>
@@ -3876,6 +4232,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="sa-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000061">
@@ -3883,6 +4242,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="sa-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000062">
@@ -3890,6 +4252,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3920,6 +4285,9 @@
                     <set-parameter param-id="sc-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="sc-1_smt.a" uuid="11111111-2222-4000-8000-013000000064">
@@ -3927,6 +4295,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000097">
                     <description>
@@ -3934,6 +4305,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000098">
                     <description>
@@ -3941,6 +4315,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="sc-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000065">
@@ -3948,6 +4325,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="sc-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000066">
@@ -3955,6 +4335,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -3985,6 +4368,9 @@
                     <set-parameter param-id="si-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="si-1_smt.a" uuid="11111111-2222-4000-8000-013000000068">
@@ -3992,6 +4378,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000103">
                     <description>
@@ -3999,6 +4388,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000104">
                     <description>
@@ -4006,6 +4398,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="si-1_smt.b.1" uuid="11111111-2222-4000-8000-013000000069">
@@ -4013,6 +4408,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="si-1_smt.b.2" uuid="11111111-2222-4000-8000-013000000070">
@@ -4020,6 +4418,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4046,6 +4447,9 @@
                     <set-parameter param-id="si-8_prm_3">
                         <value>[specify frequency]</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4076,6 +4480,9 @@
                     <set-parameter param-id="sr-1_prm_3">
                         <value>at least annually</value>
                     </set-parameter>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
             <statement statement-id="sr-1_smt.a" uuid="11111111-2222-4000-8000-013000000073">
@@ -4083,6 +4490,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000012" uuid="11111111-2222-4000-8000-014000000110">
                     <description>
@@ -4090,6 +4500,9 @@
                         <p>Component approach. This links to a component representing the Policy.</p>
                         <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000013" uuid="11111111-2222-4000-8000-014000000111">
                     <description>
@@ -4097,6 +4510,9 @@
                         <p>Component approach. This links to a component representing the procedure.</p>
                         <p>That component contains a link to the procedure, so it does not have to be linked here too.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4108,6 +4524,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4119,6 +4538,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4130,6 +4552,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4141,6 +4566,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4152,6 +4580,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4163,6 +4594,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4174,6 +4608,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4185,6 +4622,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4196,6 +4636,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4207,6 +4650,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4218,6 +4664,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4229,6 +4678,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4240,6 +4692,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4251,6 +4706,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4262,6 +4720,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4273,6 +4734,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4284,6 +4748,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4295,6 +4762,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4306,6 +4776,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4317,6 +4790,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4328,6 +4804,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4339,6 +4818,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4350,6 +4832,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4361,6 +4846,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4372,6 +4860,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4383,6 +4874,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4394,6 +4888,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4405,6 +4902,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4416,6 +4916,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4426,7 +4929,9 @@
                 <by-component component-uuid="11111111-2222-4000-8000-009000000000" uuid="e841b346-68a1-4d83-8699-5c47af91a620">
                     <description>
                         <p>Implementation description needed</p>
-                    </description>
+                    </description><responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4438,6 +4943,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4449,6 +4957,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4460,6 +4971,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4471,6 +4985,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4482,6 +4999,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4493,6 +5013,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4504,6 +5027,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4515,6 +5041,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4526,6 +5055,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4537,6 +5069,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4548,6 +5083,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4559,6 +5097,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4570,6 +5111,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4581,6 +5125,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4592,6 +5139,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4603,6 +5153,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4614,6 +5167,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4625,6 +5181,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4636,6 +5195,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4647,6 +5209,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4658,6 +5223,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4669,6 +5237,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4680,6 +5251,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4691,6 +5265,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4702,6 +5279,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4713,6 +5293,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4724,6 +5307,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4735,6 +5321,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4746,6 +5335,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4757,6 +5349,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4768,6 +5363,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4779,6 +5377,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4790,6 +5391,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4801,6 +5405,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4812,6 +5419,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4823,6 +5433,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4834,6 +5447,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4845,6 +5461,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4856,6 +5475,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4867,6 +5489,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4878,6 +5503,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4889,6 +5517,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4900,6 +5531,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4911,6 +5545,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4922,6 +5559,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4933,6 +5573,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4944,6 +5587,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4955,6 +5601,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4966,6 +5615,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4977,6 +5629,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4988,6 +5643,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -4999,6 +5657,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5010,6 +5671,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5021,6 +5685,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5032,6 +5699,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5043,6 +5713,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5054,6 +5727,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5065,6 +5741,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5076,6 +5755,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5087,6 +5769,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5098,6 +5783,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5109,6 +5797,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5120,6 +5811,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5131,6 +5825,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5142,6 +5839,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5153,6 +5853,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5164,6 +5867,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5175,6 +5881,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5186,6 +5895,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5197,6 +5909,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5208,6 +5923,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5219,6 +5937,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5230,6 +5951,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5241,6 +5965,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5252,6 +5979,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5263,6 +5993,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5274,6 +6007,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5285,6 +6021,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5296,6 +6035,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5307,6 +6049,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5318,6 +6063,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5329,6 +6077,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5340,6 +6091,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5351,6 +6105,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5362,6 +6119,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5373,6 +6133,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5384,6 +6147,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5395,6 +6161,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5406,6 +6175,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5417,6 +6189,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5428,6 +6203,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5439,6 +6217,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5450,6 +6231,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5461,6 +6245,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5472,6 +6259,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5483,6 +6273,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5494,6 +6287,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5505,6 +6301,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5516,6 +6315,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5527,6 +6329,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5538,6 +6343,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5549,6 +6357,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5560,6 +6371,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5571,6 +6385,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5582,6 +6399,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5593,6 +6413,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5604,6 +6427,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5615,6 +6441,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5626,6 +6455,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5637,6 +6469,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5648,6 +6483,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5659,6 +6497,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5670,6 +6511,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5681,6 +6525,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5692,6 +6539,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5703,6 +6553,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5714,6 +6567,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5725,6 +6581,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5736,6 +6595,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5747,6 +6609,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5758,6 +6623,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5769,6 +6637,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5780,6 +6651,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5791,6 +6665,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5802,6 +6679,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5813,6 +6693,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5824,6 +6707,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5835,6 +6721,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5846,6 +6735,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5857,6 +6749,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5868,6 +6763,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5879,6 +6777,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5890,6 +6791,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5901,6 +6805,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5912,6 +6819,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5923,6 +6833,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5934,6 +6847,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5945,6 +6861,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5956,6 +6875,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5967,6 +6889,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5978,6 +6903,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -5989,6 +6917,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6000,6 +6931,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6011,6 +6945,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6022,6 +6959,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6033,6 +6973,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6044,6 +6987,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6055,6 +7001,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6066,6 +7015,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6077,6 +7029,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6088,6 +7043,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6099,6 +7057,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6110,6 +7071,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6121,6 +7085,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6132,6 +7099,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6143,6 +7113,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6154,6 +7127,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6165,6 +7141,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6176,6 +7155,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6187,6 +7169,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6198,6 +7183,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6209,6 +7197,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6220,6 +7211,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6231,6 +7225,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6242,6 +7239,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6253,6 +7253,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6264,6 +7267,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6275,6 +7281,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6286,6 +7295,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6297,6 +7309,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6308,6 +7323,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6319,6 +7337,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6330,6 +7351,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6341,6 +7365,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6352,6 +7379,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6363,6 +7393,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6374,6 +7407,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6385,6 +7421,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6396,6 +7435,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6407,6 +7449,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6418,6 +7463,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6429,6 +7477,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6440,6 +7491,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6451,6 +7505,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6462,6 +7519,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6473,6 +7533,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6484,6 +7547,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6495,6 +7561,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6506,6 +7575,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6517,6 +7589,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6528,6 +7603,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6539,6 +7617,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6550,6 +7631,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6561,6 +7645,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6572,6 +7659,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6583,6 +7673,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6594,6 +7687,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6605,6 +7701,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6616,6 +7715,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6627,6 +7729,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6638,6 +7743,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6649,6 +7757,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6660,6 +7771,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6671,6 +7785,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6682,6 +7799,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6693,6 +7813,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6704,6 +7827,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6715,6 +7841,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6726,6 +7855,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6737,6 +7869,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6748,6 +7883,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6759,6 +7897,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6770,6 +7911,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6781,6 +7925,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6792,6 +7939,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6803,6 +7953,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6814,6 +7967,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6825,6 +7981,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6836,6 +7995,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6847,6 +8009,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6858,6 +8023,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6869,6 +8037,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6880,6 +8051,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6891,6 +8065,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6902,6 +8079,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6913,6 +8093,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6924,6 +8107,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6935,6 +8121,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6946,6 +8135,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6957,6 +8149,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6968,6 +8163,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6979,6 +8177,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -6990,6 +8191,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7001,6 +8205,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7012,6 +8219,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7023,6 +8233,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7034,6 +8247,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7045,6 +8261,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7056,6 +8275,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7067,6 +8289,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7078,6 +8303,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7089,6 +8317,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7100,6 +8331,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7111,6 +8345,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7122,6 +8359,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7133,6 +8373,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7144,6 +8387,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7156,6 +8402,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7167,6 +8416,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>
@@ -7178,6 +8430,9 @@
                     <description>
                         <p>Implementation description needed</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
             </statement>
         </implemented-requirement>

--- a/src/validations/constraints/content/ssp-by-component-has-responsible-role-INVALID.xml
+++ b/src/validations/constraints/content/ssp-by-component-has-responsible-role-INVALID.xml
@@ -1,0 +1,10 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <control-implementation>
+    <implemented-requirement uuid="11111111-2222-4000-8000-012000000001" control-id="ac-1">
+      <statement statement-id="ac-1_smt.a.1" uuid="11111111-2222-4000-8000-013000000001">
+        <by-component component-uuid="11111111-2222-4000-8000-009000000000" uuid="11111111-2222-4000-8000-014000000001">
+        </by-component>
+      </statement>
+    </implemented-requirement>
+  </control-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -639,6 +639,11 @@
     <context>
         <metapath target="/system-security-plan/control-implementation/implemented-requirement/statement/by-component"/>
         <constraints>
+            <expect id="by-component-has-responsible-role" target="." test="count(responsible-role) >= 1" level="ERROR">
+                <formal-name>By Component Has Responsible Role</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/6-security-controls/#responsible-roles-and-parameter-assignments"/>
+                <message>In a FedRAMP SSP, each by-component MUST have at least one responsible role.</message>
+            </expect>
             <expect id="implementation-status-has-remarks" target="implementation-status[@state=('partial', 'planned', 'alternative', 'not-applicable' )]" test="exists(remarks)" level="ERROR">
                 <formal-name>Implementation Status Has Remarks</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/6-security-controls/#implementation-status"/>

--- a/src/validations/constraints/unit-tests/by-component-has-responsible-role-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/by-component-has-responsible-role-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for by-component-has-responsible-role
+  description: >-
+    This test case validates the behavior of constraint
+    by-component-has-responsible-role
+  content: ../content/ssp-by-component-has-responsible-role-INVALID.xml
+  expectations:
+    - constraint-id: by-component-has-responsible-role
+      result: fail

--- a/src/validations/constraints/unit-tests/by-component-has-responsible-role-PASS.yaml
+++ b/src/validations/constraints/unit-tests/by-component-has-responsible-role-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for by-component-has-responsible-role
+  description: >-
+    This test case validates the behavior of constraint
+    by-component-has-responsible-role
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: by-component-has-responsible-role
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the`by-component-has-responsible-role` constraint which ensures that every control implementation statement has at least one responsible-role for every by-component.

## Changes
Added constraint: 
- `by-component-has-responsible-role`

Added valid/invalid test content:
- `ssp-by-component-has-responsible-role-INVALID.xml`
- `ssp-by-component-has-responsible-role-VALID.xml`

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
