### PR TITLE
Add `implementation-status-has-remarks` Constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -97,6 +97,7 @@ Examples:
   | has-system-id |
   | has-system-name-short |
   | has-user-guide |
+  | implementation-status-has-remarks |
   | import-profile-has-available-document |
   | import-profile-resolves-to-fedramp-content |
   | incomplete-implemented-requirements |
@@ -314,6 +315,8 @@ Examples:
   | has-system-name-short-PASS.yaml |
   | has-user-guide-FAIL.yaml |
   | has-user-guide-PASS.yaml |
+  | implementation-status-has-remarks-FAIL.yaml |
+  | implementation-status-has-remarks-PASS.yaml |
   | import-profile-has-available-document-FAIL.yaml |
   | import-profile-has-available-document-PASS.yaml |
   | import-profile-resolves-to-fedramp-content-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-implementation-status-has-remarks-INVALID.xml
+++ b/src/validations/constraints/content/ssp-implementation-status-has-remarks-INVALID.xml
@@ -1,0 +1,15 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <control-implementation>
+    <implemented-requirement uuid="11111111-2222-4000-8000-012000000001" control-id="ac-1">
+      <statement statement-id="ac-1_smt.a.1" uuid="11111111-2222-4000-8000-013000000001">
+        <by-component component-uuid="11111111-2222-4000-8000-009000000000" uuid="11111111-2222-4000-8000-014000000001">
+          <implementation-status state="planned"/>
+          <!-- <remarks>
+            <p>The specified component is the system itself.</p>
+            <p>Any control implementation response that can not be associated with another component is associated with the component representing the system.</p>
+          </remarks> Implementation status is not "implemented", therefore it is missing remarks to provide context. -->
+        </by-component>
+      </statement>
+    </implemented-requirement>
+  </control-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -647,6 +647,17 @@
     </context>
 
     <context>
+        <metapath target="/system-security-plan/control-implementation/implemented-requirement/statement/by-component"/>
+        <constraints>
+            <expect id="implementation-status-has-remarks" target="implementation-status[@state=('partial', 'planned', 'alternative', 'not-applicable' )]" test="exists(remarks)" level="ERROR">
+                <formal-name>Implementation Status Has Remarks</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/6-security-controls/#implementation-status"/>
+                <message>In a FedRAMP SSP, each by-component that is not implemented MUST have remarks to provide context.</message>
+            </expect>
+        </constraints>
+    </context>
+
+    <context>
         <metapath target="/system-security-plan/system-characteristics/authorization-boundary/diagram/link"/>
         <constraints>
             <let var="authorization-boundary-href" expression=".[@rel='diagram']/@href"/>

--- a/src/validations/constraints/unit-tests/implementation-status-has-remarks-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/implementation-status-has-remarks-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for implementation-status-has-remarks
+  description: >-
+    This test case validates the behavior of constraint
+    implementation-status-has-remarks
+  content: ../content/ssp-implementation-status-has-remarks-INVALID.xml
+  expectations:
+    - constraint-id: implementation-status-has-remarks
+      result: fail

--- a/src/validations/constraints/unit-tests/implementation-status-has-remarks-PASS.yaml
+++ b/src/validations/constraints/unit-tests/implementation-status-has-remarks-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for implementation-status-has-remarks
+  description: >-
+    This test case validates the behavior of constraint
+    implementation-status-has-remarks
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: implementation-status-has-remarks
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `implementation-status-has-remarks` constraint which ensures that SSP statements include (via by-component assembly) with the following implementation status (partial, planned, alternative, or not-applicable) have remarks.

## Changes
Added constraint: 
- `implementation-status-has-remarks` 

Added valid/invalid test content:
- `ssp-implementation-status-has-remarks-INVALID.xml`

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
