### PR TITLE
Add `inventory-item-has-hardware-model` Constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -125,6 +125,7 @@ Examples:
   | inventory-item-allows-authenticated-scan |
   | inventory-item-and-component-has-public |
   | inventory-item-has-function |
+  | inventory-item-has-hardware-model |
   | inventory-item-has-scan-type |
   | inventory-item-has-software-name |
   | inventory-item-has-software-version |
@@ -392,6 +393,8 @@ Examples:
   | inventory-item-and-component-has-public-PASS.yaml |
   | inventory-item-has-function-FAIL.yaml |
   | inventory-item-has-function-PASS.yaml |
+  | inventory-item-has-hardware-model-FAIL.yaml |
+  | inventory-item-has-hardware-model-PASS.yaml |
   | inventory-item-has-scan-type-FAIL.yaml |
   | inventory-item-has-scan-type-PASS.yaml |
   | inventory-item-has-software-name-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -2310,6 +2310,7 @@ approved.</p>
       <description>
         <p>Legacy Example (No implemented-component).</p>
       </description>
+      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-01"/>
       <prop name="software-version" value="software-version"/>
       <prop name="ipv4-address" value="10.1.1.1"/>
@@ -2365,6 +2366,7 @@ approved.</p>
       <description>
         <p>Component Inventory Example</p>
       </description>
+      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-02"/>
       <prop name="ipv4-address" value="10.2.2.2"/>
       <prop name="ipv6-address" value="0000:0000:0000:0000:0000:ffff:0a02:0202"/>
@@ -2408,6 +2410,7 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
+      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-03"/>
       <prop name="asset-type" value="web-server"/>
       <prop name="virtual" value="yes"/>
@@ -2430,6 +2433,7 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
+      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-04"/>
       <prop name="asset-type" value="appliance"/>
       <prop name="virtual" value="yes"/>
@@ -2447,6 +2451,7 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
+      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-05"/>
       <prop name="asset-type" value="firewall"/>
       <prop name="ipv4-address" value="10.5.5.5"/>
@@ -2468,6 +2473,7 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
+      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-06"/>
       <prop name="ipv4-address" value="10.6.6.6"/>
       <prop name="ipv6-address" value="0000:0000:0000:0000:0000:ffff:0a06:0606"/>
@@ -2493,6 +2499,7 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
+      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-07"/>
       <prop name="asset-type" value="switch"/>
       <prop name="ipv4-address" value="10.7.7.7"/>
@@ -2513,6 +2520,7 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
+      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-08"/>
       <prop name="asset-type" value="web-server"/>
       <prop name="ipv4-address" value="10.8.8.8"/>
@@ -2537,6 +2545,7 @@ approved.</p>
       <description>
         <p>Email-Service</p>
       </description>
+      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-09"/>
       <prop name="asset-type" value="email-server"/>
       <prop name="ipv4-address" value="10.10.10.100"/>

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -2310,7 +2310,6 @@ approved.</p>
       <description>
         <p>Legacy Example (No implemented-component).</p>
       </description>
-      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-01"/>
       <prop name="software-version" value="software-version"/>
       <prop name="ipv4-address" value="10.1.1.1"/>
@@ -2366,7 +2365,6 @@ approved.</p>
       <description>
         <p>Component Inventory Example</p>
       </description>
-      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-02"/>
       <prop name="ipv4-address" value="10.2.2.2"/>
       <prop name="ipv6-address" value="0000:0000:0000:0000:0000:ffff:0a02:0202"/>
@@ -2410,7 +2408,6 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
-      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-03"/>
       <prop name="asset-type" value="web-server"/>
       <prop name="virtual" value="yes"/>
@@ -2433,7 +2430,6 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
-      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-04"/>
       <prop name="asset-type" value="appliance"/>
       <prop name="virtual" value="yes"/>
@@ -2451,7 +2447,6 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
-      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-05"/>
       <prop name="asset-type" value="firewall"/>
       <prop name="ipv4-address" value="10.5.5.5"/>
@@ -2499,7 +2494,6 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
-      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-07"/>
       <prop name="asset-type" value="switch"/>
       <prop name="ipv4-address" value="10.7.7.7"/>
@@ -2520,7 +2514,6 @@ approved.</p>
       <description>
         <p>None.</p>
       </description>
-      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-08"/>
       <prop name="asset-type" value="web-server"/>
       <prop name="ipv4-address" value="10.8.8.8"/>
@@ -2545,7 +2538,6 @@ approved.</p>
       <description>
         <p>Email-Service</p>
       </description>
-      <prop name="hardware-model" value="model"/>
       <prop name="asset-id" value="unique-asset-ID-09"/>
       <prop name="asset-type" value="email-server"/>
       <prop name="ipv4-address" value="10.10.10.100"/>

--- a/src/validations/constraints/content/ssp-inventory-item-has-hardware-model-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-has-hardware-model-INVALID.xml
@@ -1,7 +1,13 @@
 <system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
   <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000000007" type="hardware">
+      <prop name="asset-type" value="hardware"/>
+      <!-- <prop name="hardware-model" value="model"/> Missing "hardware-model" prop. -->
+    </component>
     <inventory-item uuid="11111111-2222-4000-8000-011000000001">
       <!-- <prop name="hardware-model" value="model"/> Missing "hardware-model" prop. -->
+      <implemented-component component-uuid="11111111-2222-4000-8000-009000000007">
+      </implemented-component>
     </inventory-item>
   </system-implementation>
 </system-security-plan>

--- a/src/validations/constraints/content/ssp-inventory-item-has-hardware-model-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-has-hardware-model-INVALID.xml
@@ -1,0 +1,7 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000001">
+      <!-- <prop name="hardware-model" value="model"/> Missing "hardware-model" prop. -->
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -692,6 +692,11 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>Every inventory-item MUST provide remarks to describe the function of the item, either within the inventory-item itself, or within the component linked by the inventory-item.</message>
             </expect>
+            <expect id="inventory-item-has-hardware-model" target="." test="count(prop[@name='hardware-model' ]) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name='hardware-model' ]) >= 1" level="ERROR">
+                <formal-name>Inventory Item Has Hardware Model</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item MUST provide the hardware model either in the inventory item itself or within the linked component.</message>
+            </expect>
             <expect id="inventory-item-has-scan-type" target="." test="count(prop[@name='scan-type' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count($implemented-component/prop[@name='scan-type' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
                 <formal-name>Inventory Item Has Scan Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -692,7 +692,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>Every inventory-item MUST provide remarks to describe the function of the item, either within the inventory-item itself, or within the component linked by the inventory-item.</message>
             </expect>
-            <expect id="inventory-item-has-hardware-model" target="." test="count(prop[@name='hardware-model' ]) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name='hardware-model' ]) >= 1" level="ERROR">
+            <expect id="inventory-item-has-hardware-model" target=".[../component[@uuid=$component-uuid and (@type='hardware' or prop[@name='asset-type' and @value='hardware'])] or prop[@name='asset-type' and @value='hardware']]" test="count(prop[@name='hardware-model' ]) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name='hardware-model' ]) >= 1" level="ERROR">
                 <formal-name>Inventory Item Has Hardware Model</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each inventory item MUST provide the hardware model either in the inventory item itself or within the linked component.</message>

--- a/src/validations/constraints/unit-tests/inventory-item-has-hardware-model-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-hardware-model-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-has-hardware-model
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-hardware-model
+  content: ../content/ssp-inventory-item-has-hardware-model-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-has-hardware-model
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-has-hardware-model-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-hardware-model-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-has-hardware-model
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-hardware-model
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-has-hardware-model
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `inventory-item-has-hardware-model` constraint which ensures that hardware model information is provided for hardware components / inventory items.

## Changes
Added constraint: 
- `inventory-item-has-hardware-model`

Added valid/invalid test content:
- `ssp-inventory-item-has-hardware-model-INVALID.xml`
- Edited `fedramp-ssp-example.oscal.xml` to align with constraint

Added yaml files for testing:
- Pass/fail yaml tests added for each of the above constraints. 

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
