### PR TITLE
Add `component-type` Allowed Values

### DIFF
--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -100,6 +100,8 @@
                 <enum value="this-system">The system as a whole.</enum>
                 <enum value="system">An external system, which may be a leveraged system or the other side of an interconnection.</enum>
                 <enum value="network">A physical or virtual network.</enum>
+                <enum value="client">A client that may use a service.</enum>
+                <enum value="connection">A logical connection between two or more network nodes.</enum>
             </allowed-values>
 
             <allowed-values id="connection-security" target="system-implementation/component/prop[@name='connection-security' and @ns='http://fedramp.gov/ns/oscal']/@value" allow-other="yes" level="WARNING">


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add allowed-values to the existing `component-type` constraint.

## Changes
- Added allowed values: 
`<enum value="client">A client that may use a service.</enum>`
`<enum value="connection">A logical connection between two or more network nodes.</enum>`

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
