### PR TITLE
Add `attachment-type` Allowed Values

### DIFF
--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -61,6 +61,7 @@
                 <enum value="privacy-impact-assessment">Privacy Impact Assessment</enum>
                 <enum value="information-system-contingency-plan">Information System Contingency Plan</enum>
                 <enum value="configuration-management-plan">configuration-management-plan</enum>
+                <enum value="fedramp-poam">A Plan of Action and Milestones represented either using the FedRAMP template or FedRAMP-compliant OSCAL.</enum>
                 <remarks>
                     <p>Not all values apply to all FedRAMP artifacts.</p>
                 </remarks>


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add allowed-values to the existing `attachment-type` constraint.

## Changes
- Added allowed values: 
`<enum value="fedramp-poam">A Plan of Action and Milestones represented either using the FedRAMP template or FedRAMP-compliant OSCAL.</enum>`

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
