### PR TITLE
Add `iventory-item-or-component-has-virtual` Constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -129,6 +129,7 @@ Examples:
   | inventory-item-has-valid-mac-address |
   | inventory-item-has-vendor-name |
   | inventory-item-or-component-has-asset-id |
+  | inventory-item-or-component-has-virtual |
   | inventory-item-public |
   | inventory-item-virtual |
   | last-accessed-is-datetime |
@@ -402,6 +403,8 @@ Examples:
   | inventory-item-public-PASS.yaml |
   | inventory-item-virtual-FAIL.yaml |
   | inventory-item-virtual-PASS.yaml |
+  | iventory-item-or-component-has-virtual-FAIL.yaml |
+  | iventory-item-or-component-has-virtual-PASS.yaml |
   | last-accessed-is-datetime-FAIL.yaml |
   | last-accessed-is-datetime-PASS.yaml |
   | leveraged-authorization-has-authorization-type-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-inventory-item-or-component-has-virtual-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-or-component-has-virtual-INVALID.xml
@@ -1,0 +1,12 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000000007" type="process-procedure">
+      <!-- <prop name="virtual" value="no"/> The linked component is missing the "virtual" prop.-->
+    </component>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000001">
+      <!-- <prop name="virtual" value="no"/> Iventory item itself is missing the "virtual" prop.-->
+      <implemented-component component-uuid="11111111-2222-4000-8000-009000000007">
+      </implemented-component>
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -708,11 +708,16 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each inventory item MUST include the vendor name in the inventory item itself or within the linked component.</message>
             </expect>
-<expect id="scan-type-has-remarks" target="..//prop[@name='scan-type' and @ns='http://fedramp.gov/ns/oscal' and @value=('other','not-applicable')]" test="exists(remarks)" level="ERROR">
-    <formal-name>Scan Type Has Remarks</formal-name>
-    <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
-    <message>When scan-type is 'other' or 'not-applicable', remarks MUST be provided to explain the selection.</message>
-</expect>
+            <expect id="inventory-item-or-component-has-virtual" target="." test="count(prop[@name='virtual']) = 1 or count(../component[@uuid=$component-uuid]/prop[@name='virtual']) = 1" level="ERROR">
+                <formal-name>Inventory Item or Component Has Virtual</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item MUST state if it is virtual in the inventory item itself or the linked component.</message>
+            </expect>
+            <expect id="scan-type-has-remarks" target="..//prop[@name='scan-type' and @ns='http://fedramp.gov/ns/oscal' and @value=('other','not-applicable')]" test="exists(remarks)" level="ERROR">
+                <formal-name>Scan Type Has Remarks</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>When scan-type is 'other' or 'not-applicable', remarks MUST be provided to explain the selection.</message>
+            </expect>
         </constraints>
     </context>
 

--- a/src/validations/constraints/unit-tests/iventory-item-or-component-has-virtual-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/iventory-item-or-component-has-virtual-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-or-component-has-virtual
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-or-component-has-virtual
+  content: ../content/ssp-inventory-item-or-component-has-virtual-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-or-component-has-virtual
+      result: fail

--- a/src/validations/constraints/unit-tests/iventory-item-or-component-has-virtual-PASS.yaml
+++ b/src/validations/constraints/unit-tests/iventory-item-or-component-has-virtual-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-or-component-has-virtual
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-or-component-has-virtual
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-or-component-has-virtual
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `iventory-item-or-component-has-virtual` constraint which ensures that every inventory item, or it's linked component, is virtual or not by checking for the existence and value of the "virtual" prop.

## Changes
Added constraint: 
- `iventory-item-or-component-has-virtual`

Added valid/invalid test content:
- `ssp-iventory-item-or-component-has-virtual-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with constraint

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
