### PR TITLE
Add missing responsible-role to by-component

### DIFF
--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -4435,6 +4435,9 @@
                     <description>
                         <p>For the portion of the control satisfied by the service provider, describe <strong>how</strong> the control is met.</p>
                     </description>
+                    <responsible-role role-id="system-admin">
+                        <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
+                    </responsible-role>
                 </by-component>
                 <by-component component-uuid="11111111-2222-4000-8000-009000000018" uuid="11111111-2222-4000-8000-014000000107">
                     <description>


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to fix `fedramp-ssp-example.oscal.xml`. Test are failing because one by-component is missing a responsible role.

## Changes
- Added a `responsible-role` to the `by-component`.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ Not applicable.
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
