### PR TITLE
Add `inventory-item-or-component-has-network` constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -131,6 +131,7 @@ Examples:
   | inventory-item-has-valid-mac-address |
   | inventory-item-has-vendor-name |
   | inventory-item-or-component-has-asset-id |
+  | inventory-item-or-component-has-network |
   | inventory-item-public |
   | inventory-item-virtual |
   | last-accessed-is-datetime |
@@ -404,6 +405,8 @@ Examples:
   | inventory-item-has-vendor-name-PASS.yaml |
   | inventory-item-or-component-has-asset-id-FAIL.yaml |
   | inventory-item-or-component-has-asset-id-PASS.yaml |
+  | inventory-item-or-component-has-network-FAIL.yaml |
+  | inventory-item-or-component-has-network-PASS.yaml |
   | inventory-item-public-FAIL.yaml |
   | inventory-item-public-PASS.yaml |
   | inventory-item-virtual-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1525,6 +1525,7 @@ leveraged-authorization assembly:</p>
       <prop name="implementation-point" value="internal"/>
       <prop name="public" value="no"/>
       <prop name="connection-security" value="tls-1.3" ns="http://fedramp.gov/ns/oscal"/>
+      <prop name="ipv4-address" value="10.10.10.100"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="provider" value="self"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="direction" value="outgoing"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
@@ -1656,6 +1657,7 @@ property.</p>
       </description>
       <prop name="implementation-point" value="internal"/>
       <prop name="public" value="yes"/>
+      <prop name="ipv4-address" value="10.10.10.100"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <status state="operational"/>
       

--- a/src/validations/constraints/content/ssp-inventory-item-or-component-has-network-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-or-component-has-network-INVALID.xml
@@ -1,0 +1,12 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000500004" type="service">
+      <prop name="implementation-point" value="internal"/>
+      <!-- <prop name="ipv4-address" value="10.10.10.100"/> Missing network.-->
+    </component>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000009">
+      <!-- <prop name="ipv4-address" value="10.10.10.100"/> Missing network.-->
+      <!-- <prop name="ipv6-address" value="0000:0000:0000:0000:0000:ffff:0a08:0808"/> Missing network.-->
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -626,6 +626,11 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each inventory item and software image component MUST include the asset ID.</message>
             </expect>
+            <expect id="inventory-item-or-component-has-network" target="(inventory-item)| (component[@type='service' and prop[@name='implementation-point' and @value='internal']])" test="count(prop[@name=('ipv4-address', 'ipv6-address', 'fqdn', 'uri')]) >= 1" level="WARNING">
+                <formal-name>Inventory Item or Component Has Network</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item and internal service component SHOULD be reachable via a network.</message>
+            </expect>
             <expect id="leveraged-authorization-has-authorization-type" target="leveraged-authorization" test="count(prop[@name='authorization-type'][@ns='http://fedramp.gov/ns/oscal']) = 1" level="ERROR">
                 <formal-name>Leveraged Authorization Has Authorization Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
@@ -668,7 +673,6 @@
 
         </constraints>
     </context>
-
 
     <context>
         <metapath target="/system-security-plan/system-implementation/inventory-item"/>

--- a/src/validations/constraints/unit-tests/inventory-item-or-component-has-network-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-or-component-has-network-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-or-component-has-network
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-or-component-has-network
+  content: ../content/ssp-inventory-item-or-component-has-network-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-or-component-has-network
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-or-component-has-network-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-or-component-has-network-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-or-component-has-network
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-or-component-has-network
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-or-component-has-network
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `inventory-item-or-component-has-network` constraint which ensures that each inventory item or internal service component is reachable via a network, which requires either an IPv4 address, IPv6 address, fully qualified domain name (FQDN) or uniform resource identifier (URI).

## Changes
Added constraint: 
- `inventory-item-or-component-has-network`

Added valid/invalid test content:
- `ssp-inventory-item-or-component-has-network-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with constraint

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
