### PR TITLE
Add `issue-1032` Constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -37,6 +37,7 @@ Examples:
   | cia-impact-has-adjustment-justification |
   | cia-impact-has-selected |
   | cloud-service-model |
+  | component-has-authenticated-scan |
   | component-has-authentication-method |
   | component-has-diagram-label |
   | component-has-non-provider-responsible-role |
@@ -128,6 +129,7 @@ Examples:
   | inventory-item-allows-authenticated-scan |
   | inventory-item-and-component-has-public |
   | inventory-item-has-asset-type |
+  | inventory-item-has-authenticated-scan |
   | inventory-item-has-diagram-label |
   | inventory-item-has-function |
   | inventory-item-has-is-scanned |
@@ -221,6 +223,8 @@ Examples:
   | cia-impact-has-selected-PASS.yaml |
   | cloud-service-model-FAIL.yaml |
   | cloud-service-model-PASS.yaml |
+  | component-has-authenticated-scan-FAIL.yaml |
+  | component-has-authenticated-scan-PASS.yaml |
   | component-has-authentication-method-FAIL.yaml |
   | component-has-authentication-method-PASS.yaml |
   | component-has-diagram-label-FAIL.yaml |
@@ -403,6 +407,8 @@ Examples:
   | inventory-item-and-component-has-public-PASS.yaml |
   | inventory-item-has-asset-type-FAIL.yaml |
   | inventory-item-has-asset-type-PASS.yaml |
+  | inventory-item-has-authenticated-scan-FAIL.yaml |
+  | inventory-item-has-authenticated-scan-PASS.yaml |
   | inventory-item-has-diagram-label-FAIL.yaml |
   | inventory-item-has-diagram-label-PASS.yaml |
   | inventory-item-has-function-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1528,6 +1528,7 @@ leveraged-authorization assembly:</p>
       </description>
       <prop name='diagram-label' ns='http://fedramp.gov/ns/oscal' value='label'/>
       <prop name="implementation-point" value="internal"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
       <prop name="public" value="no"/>
       <prop name="connection-security" value="tls-1.3" ns="http://fedramp.gov/ns/oscal"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="provider" value="self"/>
@@ -1661,6 +1662,7 @@ property.</p>
         <p>Describe the service and what it is used for.</p>
       </description>
       <prop name="implementation-point" value="internal"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
       <prop name="public" value="yes"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <status state="operational"/>
@@ -2477,6 +2479,7 @@ approved.</p>
       <!-- Todo: check why schematron validation is indicating that this is not a valid ipv4 value -->
       <prop name="ipv6-address" value="0000:0000:0000:0000:0000:ffff:0a03:0303"/>
       <prop name="is-scanned" value="yes"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
 
@@ -2499,6 +2502,7 @@ approved.</p>
       <prop name="ipv4-address" value="10.4.4.4"/>
       <prop name="ipv6-address" value="0000:0000:0000:0000:0000:ffff:0a04:0404"/>
       <prop name="is-scanned" value="yes"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="other">
         <remarks><p>a different kind of scan</p></remarks>
@@ -2517,6 +2521,7 @@ approved.</p>
       <prop name="virtual" value="no"/>
       <prop name="public" value="yes"/>
       <prop name="is-scanned" value="yes"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
  
@@ -2544,6 +2549,7 @@ approved.</p>
           <p>Asset wasn't running at time of scan.</p>
         </remarks>
       </prop>
+      <prop name="allows-authenticated-scan" value="yes"/>
       <prop name="function" value="Required brief, text-based description.">
         <remarks>
           <p>Required, longer, formatted description.</p>
@@ -2565,6 +2571,7 @@ approved.</p>
       <prop name="virtual" value="no"/>
       <prop name="public" value="no"/>
       <prop name="is-scanned" value="yes"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <prop name="function" value="Required brief, text-based description.">
@@ -2591,6 +2598,7 @@ approved.</p>
           <p>Asset wasn't running at time of scan.</p>
         </remarks>
       </prop>
+      <prop name="allows-authenticated-scan" value="yes"/>
       <prop name="function" value="Required brief, text-based description.">
         <remarks>
           <p>Optional, longer, formatted description.</p>
@@ -2611,6 +2619,7 @@ approved.</p>
       <prop name="virtual" value="yes"/>
       <prop name="public" value="no"/>
       <prop name="is-scanned" value="yes"/>
+      <prop name="allows-authenticated-scan" value="yes"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <prop name='function' value='virtual'><remarks><p>virtual function</p></remarks></prop>

--- a/src/validations/constraints/content/ssp-component-has-authenticated-scan-INVALID.xml
+++ b/src/validations/constraints/content/ssp-component-has-authenticated-scan-INVALID.xml
@@ -1,0 +1,8 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000500004" type="service">
+      <!-- <prop name="allows-authenticated-scan" value="yes"/> Missing allows-authenticated-scan prop. -->
+      <prop name="implementation-point" value="internal"/>
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-inventory-item-has-authenticated-scan-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-has-authenticated-scan-INVALID.xml
@@ -1,0 +1,12 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component type="service" uuid="11111111-2222-4000-8000-009000000007">
+      <!-- <prop name="allows-authenticated-scan" value="yes"/> Missing allows-authenticated-scan prop. -->
+    </component>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000001">
+      <!-- <prop name="allows-authenticated-scan" value="yes"/> Missing allows-authenticated-scan prop. -->
+      <implemented-component component-uuid="11111111-2222-4000-8000-009000000007">
+      </implemented-component>
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -676,7 +676,6 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#ports-protocols-and-services"/>
                 <message>A FedRAMP SSP's component MUST reference the existing component(s) that use it via network communication. However, component "{../@uuid}" references a nonexistent component "{@href}".</message>
             </expect>
-
         </constraints>
     </context>
 
@@ -684,6 +683,11 @@
         <metapath target="/system-security-plan/system-implementation/component"/>
         <constraints>
             <let var="interconnection-component-used-by-href" expression=".[@type=('interconnection', 'connection')]/link[@rel='used-by']/@href"/>
+            <expect id="component-has-authenticated-scan" target=".[@type='service' and prop[@name='implementation-point' and @value='internal']]" test="count(prop[@name='allows-authenticated-scan']) = 1" level="ERROR">
+                <formal-name>Component Has Authenticated Scan</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each internal service component MUST state whether it allows authenticated scans.</message>
+            </expect>
             <expect id="interconnection-component-linked-has-protocol" target=".[@type=('interconnection', 'connection')]" test="some $href in $interconnection-component-used-by-href satisfies count(../component[@uuid=substring-after($href,'#')]/protocol) >= 1" level="ERROR">
                 <formal-name>Linked Interconnection Component Has Protocol</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#ports-protocols-and-services"/>
@@ -691,7 +695,6 @@
             </expect>
         </constraints>
     </context>
-
 
     <context>
         <metapath target="/system-security-plan/system-implementation/inventory-item"/>
@@ -715,6 +718,11 @@
                 <formal-name>Inventory Item Has Asset-Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each inventory item MUST define the asset type either in the inventory item itself or within the linked component.</message>
+            </expect>
+            <expect id="inventory-item-has-authenticated-scan" target="." test="count(prop[@name='allows-authenticated-scan']) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name='allows-authenticated-scan']) = 1" level="ERROR">
+                <formal-name>Inventory Item Has Authenticated Scan</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item MUST state whether it allows authenticated scans in the inventory item itself or within the linked component.</message>
             </expect>
             <expect id="inventory-item-has-diagram-label" target="." test="count(prop[@name='diagram-label' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name='diagram-label' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
                 <formal-name>Inventory Item Has Diagram Label</formal-name>

--- a/src/validations/constraints/unit-tests/component-has-authenticated-scan-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/component-has-authenticated-scan-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for component-has-authenticated-scan
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-authenticated-scan
+  content: ../content/ssp-component-has-authenticated-scan-INVALID.xml
+  expectations:
+    - constraint-id: component-has-authenticated-scan
+      result: fail

--- a/src/validations/constraints/unit-tests/component-has-authenticated-scan-PASS.yaml
+++ b/src/validations/constraints/unit-tests/component-has-authenticated-scan-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for component-has-authenticated-scan
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-authenticated-scan
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: component-has-authenticated-scan
+      result: pass

--- a/src/validations/constraints/unit-tests/inventory-item-has-authenticated-scan-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-authenticated-scan-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-has-authenticated-scan
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-authenticated-scan
+  content: ../content/ssp-inventory-item-has-authenticated-scan-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-has-authenticated-scan
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-has-authenticated-scan-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-authenticated-scan-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-has-authenticated-scan
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-authenticated-scan
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-has-authenticated-scan
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `component-has-authenticated-scan` and `inventory-item-has-authenticated-scan` constraints which help ensure that there is an "allow-authenticated-scan" prop in the inventory, and each Internal "service" component has "allows-authenticated-scan".
## Changes
Added constraints: 
- `component-has-authenticated-scan`
- `inventory-item-has-authenticated-scan`

Added valid/invalid test content:
- `ssp-component-has-authenticated-scan-INVALID.xml`
- `ssp-inventory-item-has-authenticated-scan-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with constraints.

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
