### PR TITLE
Adjust Constraint Target For `inventory-item-has-vendor-name`

### DIFF
--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -2643,7 +2643,7 @@ SSP authors must add implmentations for all required controls.
           </description>
           <link href="#11111111-2222-4000-8000-001000000005" rel="policy"/>
           <link href="#11111111-2222-4000-8000-001000000023" rel="procedure"/>
-          <implementation-status state="operational"/>
+          <implementation-status state="implemented"/>
                     <responsible-role role-id="system-admin">
                         <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
                     </responsible-role>
@@ -2658,7 +2658,7 @@ SSP authors must add implmentations for all required controls.
             <p>Component approach. This links to a component representing the Identity Management and Access Control Policy.</p>
             <p>That component contains a link to the policy, so it does not have to be linked here too.</p>
           </description>
-          <implementation-status state="operational"/>
+          <implementation-status state="implemented"/>
                     <responsible-role role-id="system-admin">
                         <party-uuid>11111111-0000-4000-9000-000000000001</party-uuid>
                     </responsible-role>

--- a/src/validations/constraints/content/ssp-inventory-item-has-vendor-name-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-has-vendor-name-INVALID.xml
@@ -1,6 +1,6 @@
 <system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
   <system-implementation>
-    <component uuid="11111111-2222-4000-8000-009000000007" type="process-procedure">
+    <component uuid="11111111-2222-4000-8000-009000000007" type="software">
       <!-- <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/> Missing software-name in linked component-->
     </component>
     <inventory-item uuid="11111111-2222-4000-8000-011000000001">

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -724,7 +724,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each inventory item that has a MAC address MUST format the MAC address correctly.</message>
             </expect>
-            <expect id="inventory-item-has-vendor-name" target="." test="count(prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
+            <expect id="inventory-item-has-vendor-name" target=".[../component[@uuid=$component-uuid and @type=('hardware','software')]]" test="count(prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count(../component[@uuid=$component-uuid]/prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
                 <formal-name>Inventory Item Has Vendor Name</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each inventory item MUST include the vendor name in the inventory item itself or within the linked component.</message>


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to adjust the target for the `inventory-item-has-vendor-name` constraint per #1097.

## Changes
- Adjusted the constraint to only target inventory-items/components of type "hardware" or "software".

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ Not applicable.
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
