### PR TITLE
Add `inventory-item-or-component-has-asset-id` constraint and tests

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -119,6 +119,7 @@ Examples:
   | inventory-item-allows-authenticated-scan |
   | inventory-item-and-component-has-public |
   | inventory-item-has-vendor-name |
+  | inventory-item-or-component-has-asset-id |
   | inventory-item-public |
   | inventory-item-virtual |
   | last-accessed-is-datetime |
@@ -367,6 +368,8 @@ Examples:
   | inventory-item-and-component-has-public-PASS.yaml |
   | inventory-item-has-vendor-name-FAIL.yaml |
   | inventory-item-has-vendor-name-PASS.yaml |
+  | inventory-item-or-component-has-asset-id-FAIL.yaml |
+  | inventory-item-or-component-has-asset-id-PASS.yaml |
   | inventory-item-public-FAIL.yaml |
   | inventory-item-public-PASS.yaml |
   | inventory-item-virtual-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -2249,7 +2249,7 @@ approved.</p>
       <description>
         <p>Legacy Example (No implemented-component).</p>
       </description>
-      <!--<prop name="asset-id" value="unique-asset-ID-01"/>-->
+      <prop name="asset-id" value="unique-asset-ID-01"/>
       <prop name="ipv4-address" value="10.1.1.1"/>
       <prop name="ipv6-address" value="2001:db8:3333:4444:5555:6666:7777:8888"/>
       <prop name="virtual" value="no"/>

--- a/src/validations/constraints/content/ssp-inventory-item-or-component-has-asset-id-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-or-component-has-asset-id-INVALID.xml
@@ -1,0 +1,11 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000500004" type="software">
+      <prop name="asset-type" value="image"/>
+      <!--<prop name="asset-id" value="unique-asset-ID-02"/> Missing "asset-id" prop.-->
+    </component>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000001">
+      <!--<prop name="asset-id" value="unique-asset-ID-01"/> Missing "asset-id" prop.-->
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -643,6 +643,17 @@
     </context>
 
     <context>
+        <metapath target="/system-security-plan/system-implementation"/>
+        <constraints>
+            <expect id="inventory-item-or-component-has-asset-id" target="(inventory-item)| (component[@type='software' and prop[@name='asset-type' and @value='image']])" test="count(prop[@name='asset-id']) = 1" level="ERROR">
+                <formal-name>Inventory Item or Component Has Asset ID</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item and software image component MUST include the asset ID.</message>
+            </expect>
+        </constraints>
+    </context>
+
+    <context>
         <metapath target="/system-security-plan/system-implementation/inventory-item"/>
         <constraints>
             <let var ="component-uuid" expression="implemented-component/@component-uuid"/>

--- a/src/validations/constraints/unit-tests/inventory-item-or-component-has-asset-id-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-or-component-has-asset-id-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-or-component-has-asset-id
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-or-component-has-asset-id
+  content: ../content/ssp-inventory-item-or-component-has-asset-id-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-or-component-has-asset-id
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-or-component-has-asset-id-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-or-component-has-asset-id-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-or-component-has-asset-id
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-or-component-has-asset-id
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-or-component-has-asset-id
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `inventory-item-or-component-has-asset-id` constraint which ensures that every inventory item and software image have a unique asset ID..

## Changes
Added constraint: 
- `inventory-item-or-component-has-asset-id`

Added valid/invalid test content:
- `ssp-inventory-item-or-component-has-asset-id-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with constraint

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
