### PR TITLE
Add `inventory-item-has-software-version` constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -120,6 +120,7 @@ Examples:
   | interconnection-security |
   | inventory-item-allows-authenticated-scan |
   | inventory-item-and-component-has-public |
+  | inventory-item-has-software-version |
   | inventory-item-has-valid-mac-address |
   | inventory-item-has-vendor-name |
   | inventory-item-or-component-has-asset-id |
@@ -373,6 +374,8 @@ Examples:
   | inventory-item-allows-authenticated-scan-PASS.yaml |
   | inventory-item-and-component-has-public-FAIL.yaml |
   | inventory-item-and-component-has-public-PASS.yaml |
+  | inventory-item-has-software-version-FAIL.yaml |
+  | inventory-item-has-software-version-PASS.yaml |
   | inventory-item-has-valid-mac-address-FAIL.yaml |
   | inventory-item-has-valid-mac-address-PASS.yaml |
   | inventory-item-has-vendor-name-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -2294,6 +2294,7 @@ approved.</p>
         <p>Legacy Example (No implemented-component).</p>
       </description>
       <prop name="asset-id" value="unique-asset-ID-01"/>
+      <prop name="software-version" value="software-version"/>
       <prop name="ipv4-address" value="10.1.1.1"/>
       <prop name="ipv6-address" value="2001:db8:3333:4444:5555:6666:7777:8888"/>
       <prop name="virtual" value="no"/>

--- a/src/validations/constraints/content/ssp-inventory-item-has-software-version-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-has-software-version-INVALID.xml
@@ -1,0 +1,13 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000000007" type="software">
+      <!-- <prop name="software-version" value="software-version"/> Missing software-version in linked component-->
+    </component>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000001">
+      <prop name="asset-type" value="operating-system"/>
+      <!-- <prop name="software-version" value="software-version"/> Missing software-version in inventory-item.-->
+      <implemented-component component-uuid="11111111-2222-4000-8000-009000000007">
+      </implemented-component>
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -663,7 +663,7 @@
         <metapath target="/system-security-plan/system-implementation/inventory-item"/>
         <constraints>
             <let var ="component-uuid" expression="implemented-component/@component-uuid"/>
-            <expect id="inventory-item-has-software-version" target=".[prop[@name='asset-type' and @value=('operating-system', 'container', 'image')] or ../component[uuid=$component-uuid and type='software']]" test="count(prop[@name=('software-version', 'os-version')]) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name=('software-version', 'os-version')]) >= 1" level="ERROR">
+            <expect id="inventory-item-has-software-version" target=".[prop[@name='asset-type' and @value=('operating-system', 'container', 'image')] or ../component[uuid=$component-uuid and type='software']]" test="count(prop[@name=('software-version', 'os-version')]) = 1 or count(../component[@uuid=$component-uuid]/prop[@name=('software-version', 'os-version')]) = 1" level="ERROR">
                 <formal-name>Inventory Item Has Software Version</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each inventory item MUST include the software version in the inventory item itself or within the linked component.</message>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -663,6 +663,11 @@
         <metapath target="/system-security-plan/system-implementation/inventory-item"/>
         <constraints>
             <let var ="component-uuid" expression="implemented-component/@component-uuid"/>
+            <expect id="inventory-item-has-software-version" target=".[prop[@name='asset-type' and @value=('operating-system', 'container', 'image')] or ../component[uuid=$component-uuid and type='software']]" test="count(prop[@name=('software-version', 'os-version')]) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name=('software-version', 'os-version')]) >= 1" level="ERROR">
+                <formal-name>Inventory Item Has Software Version</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item MUST include the software version in the inventory item itself or within the linked component.</message>
+            </expect>
              <expect id="inventory-item-has-valid-mac-address" target=".[prop[@name='mac-address']]/prop[@name='mac-address']" test="matches(@value, '^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})|([0-9a-fA-F]{4}\\.[0-9a-fA-F]{4}\\.[0-9a-fA-F]{4})$')" level="ERROR">
                 <formal-name>Inventory Item Has Valid Mac Address</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>

--- a/src/validations/constraints/unit-tests/inventory-item-has-software-version-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-software-version-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-has-software-version
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-software-version
+  content: ../content/ssp-inventory-item-has-software-version-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-has-software-version
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-has-software-version-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-software-version-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-has-software-version
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-software-version
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-has-software-version
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `inventory-item-has-software-version` constraint which ensures that every inventory items has a "os-version" or "software-version"

## Changes
Added constraint: 
- `inventory-item-has-software-version`

Added valid/invalid test content:
- `ssp-inventory-item-has-software-version-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with constraint

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
