### PR TITLE
Add `inventory-item-has-asset-type` Constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -125,6 +125,7 @@ Examples:
   | interconnection-security |
   | inventory-item-allows-authenticated-scan |
   | inventory-item-and-component-has-public |
+  | inventory-item-has-asset-type |
   | inventory-item-has-diagram-label |
   | inventory-item-has-function |
   | inventory-item-has-scan-type |
@@ -393,6 +394,8 @@ Examples:
   | inventory-item-allows-authenticated-scan-PASS.yaml |
   | inventory-item-and-component-has-public-FAIL.yaml |
   | inventory-item-and-component-has-public-PASS.yaml |
+  | inventory-item-has-asset-type-FAIL.yaml |
+  | inventory-item-has-asset-type-PASS.yaml |
   | inventory-item-has-diagram-label-FAIL.yaml |
   | inventory-item-has-diagram-label-PASS.yaml |
   | inventory-item-has-function-FAIL.yaml |

--- a/src/validations/constraints/content/ssp-inventory-item-has-asset-type-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-has-asset-type-INVALID.xml
@@ -1,0 +1,7 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000001">
+      <!-- <prop name="asset-type" value="operating-system"/> Missing "asset-type" prop. -->
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -694,6 +694,11 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>For HIGH-impact systems, every inventory-item MUST identify an asset-owner or administrator property either within the inventory-item itself, or within the component linked by the inventory-item.</message>
             </expect>
+            <expect id="inventory-item-has-asset-type" target="." test="count(prop[@name='asset-type' ]) = 1 or count(../component[@uuid=$component-uuid]/prop[@name='asset-type' ]) = 1" level="ERROR">
+                <formal-name>Inventory Item Has Asset-Type</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item MUST define the asset type either in the inventory item itself or within the linked component.</message>
+            </expect>
             <expect id="inventory-item-has-diagram-label" target="." test="count(prop[@name='diagram-label' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name='diagram-label' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
                 <formal-name>Inventory Item Has Diagram Label</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>

--- a/src/validations/constraints/unit-tests/inventory-item-has-asset-type-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-asset-type-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-has-asset-type
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-asset-type
+  content: ../content/ssp-inventory-item-has-asset-type-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-has-asset-type
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-has-asset-type-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-asset-type-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-has-asset-type
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-asset-type
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-has-asset-type
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `inventory-item-has-asset-type` constraint which ensures that each inventory item, or it's linked component, has the "asset-type" prop.

## Changes
Added constraint: 
- `inventory-item-has-asset-type`

Added invalid test content:
- `ssp-inventory-item-has-is-scanned-INVALID.xml`

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
