### PR TITLE
Add the inter-boundary-component-has-information-type constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -116,6 +116,7 @@ Examples:
   | information-type-has-confidentiality-impact |
   | information-type-has-integrity-impact |
   | information-type-system |
+  | inter-boundary-component-has-information-type |
   | interconnection-direction |
   | interconnection-security |
   | inventory-item-allows-authenticated-scan |
@@ -365,6 +366,8 @@ Examples:
   | information-type-id-PASS.yaml |
   | information-type-system-FAIL.yaml |
   | information-type-system-PASS.yaml |
+  | inter-boundary-component-has-information-type-FAIL.yaml |
+  | inter-boundary-component-has-information-type-PASS.yaml |
   | interconnection-direction-FAIL.yaml |
   | interconnection-direction-PASS.yaml |
   | interconnection-security-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1199,6 +1199,10 @@ leveraged-authorization assembly:</p>
       <prop name="implementation-point" value="external"/>
       <prop name="direction" value="incoming" ns="http://fedramp.gov/ns/oscal"/>
       <prop name="direction" value="outgoing" ns="http://fedramp.gov/ns/oscal"/>
+
+      <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/>
+
       <prop name="connection-security" value="tls-1.3" ns="http://fedramp.gov/ns/oscal"/>
       <prop name="asset-type" value="saas"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
@@ -1836,6 +1840,10 @@ compliance (e.g., Module in Process).</p>
       <prop name="implementation-point" value="external"/>
       <prop name="direction" value="incoming" ns="http://fedramp.gov/ns/oscal"/>
       <prop name="direction" value="outgoing" ns="http://fedramp.gov/ns/oscal"/>
+
+      <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/>
+
       <prop ns="http://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
         <remarks>
           <p>If 'yes', describe the authentication method.</p>
@@ -2259,6 +2267,10 @@ approved.</p>
       <prop name="implementation-point" value="external"/>
       <prop name="direction" value="incoming" ns="http://fedramp.gov/ns/oscal"/>
       <prop name="direction" value="outgoing" ns="http://fedramp.gov/ns/oscal"/>
+
+      <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/>
+
       <prop ns="http://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
         <remarks>
           <p>If 'yes', describe the authentication method.</p>

--- a/src/validations/constraints/content/ssp-inter-boundary-component-has-information-type-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inter-boundary-component-has-information-type-INVALID.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://github.com/usnistgov/OSCAL/releases/download/v1.1.3/oscal_ssp_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="df903c4c-6bb5-4b78-8a71-c5baa06a9f2e">
+   <system-implementation>
+      <component uuid="67ecaba6-e5be-4c92-9731-e55825689e8f" type="service">
+         <title>Service B</title>
+         <description>
+            <p>An non-authorized service provided by the Awesome Cloud leveraged authorization.</p>
+            <p>Describe the service and what it is used for.</p>
+         </description>
+         <prop name="implementation-point" value="external"/>
+         <prop name="connection-security" value="non-fedramp-value" ns="https://fedramp.gov/ns/oscal"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="provider" value="self"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="still-supported" value="yes"/>
+         <prop ns="https://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
+            <remarks>
+               <p>If 'yes', describe the authentication method.</p>
+               <p>If 'no', explain why no authentication is used.</p>
+               <p>If 'not-applicable', attest explain why authentication is not applicable in the remarks.</p>
+            </remarks>
+         </prop>
+         <!--prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/-->
+         <prop name="poam-item-uuid" ns="https://fedramp.gov/ns/oscal" value="11111111-3333-4000-8000-000000000001"/>
+         <prop name="poam-id" ns="https://fedramp.gov/ns/oscal" value="ID-0001"/>
+         <link rel="provided-by" href="#11111111-2222-4000-8000-009000100001"/>
+         <status state="operational"/>
+         <responsible-role role-id="admin">
+         </responsible-role>
+         <responsible-role role-id="provider">
+            <party-uuid>33333333-2222-4000-8000-004000000001</party-uuid>
+         </responsible-role>
+         <remarks>
+            <p>Each non-authorized leveraged service must be expressed as a "service" component.</p>
+         </remarks>
+      </component>
+   </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-inter-boundary-component-has-information-type-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inter-boundary-component-has-information-type-INVALID.xml
@@ -19,7 +19,6 @@
                <p>If 'not-applicable', attest explain why authentication is not applicable in the remarks.</p>
             </remarks>
          </prop>
-         <!--prop ns="https://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/-->
          <prop name="poam-item-uuid" ns="https://fedramp.gov/ns/oscal" value="11111111-3333-4000-8000-000000000001"/>
          <prop name="poam-id" ns="https://fedramp.gov/ns/oscal" value="ID-0001"/>
          <link rel="provided-by" href="#11111111-2222-4000-8000-009000100001"/>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -574,7 +574,7 @@
     <context>
         <metapath target="/system-security-plan/system-implementation"/>
         <constraints>
-            <let var="inter-boundary-component" expression="component[(@type=('service','software') and not(prop[@name='leveraged-authorization-uuid']) and prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type=('service', 'software') and prop[@name='implementation-point' and @value='internal'] and (prop[@name='communicates-externally' and @value='yes' and @ns='http://fedramp.gov/ns/oscal']))]"/>
+            <let var="inter-boundary-component" expression="component[(@type=('service','software') and not(prop[@name='leveraged-authorization-uuid']) and prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type=('service','software') and prop[@name='implementation-point' and @value='internal'] and (prop[@name='communicates-externally' and @value='yes' and @ns='http://fedramp.gov/ns/oscal']))]"/>
             <expect id="authentication-method-has-remarks" target="//component[(@type='system' and ./prop[@name='leveraged-authorization-uuid']) or (@type='service' and not(./prop[@name='leveraged-authorization-uuid']) and ./prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type='service' and ./prop[@name='implementation-point' and @value='internal'] and ./prop[@name='direction']) or (@type='software' and ./prop[@name='asset-type' and @value='cli'] and ./prop[@name='direction'])]" test="count(./prop[@name='authentication-method' and @ns='http://fedramp.gov/ns/oscal'])  = count(./prop[@name='authentication-method' and @ns='http://fedramp.gov/ns/oscal']/remarks)" level="ERROR">
                 <formal-name>Authentication Method Has Remarks</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
@@ -599,6 +599,11 @@
                 <formal-name>Information Type Has Class</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>In a FedRAMP SSP, each information type property in a component MUST categorize the class of data flow as incoming to the system, outgoing from the system, or both.</message>
+            </expect>
+            <expect id="inter-boundary-component-has-information-type" target="$inter-boundary-component" test="count(prop[@name='information-type' and @ns='http://fedramp.gov/ns/oscal']) &gt;= 1" level="ERROR">
+                <formal-name>Inter-Boundary Component Has Information Type</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-information-and-information-types"/>
+                <message>An inter-boundary communication component {@uuid} ({path(.)}) MUST have at least one information-type property.</message>
             </expect>
             <expect id="inventory-item-and-component-has-public" target="(inventory-item | component[@type='service' and prop[@name='implementation-point' and @value='internal']])" test="count(prop[@name='public']) = 1" level="ERROR">
                 <formal-name>Inventory Item and Component Has Public</formal-name>

--- a/src/validations/constraints/unit-tests/inter-boundary-component-has-information-type-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inter-boundary-component-has-information-type-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid inter-boundary-component-has-information-type constraint unit test.
+test-case:
+  name: The invalid inter-boundary-component-has-information-type constraint unit test.
+  description: Test that the FedRAMP SSP inter-boundary communication component does not have the "information-type" property.
+  content: ../content/ssp-inter-boundary-component-has-information-type-INVALID.xml
+  expectations:
+  - constraint-id: inter-boundary-component-has-information-type
+    result: fail

--- a/src/validations/constraints/unit-tests/inter-boundary-component-has-information-type-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inter-boundary-component-has-information-type-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid inter-boundary-component-has-information-type constraint unit test.
+test-case:
+  name: The valid inter-boundary-component-has-information-type constraint unit test.
+  description: Test that the FedRAMP SSP inter-boundary communication component has at least one "information-type" property.
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+  - constraint-id: inter-boundary-component-has-information-type
+    result: pass


### PR DESCRIPTION
# Committer Notes

This constraint tests the following scenario:
Each inter-boundary component has at least one `information-type` property.

Related issue [#930](https://github.com/GSA/fedramp-automation/issues/930).

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
