### PR TITLE
Add the interconnection-component-has-remote-protocol constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -121,6 +121,7 @@ Examples:
   | information-type-system |
   | inter-boundary-component-has-information-type |
   | interconnection-component-has-local-protocol |
+  | interconnection-component-has-remote-protocol |
   | interconnection-direction |
   | interconnection-security |
   | inventory-item-allows-authenticated-scan |
@@ -387,6 +388,8 @@ Examples:
   | inter-boundary-component-has-information-type-PASS.yaml |
   | interconnection-component-has-local-protocol-FAIL.yaml |
   | interconnection-component-has-local-protocol-PASS.yaml |
+  | interconnection-component-has-remote-protocol-FAIL.yaml |
+  | interconnection-component-has-remote-protocol-PASS.yaml |
   | interconnection-direction-FAIL.yaml |
   | interconnection-direction-PASS.yaml |
   | interconnection-security-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -2350,7 +2350,6 @@ approved.</p>
        </responsible-role>
     </component>
 
-
     <!-- Appendix M - Inventory -->
     <inventory-item uuid="11111111-2222-4000-8000-011000000001">
       <description>

--- a/src/validations/constraints/content/ssp-interconnection-component-has-remote-protocol-INVALID.xml
+++ b/src/validations/constraints/content/ssp-interconnection-component-has-remote-protocol-INVALID.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://github.com/usnistgov/OSCAL/releases/download/v1.1.3/oscal_ssp_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="df903c4c-6bb5-4b78-8a71-c5baa06a9f2e">
+   <system-implementation>
+        <component uuid="11111111-2222-4000-8000-009000200002" type="interconnection">
+           <title>Authorized Connection Information System Name</title>
+           <description>
+              <p>Describe the purpose of the external system/service; specifically, provide reasons for connectivity (e.g., system monitoring, system alerting, download updates, etc.)</p>
+           </description>
+           <prop name="nature-of-agreement" value="contract" ns="http://fedramp.gov/ns/oscal"/>
+           <prop name="authentication-method" value="yes" ns="http://fedramp.gov/ns/oscal">
+              <remarks>
+                 <p>If 'yes', describe the authentication method in the remarks.</p>
+                 <p>If 'no', explain why no authentication is used in the remarks.</p>
+                 <p>If 'not-applicable', attest explain why authentication is not applicable in the remarks.</p>
+              </remarks>
+           </prop>
+           <prop name="information-type" class="incoming" value="C.3.5.1" ns="http://fedramp.gov/ns/oscal"/>
+           <prop name="information-type" class="incoming" value="C.3.5.8" ns="http://fedramp.gov/ns/oscal"/>
+           <prop name="ipv4-address" class="local" value="10.1.1.1"/>
+           <prop name="ipv6-address" class="local" value="::ffff:10.1.1.1"/>
+           <!--prop name="ipv4-address" class="remote" value="10.2.2.2"/>
+           <prop name="ipv6-address" class="remote" value="::ffff:10.2.2.2"/>
+           <prop name="fqdn" class="remote" value="www.example.com" ns="http://fedramp.gov/ns/oscal"/>
+           <prop name="uri" class="remote" value="https://sample.com#content" ns="http://fedramp.gov/ns/oscal"/>
+           <prop name="connection-security" value="tls-1.3" ns="http://fedramp.gov/ns/oscal"/>
+           <link rel="uri" href="https://www.example.com#content"/-->
+           <status state="operational"/>
+           <responsible-role role-id="provider">
+              <party-uuid>44444444-2222-4000-8000-004000000001</party-uuid>
+           </responsible-role>
+           <responsible-role role-id="isa-poc-remote">
+              <party-uuid>11111111-2222-4000-8000-004000000008</party-uuid>
+           </responsible-role>
+           <responsible-role role-id="isa-poc-local">
+              <party-uuid>11111111-2222-4000-8000-004000000008</party-uuid>
+           </responsible-role>
+           <responsible-role role-id="administrator">
+              <prop name="privilege-uuid" value="11111111-2222-4000-8000-008000000004" ns="http://fedramp.gov/ns/oscal"/>
+              <party-uuid>11111111-2222-4000-8000-004000000010</party-uuid>
+              <party-uuid>11111111-2222-4000-8000-004000000011</party-uuid>
+              <party-uuid>11111111-2222-4000-8000-004000000012</party-uuid>
+           </responsible-role>
+        </component>
+   </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-interconnection-component-has-remote-protocol-INVALID.xml
+++ b/src/validations/constraints/content/ssp-interconnection-component-has-remote-protocol-INVALID.xml
@@ -3,44 +3,12 @@
 <system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="df903c4c-6bb5-4b78-8a71-c5baa06a9f2e">
    <system-implementation>
         <component uuid="11111111-2222-4000-8000-009000200002" type="interconnection">
-           <title>Authorized Connection Information System Name</title>
-           <description>
-              <p>Describe the purpose of the external system/service; specifically, provide reasons for connectivity (e.g., system monitoring, system alerting, download updates, etc.)</p>
-           </description>
-           <prop name="nature-of-agreement" value="contract" ns="http://fedramp.gov/ns/oscal"/>
-           <prop name="authentication-method" value="yes" ns="http://fedramp.gov/ns/oscal">
-              <remarks>
-                 <p>If 'yes', describe the authentication method in the remarks.</p>
-                 <p>If 'no', explain why no authentication is used in the remarks.</p>
-                 <p>If 'not-applicable', attest explain why authentication is not applicable in the remarks.</p>
-              </remarks>
-           </prop>
-           <prop name="information-type" class="incoming" value="C.3.5.1" ns="http://fedramp.gov/ns/oscal"/>
-           <prop name="information-type" class="incoming" value="C.3.5.8" ns="http://fedramp.gov/ns/oscal"/>
-           <prop name="ipv4-address" class="local" value="10.1.1.1"/>
-           <prop name="ipv6-address" class="local" value="::ffff:10.1.1.1"/>
-           <!--prop name="ipv4-address" class="remote" value="10.2.2.2"/>
-           <prop name="ipv6-address" class="remote" value="::ffff:10.2.2.2"/>
-           <prop name="fqdn" class="remote" value="www.example.com" ns="http://fedramp.gov/ns/oscal"/>
-           <prop name="uri" class="remote" value="https://sample.com#content" ns="http://fedramp.gov/ns/oscal"/>
-           <prop name="connection-security" value="tls-1.3" ns="http://fedramp.gov/ns/oscal"/>
-           <link rel="uri" href="https://www.example.com#content"/-->
-           <status state="operational"/>
-           <responsible-role role-id="provider">
-              <party-uuid>44444444-2222-4000-8000-004000000001</party-uuid>
-           </responsible-role>
-           <responsible-role role-id="isa-poc-remote">
-              <party-uuid>11111111-2222-4000-8000-004000000008</party-uuid>
-           </responsible-role>
-           <responsible-role role-id="isa-poc-local">
-              <party-uuid>11111111-2222-4000-8000-004000000008</party-uuid>
-           </responsible-role>
-           <responsible-role role-id="administrator">
-              <prop name="privilege-uuid" value="11111111-2222-4000-8000-008000000004" ns="http://fedramp.gov/ns/oscal"/>
-              <party-uuid>11111111-2222-4000-8000-004000000010</party-uuid>
-              <party-uuid>11111111-2222-4000-8000-004000000011</party-uuid>
-              <party-uuid>11111111-2222-4000-8000-004000000012</party-uuid>
-           </responsible-role>
+            <!-- Missing at least one remote IPv4 Address, IPv6 Address, URI, or FQDN. -->
+            <!--prop name="ipv4-address" class="remote" value="10.2.2.2"/-->
+            <!--prop name="ipv6-address" class="remote" value="::ffff:10.2.2.2"/-->
+            <!--prop name="fqdn" class="remote" value="dns.name"/-->
+            <!--prop name="uri" class="remote" value="uniform.resource.identifier"/-->
+            <!--link rel="uri" href="#11111111-2222-4000-8000-009000100001"/-->
         </component>
    </system-implementation>
 </system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -621,6 +621,11 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
                 <message>In a FedRAMP SSP, an interconnection component MUST have at least one local IPv4 Address, IPv6 Address, URI, or FQDN.</message>
             </expect>
+            <expect id="interconnection-component-has-remote-protocol" target="component[@type='interconnection']" test="count(prop[@class='remote' and @name=('ipv4-address','ipv6-address','fqdn','uri')] | link[@rel='uri']) &gt;= 1" level="ERROR">
+                <formal-name>Interconnection Component Has Remote Protocols</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/"/>
+                <message>In a FedRAMP SSP, an interconnection component MUST have at least one remote IPv4 Address, IPv6 Address, URI, or FQDN.</message>
+            </expect>
             <expect id="inventory-item-and-component-has-public" target="(inventory-item | component[@type='service' and prop[@name='implementation-point' and @value='internal']])" test="count(prop[@name='public']) = 1" level="ERROR">
                 <formal-name>Inventory Item and Component Has Public</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>

--- a/src/validations/constraints/unit-tests/interconnection-component-has-remote-protocol-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/interconnection-component-has-remote-protocol-FAIL.yaml
@@ -1,0 +1,8 @@
+# Driver for the invalid interconnection-component-has-remote-protocol constraint unit test.
+test-case:
+  name: The invalid interconnection-component-has-remote-protocol constraint unit test.
+  description: Test that the FedRAMP SSP interconnection component does not have remote IPv4 Address, IPv6 Address, URI, or FQDN.
+  content: ../content/ssp-interconnection-component-has-remote-protocol-INVALID.xml
+  expectations:
+  - constraint-id: interconnection-component-has-remote-protocol
+    result: fail

--- a/src/validations/constraints/unit-tests/interconnection-component-has-remote-protocol-PASS.yaml
+++ b/src/validations/constraints/unit-tests/interconnection-component-has-remote-protocol-PASS.yaml
@@ -1,0 +1,8 @@
+# Driver for the valid interconnection-component-has-remote-protocol constraint unit test.
+test-case:
+  name: The valid interconnection-component-has-remote-protocol constraint unit test.
+  description: Test that the FedRAMP SSP interconnection component has at least one remote IPv4 Address, IPv6 Address, URI, or FQDN.
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+  - constraint-id: interconnection-component-has-remote-protocol
+    result: pass


### PR DESCRIPTION
# Committer Notes

This constraint tests the following scenario:
An interconnection component has at least one remote IPv4 Address, IPv6 Address, URI, or FQDN.

_IMPORTANT:_ This constraint is blocked until OSCAL adds the following props:
1. `fqdn`
2. `uri`

Related issues:
1. [#930](https://github.com/GSA/fedramp-automation/issues/930)
3. [#2092](https://github.com/usnistgov/OSCAL/issues/2092)



### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
