### PR TITLE
Add `inventory-item-has-valid-mac-address` Constraint 

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -118,6 +118,7 @@ Examples:
   | interconnection-security |
   | inventory-item-allows-authenticated-scan |
   | inventory-item-and-component-has-public |
+  | inventory-item-has-valid-mac-address |
   | inventory-item-has-vendor-name |
   | inventory-item-public |
   | inventory-item-virtual |
@@ -365,6 +366,8 @@ Examples:
   | inventory-item-allows-authenticated-scan-PASS.yaml |
   | inventory-item-and-component-has-public-FAIL.yaml |
   | inventory-item-and-component-has-public-PASS.yaml |
+  | inventory-item-has-valid-mac-address-FAIL.yaml |
+  | inventory-item-has-valid-mac-address-PASS.yaml |
   | inventory-item-has-vendor-name-FAIL.yaml |
   | inventory-item-has-vendor-name-PASS.yaml |
   | inventory-item-public-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-inventory-item-has-valid-mac-address-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-has-valid-mac-address-INVALID.xml
@@ -1,0 +1,8 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000001">
+      <!-- MAC address is formatted incorrectly. -->
+      <prop name="mac-address" value="000000000000"/> 
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -646,6 +646,11 @@
         <metapath target="/system-security-plan/system-implementation/inventory-item"/>
         <constraints>
             <let var ="component-uuid" expression="implemented-component/@component-uuid"/>
+             <expect id="inventory-item-has-valid-mac-address" target=".[prop[@name='mac-address']]/prop[@name='mac-address']" test="matches(@value, '^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})|([0-9a-fA-F]{4}\\.[0-9a-fA-F]{4}\\.[0-9a-fA-F]{4})$')" level="ERROR">
+                <formal-name>Inventory Item Has Valid Mac Address</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item that has a MAC address MUST format the MAC address correctly.</message>
+            </expect>
             <expect id="inventory-item-has-vendor-name" target="." test="count(prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
                 <formal-name>Inventory Item Has Vendor Name</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>

--- a/src/validations/constraints/unit-tests/inventory-item-has-valid-mac-address-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-valid-mac-address-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-has-valid-mac-address
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-valid-mac-address
+  content: ../content/ssp-inventory-item-has-valid-mac-address-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-has-valid-mac-address
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-has-valid-mac-address-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-valid-mac-address-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-has-valid-mac-address
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-valid-mac-address
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-has-valid-mac-address
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `inventory-item-has-valid-mac-address` constraint which ensures that MAC address information is provided is formatted correctly. 

## Changes
Added constraint: 
- `inventory-item-has-valid-mac-address`

Added valid/invalid test content:
- `ssp-inventory-item-has-valid-mac-address-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with constraint

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
