### PR TITLE
Add connection-security constraint (issue #961)

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -41,6 +41,7 @@ Examples:
   | component-has-provider-responsible-role |
   | component-has-used-by-link |
   | component-type |
+  | connection-security |
   | control-implementation-status |
   | data-center-alternate |
   | data-center-count |
@@ -211,6 +212,8 @@ Examples:
   | component-responsible-role-references-party-PASS.yaml |
   | component-type-FAIL.yaml |
   | component-type-PASS.yaml |
+  | connection-security-FAIL.yaml |
+  | connection-security-PASS.yaml |
   | control-implementation-status-FAIL.yaml |
   | control-implementation-status-PASS.yaml |
   | data-center-alternate-FAIL.yaml |

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -105,6 +105,7 @@
             <allowed-values id="connection-security" target="system-implementation/component/prop[@name='connection-security' and @ns='http://fedramp.gov/ns/oscal']/@value" allow-other="yes" level="WARNING">
                 <formal-name>Connection Security</formal-name>
                 <description>Identifies connection security value.</description>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
                 <enum value="ipsec-ikev1">Internet Protocol Security (IPSec) Internet Key Exchange (IKE) Version 1</enum>
                 <enum value="ipsec-ikev2">Internet Protocol Security (IPSec) Internet Key Exchange (IKE) Version 2</enum>
                 <enum value="ipsec">Internet Protocol Security (IPSec)</enum>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -102,7 +102,7 @@
                 <enum value="network">A physical or virtual network.</enum>
             </allowed-values>
 
-            <allowed-values id="connection-security" target="system-implementation/component/prop[@name='connection-security' and @ns='https://fedramp.gov/ns/oscal']/@value" allow-other="yes" level="WARNING">
+            <allowed-values id="connection-security" target="system-implementation/component/prop[@name='connection-security' and @ns='http://fedramp.gov/ns/oscal']/@value" allow-other="yes" level="WARNING">
                 <formal-name>Connection Security</formal-name>
                 <description>Identifies connection security value.</description>
                 <enum value="ipsec-ikev1">Internet Protocol Security (IPSec) Internet Key Exchange (IKE) Version 1</enum>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -102,6 +102,24 @@
                 <enum value="network">A physical or virtual network.</enum>
             </allowed-values>
 
+            <allowed-values id="connection-security" target="system-implementation/component/prop[@name='connection-security' and @ns='https://fedramp.gov/ns/oscal']/@value" allow-other="yes" level="WARNING">
+                <formal-name>Connection Security</formal-name>
+                <description>Identifies connection security value.</description>
+                <enum value="ipsec-ikev1">Internet Protocol Security (IPSec) Internet Key Exchange (IKE) Version 1</enum>
+                <enum value="ipsec-ikev2">Internet Protocol Security (IPSec) Internet Key Exchange (IKE) Version 2</enum>
+                <enum value="ipsec">Internet Protocol Security (IPSec)</enum>
+                <enum value="ssh-1">Secure Shell 1 (SSH-1)</enum>
+                <enum value="ssh-2">Secure Shell 2 (SSH-2)</enum>
+                <enum value="ssl-1.0">Secure Sockets Layer (SSL) 1.0</enum>
+                <enum value="ssl-2.0">Secure Sockets Layer (SSL) 2.0</enum>
+                <enum value="ssl-3.0">Secure Sockets Layer (SSL) 3.0</enum>
+                <enum value="tls-1.0">Transport Layer Security (TLS) Version 1.0</enum>
+                <enum value="tls-1.1">Transport Layer Security (TLS) Version 1.1</enum>
+                <enum value="tls-1.2">Transport Layer Security (TLS) Version 1.2</enum>
+                <enum value="tls-1.3">Transport Layer Security (TLS) Version 1.3</enum>
+                <enum value="vpn">Virtual Private Network (VPN)</enum>
+            </allowed-values>
+
             <allowed-values id="control-implementation-status" target="control-implementation/implemented-requirement/statement/by-component/prop[@name='implementation-status']/@value" allow-other="no" level="ERROR">
                 <formal-name>Control Implementation Status</formal-name>
                 <description>The implementation status of the control.</description>

--- a/src/validations/constraints/unit-tests/connection-security-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/connection-security-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the negative connection-security constraint unit test.
+test-case:
+  name: The negative connection-security constraint unit test.
+  description: This test case suppresses the negative test for the connection-security "allowed-values" constraint because of its @allow-other="yes" attribute value.
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+  - constraint-id: connection-security
+    fail_count: 0

--- a/src/validations/constraints/unit-tests/connection-security-PASS.yaml
+++ b/src/validations/constraints/unit-tests/connection-security-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the positive connection-security constraint unit test.
+test-case:
+  name: The positive connection-security constraint unit test.
+  description: Test that the FedRAMP SSP connection-security properties contain FedRAMP-approved values.
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+  - constraint-id: connection-security
+    result: pass


### PR DESCRIPTION
# Committer Notes

This constraint defines the list of allowed values for the `connection-security` property.

Related issue: [#961](https://github.com/GSA/fedramp-automation/issues/961).


### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
