### PR TITLE
Add `statement-has-this-system-component` Constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -143,6 +143,7 @@ Examples:
   | scan-type |
   | security-level |
   | security-sensitivity-level-matches-security-impact-level |
+  | statement-has-this-system-component |
   | unique-inventory-item-asset-id |
   | used-by-link-references-component |
   | user-authentication |
@@ -405,6 +406,8 @@ Examples:
   | security-level-PASS.yaml |
   | security-sensitivity-level-matches-security-impact-level-FAIL.yaml |
   | security-sensitivity-level-matches-security-impact-level-PASS.yaml |
+  | statement-has-this-system-component-FAIL.yaml |
+  | statement-has-this-system-component-PASS.yaml |
   | unique-inventory-item-asset-id-FAIL.yaml |
   | unique-inventory-item-asset-id-PASS.yaml |
   | used-by-link-references-component-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -4030,6 +4030,11 @@
                 <party-uuid>11111111-2222-4000-8000-004000000018</party-uuid>
             </responsible-role>
             <statement statement-id="si-8_smt" uuid="11111111-2222-4000-8000-013000000071">
+                <by-component component-uuid="11111111-2222-4000-8000-009000000000" uuid="11111111-2222-4000-8000-024000000105">
+                    <description>
+                        <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
+                    </description>
+                </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000018" uuid="11111111-2222-4000-8000-014000000107">
                     <description>
                         <p>Describe how the control is satisfied within the system.</p>

--- a/src/validations/constraints/content/ssp-statement-has-this-system-component-INVALID.xml
+++ b/src/validations/constraints/content/ssp-statement-has-this-system-component-INVALID.xml
@@ -1,0 +1,14 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000000000" type="this-system">
+    </component>
+  </system-implementation>
+  <control-implementation>
+    <implemented-requirement uuid="11111111-2222-4000-8000-012000000001" control-id="ac-1">
+      <statement statement-id="ac-1_smt.a.1" uuid="11111111-2222-4000-8000-013000000001">
+        <!-- <by-component component-uuid="11111111-2222-4000-8000-009000000000" uuid="11111111-2222-4000-8000-014000000001">
+        </by-component> Missing "this-system" by-component.-->
+      </statement>
+    </implemented-requirement>
+  </control-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -648,6 +648,18 @@
     </context>
 
     <context>
+        <metapath target="/system-security-plan/control-implementation/implemented-requirement/statement"/>
+        <constraints>
+            <let var="component-uuid" expression="by-component/@component-uuid"/>
+            <expect id="statement-has-this-system-component" target="." test="count(../../../system-implementation/component[@type='this-system' and @uuid=$component-uuid]) = 1" level="ERROR">
+                <formal-name>Statement Has This System Component</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/6-security-controls/#response-this-system-component"/>
+                <message>In a FedRAMP SSP, each control implementation statement MUST have one "this-system" by-component.</message>
+            </expect>
+        </constraints>
+    </context>
+
+    <context>
         <metapath target="/system-security-plan/system-characteristics/authorization-boundary/diagram/link"/>
         <constraints>
             <let var="authorization-boundary-href" expression=".[@rel='diagram']/@href"/>

--- a/src/validations/constraints/unit-tests/statement-has-this-system-component-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/statement-has-this-system-component-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for statement-has-this-system-component
+  description: >-
+    This test case validates the behavior of constraint
+    statement-has-this-system-component
+  content: ../content/ssp-statement-has-this-system-component-INVALID.xml
+  expectations:
+    - constraint-id: statement-has-this-system-component
+      result: fail

--- a/src/validations/constraints/unit-tests/statement-has-this-system-component-PASS.yaml
+++ b/src/validations/constraints/unit-tests/statement-has-this-system-component-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for statement-has-this-system-component
+  description: >-
+    This test case validates the behavior of constraint
+    statement-has-this-system-component
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: statement-has-this-system-component
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `statement-has-this-system-component` constraint which ensures that every control implementation statement has one "this-system" by-component.

## Changes
Added constraint: 
- `statement-has-this-system-component`

Added valid/invalid test content:
- `ssp-statement-has-this-system-component-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with the above constraint. 

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
