### PR TITLE
Add `inventory-item-has-is-scanned` Constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -125,6 +125,7 @@ Examples:
   | inventory-item-allows-authenticated-scan |
   | inventory-item-and-component-has-public |
   | inventory-item-has-function |
+  | inventory-item-has-is-scanned |
   | inventory-item-has-scan-type |
   | inventory-item-has-valid-mac-address |
   | inventory-item-has-vendor-name |
@@ -390,6 +391,8 @@ Examples:
   | inventory-item-and-component-has-public-PASS.yaml |
   | inventory-item-has-function-FAIL.yaml |
   | inventory-item-has-function-PASS.yaml |
+  | inventory-item-has-is-scanned-FAIL.yaml |
+  | inventory-item-has-is-scanned-PASS.yaml |
   | inventory-item-has-scan-type-FAIL.yaml |
   | inventory-item-has-scan-type-PASS.yaml |
   | inventory-item-has-valid-mac-address-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -2375,6 +2375,7 @@ approved.</p>
       <prop name="fqdn" value="dns.name"/>
       <prop name="uri" value="uniform.resource.locator"/>
       <prop name="netbios-name" value="netbios-name"/>
+      <prop name="is-scanned" value="yes"/>
       <!-- patch-level applies to component, not inventory-item -->
       <!-- <prop name="patch-level" value="Patch-Level"/> -->
       <prop name="baseline-configuration-name" value="Baseline Configuration Name"/>

--- a/src/validations/constraints/content/ssp-inventory-item-has-is-scanned-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-has-is-scanned-INVALID.xml
@@ -1,0 +1,7 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000001">
+    <!-- <prop name="is-scanned" value="yes"/> Missing "is-scanned" prop -->
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -693,6 +693,11 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>Every inventory-item MUST provide remarks to describe the function of the item, either within the inventory-item itself, or within the component linked by the inventory-item.</message>
             </expect>
+            <expect id="inventory-item-has-is-scanned" target="." test="count(prop[@name='is-scanned']) = 1 or count(../component[@uuid=$component-uuid]/prop[@name='is-scanned']) = 1" level="ERROR">
+                <formal-name>Inventory Item Has Is-Scanned</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item MUST state if it is included in scans either in the inventory item itself or within the linked component.</message>
+            </expect>
             <expect id="inventory-item-has-scan-type" target="." test="count(prop[@name='scan-type' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count($implemented-component/prop[@name='scan-type' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
                 <formal-name>Inventory Item Has Scan Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>

--- a/src/validations/constraints/unit-tests/inventory-item-has-is-scanned-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-is-scanned-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-has-is-scanned
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-is-scanned
+  content: ../content/ssp-inventory-item-has-is-scanned-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-has-is-scanned
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-has-is-scanned-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-is-scanned-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-has-is-scanned
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-is-scanned
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-has-is-scanned
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `inventory-item-has-is-scanned` constraint which ensures that each inventory item, or it's linked component, has the "is-scanned" prop that states if it is included in scans or not. 

## Changes
Added constraint: 
- `inventory-item-has-is-scanned`

Added valid/invalid test content:
- `ssp-inventory-item-has-is-scanned-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with constraint

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
