### PR TITLE
Add the inter-boundary-component-has-class-attribute constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -121,6 +121,7 @@ Examples:
   | information-type-has-integrity-impact |
   | information-type-system |
   | inter-boundary-component-has-information-type |
+  | inter-boundary-component-information-type-has-class-attribute |
   | interconnection-direction |
   | interconnection-security |
   | inventory-item-allows-authenticated-scan |
@@ -386,6 +387,8 @@ Examples:
   | information-type-system-PASS.yaml |
   | inter-boundary-component-has-information-type-FAIL.yaml |
   | inter-boundary-component-has-information-type-PASS.yaml |
+  | inter-boundary-component-information-type-has-class-attribute-FAIL.yaml |
+  | inter-boundary-component-information-type-has-class-attribute-PASS.yaml |
   | interconnection-direction-FAIL.yaml |
   | interconnection-direction-PASS.yaml |
   | interconnection-security-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1209,6 +1209,7 @@ leveraged-authorization assembly:</p>
 
       <prop name="connection-security" value="tls-1.3" ns="http://fedramp.gov/ns/oscal"/>
       <prop name="asset-type" value="saas"/>
+      <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
         <remarks>
           <p>If 'yes', describe the authentication method.</p>
@@ -1857,10 +1858,8 @@ compliance (e.g., Module in Process).</p>
       <prop name="implementation-point" value="external"/>
       <prop name="direction" value="incoming" ns="http://fedramp.gov/ns/oscal"/>
       <prop name="direction" value="outgoing" ns="http://fedramp.gov/ns/oscal"/>
-
       <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/>
-
       <prop ns="http://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
         <remarks>
           <p>If 'yes', describe the authentication method.</p>
@@ -2286,10 +2285,8 @@ approved.</p>
       <prop name="implementation-point" value="external"/>
       <prop name="direction" value="incoming" ns="http://fedramp.gov/ns/oscal"/>
       <prop name="direction" value="outgoing" ns="http://fedramp.gov/ns/oscal"/>
-
       <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="outgoing" value="C.3.5.8"/>
-
       <prop ns="http://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
         <remarks>
           <p>If 'yes', describe the authentication method.</p>

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1209,7 +1209,6 @@ leveraged-authorization assembly:</p>
 
       <prop name="connection-security" value="tls-1.3" ns="http://fedramp.gov/ns/oscal"/>
       <prop name="asset-type" value="saas"/>
-      <prop ns="http://fedramp.gov/ns/oscal" name="information-type" class="incoming" value="C.3.5.1"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
         <remarks>
           <p>If 'yes', describe the authentication method.</p>
@@ -2640,7 +2639,7 @@ SSP authors must add implmentations for all required controls.
           </description>
           <link href="#11111111-2222-4000-8000-001000000005" rel="policy"/>
           <link href="#11111111-2222-4000-8000-001000000023" rel="procedure"/>
-          <implementation-status state="operational"/>
+          <implementation-status state="implemented"/>
                     <responsible-role role-id="system-admin">
                         <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
                     </responsible-role>
@@ -2655,7 +2654,7 @@ SSP authors must add implmentations for all required controls.
             <p>Component approach. This links to a component representing the Identity Management and Access Control Policy.</p>
             <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
           </description>
-          <implementation-status state="operational"/>
+          <implementation-status state="implemented"/>
                     <responsible-role role-id="system-admin">
                         <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
                     </responsible-role>

--- a/src/validations/constraints/content/ssp-inter-boundary-component-information-type-has-class-attribute-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inter-boundary-component-information-type-has-class-attribute-INVALID.xml
@@ -3,7 +3,6 @@
 <system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="df903c4c-6bb5-4b78-8a71-c5baa06a9f2e">
    <system-implementation>
 
-      <!-- The information-type prop does not have a @class attribute. -->
       <component uuid="67ecaba6-e5be-4c92-9731-e55825689e8f" type="service">
          <title>Service A</title>
          <description>
@@ -12,10 +11,13 @@
          </description>
          <prop name="implementation-point" value="external"/>
          <prop name="connection-security" value="non-fedramp-value" ns="https://fedramp.gov/ns/oscal"/>
-         <prop ns="http://fedramp.gov/ns/oscal" name="provider" value="self"/>
+         <prop name="provider" value="self" ns="http://fedramp.gov/ns/oscal"/>
          <prop ns="http://fedramp.gov/ns/oscal" name="still-supported" value="yes"/>
-         <prop ns="http://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.1"/>
-         <prop ns="http://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
+
+         <!-- The information-type prop does not have a @class attribute. -->
+         <prop name="information-type" value="C.3.5.1" ns="http://fedramp.gov/ns/oscal"/>
+
+         <prop name="authentication-method" value="yes" ns="http://fedramp.gov/ns/oscal">
             <remarks>
                <p>If 'yes', describe the authentication method.</p>
                <p>If 'no', explain why no authentication is used.</p>

--- a/src/validations/constraints/content/ssp-inter-boundary-component-information-type-has-class-attribute-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inter-boundary-component-information-type-has-class-attribute-INVALID.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://github.com/usnistgov/OSCAL/releases/download/v1.1.3/oscal_ssp_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="df903c4c-6bb5-4b78-8a71-c5baa06a9f2e">
+   <system-implementation>
+
+      <!-- The information-type prop does not have a @class attribute. -->
+      <component uuid="67ecaba6-e5be-4c92-9731-e55825689e8f" type="service">
+         <title>Service A</title>
+         <description>
+            <p>An non-authorized service provided by the Awesome Cloud leveraged authorization.</p>
+            <p>Describe the service and what it is used for.</p>
+         </description>
+         <prop name="implementation-point" value="external"/>
+         <prop name="connection-security" value="non-fedramp-value" ns="https://fedramp.gov/ns/oscal"/>
+         <prop ns="http://fedramp.gov/ns/oscal" name="provider" value="self"/>
+         <prop ns="http://fedramp.gov/ns/oscal" name="still-supported" value="yes"/>
+         <prop ns="http://fedramp.gov/ns/oscal" name="information-type" value="C.3.5.1"/>
+         <prop ns="http://fedramp.gov/ns/oscal" name="authentication-method" value="yes">
+            <remarks>
+               <p>If 'yes', describe the authentication method.</p>
+               <p>If 'no', explain why no authentication is used.</p>
+               <p>If 'not-applicable', attest explain why authentication is not applicable in the remarks.</p>
+            </remarks>
+         </prop>
+         <status state="operational"/>
+         <responsible-role role-id="admin"/>
+         <responsible-role role-id="provider">
+            <party-uuid>33333333-2222-4000-8000-004000000001</party-uuid>
+         </responsible-role>
+         <remarks>
+            <p>Each non-authorized leveraged service must be expressed as a "service" component.</p>
+         </remarks>
+      </component>
+
+   </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -625,7 +625,7 @@
             <expect id="inter-boundary-component-information-type-has-class-attribute" target="$inter-boundary-component" test="prop[@name='information-type' and @ns='http://fedramp.gov/ns/oscal']/@class => exists()" level="ERROR">
                 <formal-name>Inter-Boundary Component's Information Type Has @class Attribute</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
-                <message>Inter-boundary communication component {@uuid} ({path(.)}) information-type property MUST have the @class attribute. The @class attribute MUST not be empty, and it MUST contain a valid value (incoming or outgoing).</message>
+                <message>In a FedRAMP SSP, the information-type property of the inter-boundary communication component MUST have the @class attribute. The @class attribute MUST NOT be empty, and it MUST contain a valid value (incoming or outgoing).</message>
             </expect>
             <expect id="inventory-item-and-component-has-public" target="(inventory-item | component[@type='service' and prop[@name='implementation-point' and @value='internal']])" test="count(prop[@name='public']) = 1" level="ERROR">
                 <formal-name>Inventory Item and Component Has Public</formal-name>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -625,7 +625,7 @@
             <expect id="inter-boundary-component-information-type-has-class-attribute" target="$inter-boundary-component" test="prop[@name='information-type' and @ns='http://fedramp.gov/ns/oscal']/@class => exists()" level="ERROR">
                 <formal-name>Inter-Boundary Component's Information Type Has @class Attribute</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
-                <message>In a FedRAMP SSP, the information-type property of the inter-boundary communication component MUST have the @class attribute. The @class attribute MUST NOT be empty, and it MUST contain a valid value (incoming or outgoing).</message>
+                <message>In a FedRAMP SSP, the information type of an inter-boundary communication component MUST include the network traffic direction.</message>
             </expect>
             <expect id="inventory-item-and-component-has-public" target="(inventory-item | component[@type='service' and prop[@name='implementation-point' and @value='internal']])" test="count(prop[@name='public']) = 1" level="ERROR">
                 <formal-name>Inventory Item and Component Has Public</formal-name>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -622,6 +622,11 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-information-and-information-types"/>
                 <message>An inter-boundary communication component {@uuid} ({path(.)}) MUST have at least one information-type property.</message>
             </expect>
+            <expect id="inter-boundary-component-information-type-has-class-attribute" target="$inter-boundary-component" test="prop[@name='information-type' and @ns='http://fedramp.gov/ns/oscal']/@class => exists()" level="ERROR">
+                <formal-name>Inter-Boundary Component's Information Type Has @class Attribute</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#external-systems-and-services-not-having-fedramp-authorization"/>
+                <message>Inter-boundary communication component {@uuid} ({path(.)}) information-type property MUST have the @class attribute. The @class attribute MUST not be empty, and it MUST contain a valid value (incoming or outgoing).</message>
+            </expect>
             <expect id="inventory-item-and-component-has-public" target="(inventory-item | component[@type='service' and prop[@name='implementation-point' and @value='internal']])" test="count(prop[@name='public']) = 1" level="ERROR">
                 <formal-name>Inventory Item and Component Has Public</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>

--- a/src/validations/constraints/unit-tests/inter-boundary-component-information-type-has-class-attribute-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inter-boundary-component-information-type-has-class-attribute-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid inter-boundary-component-information-type-has-class-attribute constraint unit test.
+test-case:
+  name: The invalid inter-boundary-component-information-type-has-class-attribute constraint unit test.
+  description: Test that the FedRAMP SSP inter-boundary communication component's information-type property does not have the @class attribute.
+  content: ../content/ssp-inter-boundary-component-information-type-has-class-attribute-INVALID.xml
+  expectations:
+  - constraint-id: inter-boundary-component-information-type-has-class-attribute
+    result: fail

--- a/src/validations/constraints/unit-tests/inter-boundary-component-information-type-has-class-attribute-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inter-boundary-component-information-type-has-class-attribute-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid inter-boundary-component-information-type-has-class-attribute constraint unit test.
+test-case:
+  name: The valid inter-boundary-component-information-type-has-class-attribute constraint unit test.
+  description: Test that the FedRAMP SSP inter-boundary communication component's information-type property has the @class attribute.
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+  - constraint-id: inter-boundary-component-information-type-has-class-attribute
+    result: pass


### PR DESCRIPTION
# Committer Notes

This constraint tests the following scenario:
In inter-boundary communication components, the `information-type` properties have the `@class` attributes.

Related issue [#930](https://github.com/GSA/fedramp-automation/issues/930).

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
