### PR TITLE
Add `inventory-item-and-component-has-public` Constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -115,6 +115,7 @@ Examples:
   | interconnection-direction |
   | interconnection-security |
   | inventory-item-allows-authenticated-scan |
+  | inventory-item-and-component-has-public |
   | inventory-item-has-vendor-name |
   | inventory-item-public |
   | inventory-item-virtual |
@@ -356,6 +357,8 @@ Examples:
   | interconnection-security-PASS.yaml |
   | inventory-item-allows-authenticated-scan-FAIL.yaml |
   | inventory-item-allows-authenticated-scan-PASS.yaml |
+  | inventory-item-and-component-has-public-FAIL.yaml |
+  | inventory-item-and-component-has-public-PASS.yaml |
   | inventory-item-has-vendor-name-FAIL.yaml |
   | inventory-item-has-vendor-name-PASS.yaml |
   | inventory-item-public-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1518,6 +1518,7 @@ leveraged-authorization assembly:</p>
       </description>
 
       <prop name="implementation-point" value="internal"/>
+      <prop name="public" value="no"/>
       <prop name="connection-security" value="tls-1.3" ns="http://fedramp.gov/ns/oscal"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="provider" value="self"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="direction" value="outgoing"/>
@@ -1649,6 +1650,7 @@ property.</p>
         <p>Describe the service and what it is used for.</p>
       </description>
       <prop name="implementation-point" value="internal"/>
+      <prop name="public" value="yes"/>
       <status state="operational"/>
     </component>
 

--- a/src/validations/constraints/content/ssp-inventory-item-and-component-has-public-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-and-component-has-public-INVALID.xml
@@ -1,0 +1,11 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000500004" type="service">
+      <prop name="implementation-point" value="internal"/>
+      <!-- <prop name="public" value="no"/> Missing public prop. -->
+    </component>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000002">
+      <!-- <prop name="public" value="no"/> Missing public prop. -->
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -595,6 +595,11 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>In a FedRAMP SSP, each information type property in a component MUST categorize the class of data flow as incoming to the system, outgoing from the system, or both.</message>
             </expect>
+            <expect id="inventory-item-and-component-has-public" target="(inventory-item | component[@type='service' and prop[@name='implementation-point' and @value='internal']])" test="count(prop[@name='public']) = 1" level="ERROR">
+                <formal-name>Inventory Item and Component Has Public</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item and internal service component MUST state if they are public-facing.</message>
+            </expect>
             <expect id="leveraged-authorization-has-authorization-type" target="leveraged-authorization" test="count(prop[@name='authorization-type'][@ns='http://fedramp.gov/ns/oscal']) = 1" level="ERROR">
                 <formal-name>Leveraged Authorization Has Authorization Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>

--- a/src/validations/constraints/unit-tests/inventory-item-and-component-has-public-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-and-component-has-public-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-and-component-has-public
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-and-component-has-public
+  content: ../content/ssp-inventory-item-and-component-has-public-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-and-component-has-public
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-and-component-has-public-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-and-component-has-public-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-and-component-has-public
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-and-component-has-public
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-and-component-has-public
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `inventory-item-and-component-has-public` constraint which helps determine if every inventory item or internal service component is public facing by providing that information in the "public" prop.
## Changes
Added constraint: 
- `inventory-item-and-component-has-public`

Added valid/invalid test content:
- `ssp-inventory-item-and-component-has-public-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with constraint

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
