### PR TITLE
Add `inventory-item-has-vendor-name` constraint 

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -115,6 +115,7 @@ Examples:
   | interconnection-direction |
   | interconnection-security |
   | inventory-item-allows-authenticated-scan |
+  | inventory-item-has-vendor-name |
   | inventory-item-public |
   | inventory-item-virtual |
   | leveraged-authorization-has-authorization-type |
@@ -354,6 +355,8 @@ Examples:
   | interconnection-security-PASS.yaml |
   | inventory-item-allows-authenticated-scan-FAIL.yaml |
   | inventory-item-allows-authenticated-scan-PASS.yaml |
+  | inventory-item-has-vendor-name-FAIL.yaml |
+  | inventory-item-has-vendor-name-PASS.yaml |
   | inventory-item-public-FAIL.yaml |
   | inventory-item-public-PASS.yaml |
   | inventory-item-virtual-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -2267,6 +2267,7 @@ approved.</p>
       <prop name="vlan-id" value="VLAN Identifier"/>
       <prop name="network-id" value="Network Identifier"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <!-- <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="database"/>-->
       <prop name="allows-authenticated-scan" value="no">
         <remarks>
@@ -2322,6 +2323,7 @@ preferable to the link[rel='validation'] example above.</p>
       <!-- <prop name="patch-level" value="Patch-Level"/> -->
       <prop name="baseline-configuration-name" value="Baseline Configuration Name"/>
       <prop name="physical-location" value="Physical location of Asset"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop name="allows-authenticated-scan" value="no">
         <remarks>
           <p>If no, explain why. If yes, omit remark.</p>
@@ -2353,6 +2355,7 @@ preferable to the link[rel='validation'] example above.</p>
       <!-- Todo: check why schematron validation is indicating that this is not a valid ipv4 value -->
       <prop name="ipv6-address" value="0000:0000:0000:0000:0000:ffff:0a03:0303"/>
       <prop name="is-scanned" value="yes"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000000008"/>
     </inventory-item>
@@ -2367,6 +2370,7 @@ preferable to the link[rel='validation'] example above.</p>
       <prop name="ipv4-address" value="10.4.4.4"/>
       <prop name="ipv6-address" value="0000:0000:0000:0000:0000:ffff:0a04:0404"/>
       <prop name="is-scanned" value="yes"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000000007"/>
     </inventory-item>
@@ -2381,6 +2385,7 @@ preferable to the link[rel='validation'] example above.</p>
       <prop name="virtual" value="no"/>
       <prop name="public" value="yes"/>
       <prop name="is-scanned" value="yes"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000000011"/>
     </inventory-item>
@@ -2394,6 +2399,7 @@ preferable to the link[rel='validation'] example above.</p>
       <prop name="asset-type" value="router"/>
       <prop name="virtual" value="no"/>
       <prop name="public" value="no"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop name="is-scanned" value="no">
         <remarks>
           <p>Asset wasn't running at time of scan.</p>
@@ -2412,6 +2418,7 @@ preferable to the link[rel='validation'] example above.</p>
       <prop name="virtual" value="no"/>
       <prop name="public" value="no"/>
       <prop name="is-scanned" value="yes"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000000008"/>
     </inventory-item>
@@ -2425,6 +2432,7 @@ preferable to the link[rel='validation'] example above.</p>
       <prop name="ipv6-address" value="0000:0000:0000:0000:0000:ffff:0a08:0808"/>
       <prop name="virtual" value="yes"/>
       <prop name="public" value="no"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop name="is-scanned" value="no">
         <remarks>
           <p>Asset wasn't running at time of scan.</p>
@@ -2443,6 +2451,7 @@ preferable to the link[rel='validation'] example above.</p>
       <prop name="virtual" value="yes"/>
       <prop name="public" value="no"/>
       <prop name="is-scanned" value="yes"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000000018"/>
     </inventory-item>

--- a/src/validations/constraints/content/ssp-inventory-item-has-vendor-name-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-has-vendor-name-INVALID.xml
@@ -1,0 +1,12 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000000007" type="process-procedure">
+      <!-- <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/> Missing software-name in linked component-->
+    </component>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000001">
+      <!-- <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/> Missing software-name in inventory-item.-->
+      <implemented-component component-uuid="11111111-2222-4000-8000-009000000007">
+      </implemented-component>
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -637,6 +637,18 @@
     </context>
 
     <context>
+        <metapath target="/system-security-plan/system-implementation/inventory-item"/>
+        <constraints>
+            <let var ="component-uuid" expression="implemented-component/@component-uuid"/>
+            <expect id="inventory-item-has-vendor-name" target="." test="count(prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
+                <formal-name>Inventory Item Has Vendor Name</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item MUST include the vendor name in the inventory item itself or within the linked component.</message>
+            </expect>
+        </constraints>
+    </context>
+
+    <context>
         <metapath target="/(assessment-plan|assessment-results|plan-of-action-and-milestones|system-security-plan)/metadata"/>
         <constraints>
             <expect id="fedramp-version" target="." test="exists(prop[@name='fedramp-version'][@ns='http://fedramp.gov/ns/oscal'])" level="ERROR">

--- a/src/validations/constraints/unit-tests/inventory-item-has-vendor-name-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-vendor-name-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-has-vendor-name
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-vendor-name
+  content: ../content/ssp-inventory-item-has-vendor-name-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-has-vendor-name
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-has-vendor-name-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-vendor-name-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-has-vendor-name
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-vendor-name
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-has-vendor-name
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `inventory-item-has-vendor-name` constraint which ensures that every inventory item has a "vendor-name" FedRAMP extension prop, either on the inventory-item itself or within the component linked to the inventory-item.

## Changes
Added constraint: 
- `inventory-item-has-vendor-name` 

Added valid/invalid test content:
- `ssp-inventory-item-has-vendor-name-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with constraint

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
