### PR TITLE
Add new metapath target to `security-level` constraint

### DIFF
--- a/src/validations/constraints/content/ssp-security-level-INVALID.xml
+++ b/src/validations/constraints/content/ssp-security-level-INVALID.xml
@@ -24,4 +24,13 @@
       <security-objective-availability>INVALID-fips-199-moderate</security-objective-availability>
     </security-impact-level>
   </system-characteristics>
+  <system-implementation>
+    <leveraged-authorization uuid="11111111-2222-4000-8000-019000000001">
+      <prop ns="http://fedramp.gov/ns/oscal" name="impact-level" value="INVALID-fips-199-moderate">
+        <remarks>
+          <p>For now, this is a required field. In the future we intend to pull this information directly from FedRAMP's records based on the "leveraged-system-identifier" property's value.</p>
+        </remarks>
+      </prop>
+    </leveraged-authorization>
+  </system-implementation>
 </system-security-plan>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -647,9 +647,10 @@
         <metapath target="/system-security-plan/system-characteristics/security-sensitivity-level"/>
         <metapath target="/system-security-plan/system-characteristics/security-impact-level/(security-objective-confidentiality|security-objective-integrity|security-objective-availability)"/>
         <metapath target="/system-security-plan/system-characteristics/system-information/information-type/(confidentiality-impact|integrity-impact|availability-impact)/(base|selected)"/>
+        <metapath target="/system-security-plan/system-implementation/leveraged-authorization"/>
         <constraints>
-
-            <allowed-values id="security-level" target="." allow-other="no" level="ERROR">
+            <let var="security-level-target" expression="if (prop[@name='impact-level' and @ns='http://fedramp.gov/ns/oscal']) then prop[@name='impact-level' and @ns='http://fedramp.gov/ns/oscal']/@value else ."/>
+            <allowed-values id="security-level" target="$security-level-target" allow-other="no" level="ERROR">
                 <formal-name>Security Impact Level</formal-name>
                 <description>The security objective level as defined by <a href="https://doi.org/10.6028/NIST.SP.800-60v1r1">NIST SP 800-60</a>.
                 </description>


### PR DESCRIPTION
# Committer Notes

## Purpose
This PR aims to add a new metapath target to the `security-level` constraint. The new target checks the `impact-level` prop in a leveraged-authorization. 

## Changes
- Added new metapath target `<metapath target="/system-security-plan/system-implementation/leveraged-authorization"/>` to the existing `security-level` constraint.
- Added a var to check if we are dealing with the `impact-level` prop in a leveraged authorization or not in order to correctly set the target.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
