### PR TITLE
Profile fix issue 1102

### DIFF
--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="2ef3cdd1-6928-494b-b2ef-593e774fae38">
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="fb45bdae-dc80-49e3-b072-3820c6a143fe">
 	<metadata>
 		<title>FedRAMP Rev 5 High Baseline</title>
 		<published>2024-09-24T02:24:00Z</published>
-		<last-modified>2024-09-24T02:24:00Z</last-modified>
-		<version>fedramp2.1.0-oscal1.0.4</version>
-		<oscal-version>1.0.4</oscal-version>
+		<last-modified>2025-01-15T00:00:00Z</last-modified>
+		<version>fedramp-3.0.0rc1-oscal-1.1.2</version>
+		<oscal-version>1.1.2</oscal-version>
 		<role id="prepared-by">
 			<title>Document creator</title>
 		</role>
@@ -2873,17 +2873,17 @@
 		</alter>
 		<alter control-id="ac-2.3">
 			<add position="ending" by-id="ac-2.3_smt">
-				<part id="ac-2.3_fr" name="item">
+				<part id="ac-2.3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-2 (3) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-2.3_fr_smt.1" name="item">
+					<part id="ac-2.3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider defines the time period for non-user accounts (e.g., accounts associated with devices). The time periods are approved and accepted by the JAB/AO. Where user management is a function of the service, reports of activity of consumer users shall be made available.</p>
 					</part>
-					<part id="ac-2.3_fr_smt.2" name="item">
+					<part id="ac-2.3_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(d) Requirement:"/>
 						<p>The service provider defines the time period of inactivity for device identifiers.</p>
 					</part>
-					<part id="ac-2.3_fr_gdn.1" name="guidance">
+					<part id="ac-2.3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For DoD clouds, see DoD cloud website for specific DoD requirements that go above and beyond FedRAMP https://public.cyber.mil/dccs/.</p>
 					</part>
@@ -2940,9 +2940,9 @@
 		</alter>
 		<alter control-id="ac-2.5">
 			<add position="ending" by-id="ac-2.5_smt">
-				<part id="ac-2.5_fr" name="item">
+				<part id="ac-2.5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-2 (5) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-2.5_fr_gdn.1" name="guidance">
+					<part id="ac-2.5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Should use a shorter timeframe than AC-12.</p>
 					</part>
@@ -2999,9 +2999,9 @@
 		</alter>
 		<alter control-id="ac-2.9">
 			<add position="ending" by-id="ac-2.9_smt">
-				<part id="ac-2.9_fr" name="item">
+				<part id="ac-2.9_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-2 (9) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-2.9_fr_smt.1" name="item">
+					<part id="ac-2.9_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Required if shared/group accounts are deployed.</p>
 					</part>
@@ -3021,13 +3021,13 @@
 		</alter>
 		<alter control-id="ac-2.12">
 			<add position="ending" by-id="ac-2.12_smt">
-				<part id="ac-2.12_fr" name="item">
+				<part id="ac-2.12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-2 (12) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-2.12_fr_smt.1" name="item">
+					<part id="ac-2.12_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>Required for privileged accounts.</p>
 					</part>
-					<part id="ac-2.12_fr_smt.2" name="item">
+					<part id="ac-2.12_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
 						<p>Required for privileged accounts.</p>
 					</part>
@@ -3168,9 +3168,9 @@
 		</alter>
 		<alter control-id="ac-4.4">
 			<add position="ending" by-id="ac-4.4_smt">
-				<part id="ac-4.4_fr" name="item">
+				<part id="ac-4.4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-4 (4) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-4.4_fr_smt.1" name="item">
+					<part id="ac-4.4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider must support Agency requirements to comply with M-21-31 (https://www.whitehouse.gov/wp-content/uploads/2021/08/M-21-31-Improving-the-Federal-Governments-Investigative-and-Remediation-Capabilities-Related-to-Cybersecurity-Incidents.pdf) and M-22-09 (https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf).</p>
 					</part>
@@ -3187,9 +3187,9 @@
 		</alter>
 		<alter control-id="ac-5">
 			<add position="ending" by-id="ac-5_smt">
-				<part id="ac-5_fr" name="item">
+				<part id="ac-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-5 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-5_fr_gdn.1" name="guidance">
+					<part id="ac-5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>CSPs have the option to provide a separation of duties matrix as an attachment to the SSP.</p>
 					</part>
@@ -3256,9 +3256,9 @@
 		</alter>
 		<alter control-id="ac-6.2">
 			<add position="ending" by-id="ac-6.2_smt">
-				<part id="ac-6.2_fr" name="item">
+				<part id="ac-6.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-6 (2) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-6.2_fr_gdn.1" name="guidance">
+					<part id="ac-6.2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Examples of security functions include but are not limited to: establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters, system programming, system and security administration, other privileged functions.</p>
 					</part>
@@ -3349,9 +3349,9 @@
 		</alter>
 		<alter control-id="ac-7">
 			<add position="ending" by-id="ac-7_smt">
-				<part id="ac-7_fr" name="item">
+				<part id="ac-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-7 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-7_fr_smt.1" name="item">
+					<part id="ac-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>In alignment with NIST SP 800-63B.</p>
 					</part>
@@ -3376,21 +3376,21 @@
 		</alter>
 		<alter control-id="ac-8">
 			<add position="ending" by-id="ac-8_smt">
-				<part id="ac-8_fr" name="item">
+				<part id="ac-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-8_fr_smt.1" name="item">
+					<part id="ac-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider shall determine elements of the cloud environment that require the System Use Notification control. The elements of the cloud environment that require System Use Notification are approved and accepted by the JAB/AO.</p>
 					</part>
-					<part id="ac-8_fr_smt.2" name="item">
+					<part id="ac-8_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider shall determine how System Use Notification is going to be verified and provide appropriate periodicity of the check. The System Use Notification verification and periodicity are approved and accepted by the JAB/AO.</p>
 					</part>
-					<part id="ac-8_fr_smt.3" name="item">
+					<part id="ac-8_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>If not performed as part of a Configuration Baseline check, then there must be documented agreement on how to provide results of verification and the necessary periodicity of the verification by the service provider. The documented agreement on how to provide verification of the results are approved and accepted by the JAB/AO.</p>
 					</part>
-					<part id="ac-8_fr_gdn.1" name="guidance">
+					<part id="ac-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>If performed as part of a Configuration Baseline check, then the % of items requiring setting that are checked and that pass (or fail) check can be provided.</p>
 					</part>
@@ -3438,9 +3438,9 @@
 		</alter>
 		<alter control-id="ac-20">
 			<add position="ending" by-id="ac-20_smt">
-				<part id="ac-20_fr" name="item">
+				<part id="ac-20_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-20 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-20_fr_gdn.1" name="guidance">
+					<part id="ac-20_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The interrelated controls of AC-20, CA-3, and SA-9 should be differentiated as follows:</p>
 						<p>AC-20 describes system access to and from external systems.</p>
@@ -3767,13 +3767,13 @@
 		</alter>
 		<alter control-id="au-2">
 			<add position="ending" by-id="au-2_smt">
-				<part id="au-2_fr" name="item">
+				<part id="au-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AU-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="au-2_fr_smt.1" name="item">
+					<part id="au-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Coordination between service provider and consumer shall be documented and accepted by the JAB/AO.</p>
 					</part>
-					<part id="au-2_fr_gdn.1" name="guidance">
+					<part id="au-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Guidance:"/>
 						<p>Annually or whenever changes in the threat environment are communicated to the service provider by the JAB/AO.</p>
 					</part>
@@ -3856,9 +3856,9 @@
 		</alter>
 		<alter control-id="au-3.1">
 			<add position="ending" by-id="au-3.1_smt">
-				<part id="au-3.1_fr" name="item">
+				<part id="au-3.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AU-3 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="au-3.1_fr_gdn.1" name="guidance">
+					<part id="au-3.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For client-server transactions, the number of bytes sent and received gives bidirectional transfer information that can be helpful during an investigation or inquiry.</p>
 					</part>
@@ -3938,9 +3938,9 @@
 		</alter>
 		<alter control-id="au-6">
 			<add position="ending" by-id="au-6_smt">
-				<part id="au-6_fr" name="item">
+				<part id="au-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AU-6 Additional FedRAMP Requirements and Guidance</title>
-					<part id="au-6_fr_smt.1" name="item">
+					<part id="au-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Coordination between service provider and consumer shall be documented and accepted by the JAB/AO. In multi-tenant environments, capability and means for providing review, analysis, and reporting to consumer for data pertaining to consumer shall be documented.</p>
 					</part>
@@ -4028,9 +4028,9 @@
 		</alter>
 		<alter control-id="au-6.6">
 			<add position="ending" by-id="au-6.6_smt">
-				<part id="au-6.6_fr" name="item">
+				<part id="au-6.6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AU-6 (6) Additional FedRAMP Requirements and Guidance</title>
-					<part id="au-6.6_fr_smt.1" name="item">
+					<part id="au-6.6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Coordination between service provider and consumer shall be documented and accepted by the JAB/AO.</p>
 					</part>
@@ -4141,9 +4141,9 @@
 		</alter>
 		<alter control-id="au-9.3">
 			<add position="ending" by-id="au-9.3_smt">
-				<part id="au-9.3_fr" name="item">
+				<part id="au-9.3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AU-9 (3) Additional FedRAMP Requirements and Guidance</title>
-					<part id="au-9.3_fr_gdn.1" name="guidance">
+					<part id="au-9.3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Note that this enhancement requires the use of cryptography which must be compliant with Federal requirements and utilize FIPS validated or NSA approved cryptography (see SC-13.)</p>
 					</part>
@@ -4160,17 +4160,17 @@
 		</alter>
 		<alter control-id="au-11">
 			<add position="ending" by-id="au-11_smt">
-				<part id="au-11_fr" name="item">
+				<part id="au-11_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AU-11 Additional FedRAMP Requirements and Guidance</title>
-					<part id="au-11_fr_smt.1" name="item">
+					<part id="au-11_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider retains audit records on-line for at least ninety days and further preserves audit records off-line for a period that is in accordance with NARA requirements.</p>
 					</part>
-					<part id="au-11_fr_smt.2" name="item">
+					<part id="au-11_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider must support Agency requirements to comply with M-21-31 (https://www.whitehouse.gov/wp-content/uploads/2021/08/M-21-31-Improving-the-Federal-Governments-Investigative-and-Remediation-Capabilities-Related-to-Cybersecurity-Incidents.pdf)</p>
 					</part>
-					<part id="au-11_fr_gdn.1" name="guidance">
+					<part id="au-11_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The service provider is encouraged to align with M-21-31 where possible</p>
 					</part>
@@ -4256,9 +4256,9 @@
 		</alter>
 		<alter control-id="ca-2">
 			<add position="ending" by-id="ca-2_smt">
-				<part id="ca-2_fr" name="item">
+				<part id="ca-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-2_fr_gdn.1" name="guidance">
+					<part id="ca-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Reference FedRAMP Annual Assessment Guidance.</p>
 					</part>
@@ -4322,9 +4322,9 @@
 		</alter>
 		<alter control-id="ca-2.1">
 			<add position="ending" by-id="ca-2.1_smt">
-				<part id="ca-2.1_fr" name="item">
+				<part id="ca-2.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-2 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-2.1_fr_smt.1" name="item">
+					<part id="ca-2.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>For JAB Authorization, must use an accredited 3PAO.</p>
 					</part>
@@ -4341,9 +4341,9 @@
 		</alter>
 		<alter control-id="ca-2.2">
 			<add position="ending" by-id="ca-2.2_smt">
-				<part id="ca-2.2_fr" name="item">
+				<part id="ca-2.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-2 (2) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-2.2_fr_smt.1" name="item">
+					<part id="ca-2.2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>To include 'announced', 'vulnerability scanning'</p>
 					</part>
@@ -4405,13 +4405,13 @@
 		</alter>
 		<alter control-id="ca-5">
 			<add position="ending" by-id="ca-5_smt">
-				<part id="ca-5_fr" name="item">
+				<part id="ca-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-5 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-5_fr_smt.1" name="item">
+					<part id="ca-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>POA&amp;Ms must be provided at least monthly.</p>
 					</part>
-					<part id="ca-5_fr_gdn.1" name="guidance">
+					<part id="ca-5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Reference FedRAMP-POAM-Template</p>
 					</part>
@@ -4436,9 +4436,9 @@
 		</alter>
 		<alter control-id="ca-6">
 			<add position="ending" by-id="ca-6_smt">
-				<part id="ca-6_fr" name="item">
+				<part id="ca-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-6 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-6_fr_gdn.1" name="guidance">
+					<part id="ca-6_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Guidance:"/>
 						<p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F and according to FedRAMP Significant Change Policies and Procedures. The service provider describes the types of changes to the information system or the environment of operations that would impact the risk posture. The types of changes are approved and accepted by the JAB/AO.</p>
 					</part>
@@ -4491,17 +4491,17 @@
 		</alter>
 		<alter control-id="ca-7">
 			<add position="ending" by-id="ca-7_smt">
-				<part id="ca-7_fr" name="item">
+				<part id="ca-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-7 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-7_fr_smt.1" name="item">
+					<part id="ca-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Operating System, Database, Web Application, Container, and Service Configuration Scans: at least monthly. All scans performed by Independent Assessor: at least annually.</p>
 					</part>
-					<part id="ca-7_fr_smt.2" name="item">
+					<part id="ca-7_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSOs with more than one agency ATO must implement a collaborative Continuous Monitoring (ConMon) approach described in the FedRAMP Guide for Multi-Agency Continuous Monitoring. This requirement applies to CSOs authorized via the Agency path as each agency customer is responsible for performing ConMon oversight. It does not apply to CSOs authorized via the JAB path because the JAB performs ConMon oversight.</p>
 					</part>
-					<part id="ca-7_fr_gdn.1" name="guidance">
+					<part id="ca-7_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>FedRAMP does not provide a template for the Continuous Monitoring Plan. CSPs should reference the FedRAMP Continuous Monitoring Strategy Guide when developing the Continuous Monitoring Plan.</p>
 					</part>
@@ -4617,9 +4617,9 @@
 		</alter>
 		<alter control-id="ca-8">
 			<add position="ending" by-id="ca-8_smt">
-				<part id="ca-8_fr" name="item">
+				<part id="ca-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-8_fr_gdn.1" name="guidance">
+					<part id="ca-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Reference the FedRAMP Penetration Test Guidance.</p>
 					</part>
@@ -4646,9 +4646,9 @@
 		</alter>
 		<alter control-id="ca-8.2">
 			<add position="ending" by-id="ca-8.2_smt">
-				<part id="ca-8.2_fr" name="item">
+				<part id="ca-8.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-8(2) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-8.2_fr_gdn.1" name="guidance">
+					<part id="ca-8.2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See the FedRAMP Documents page&gt; Penetration Test Guidance</p>
 						<p>https://www.FedRAMP.gov/documents/</p>
@@ -4809,9 +4809,9 @@
 		</alter>
 		<alter control-id="cm-2">
 			<add position="ending" by-id="cm-2_smt">
-				<part id="cm-2_fr" name="item">
+				<part id="cm-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-2_fr_gdn.1" name="guidance">
+					<part id="cm-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b)(1) Guidance:"/>
 						<p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F.</p>
 					</part>
@@ -4882,13 +4882,13 @@
 		</alter>
 		<alter control-id="cm-3">
 			<add position="ending" by-id="cm-3_smt">
-				<part id="cm-3_fr" name="item">
+				<part id="cm-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-3 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-3_fr_smt.1" name="item">
+					<part id="cm-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider establishes a central means of communicating major changes to or developments in the information system or environment of operations that may affect its services to the federal government and associated service consumers (e.g., electronic bulletin board, web status page). The means of communication are approved and accepted by the JAB/AO.</p>
 					</part>
-					<part id="cm-3_fr_gdn.1" name="guidance">
+					<part id="cm-3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Guidance:"/>
 						<p>In accordance with record retention policies and procedures.</p>
 					</part>
@@ -5153,17 +5153,17 @@
 		</alter>
 		<alter control-id="cm-6">
 			<add position="ending" by-id="cm-6_smt">
-				<part id="cm-6_fr" name="item">
+				<part id="cm-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-6 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-6_fr_smt.1" name="item">
+					<part id="cm-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement 1:"/>
 						<p>The service provider shall use the DoD STIGs to establish configuration settings; Center for Internet Security up to Level 2 (CIS Level 2) guidelines shall be used if STIGs are not available; Custom baselines shall be used if CIS is not available.</p>
 					</part>
-					<part id="cm-6_fr_smt.2" name="item">
+					<part id="cm-6_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement 2:"/>
 						<p>The service provider shall ensure that checklists for configuration settings are Security Content Automation Protocol (SCAP) validated or SCAP compatible (if validated checklists are not available).</p>
 					</part>
-					<part id="cm-6_fr_gdn.1" name="guidance">
+					<part id="cm-6_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Compliance checks are used to evaluate configuration settings and provide general insight into the overall effectiveness of configuration management activities. CSPs and 3PAOs typically combine compliance check findings into a single CM-6 finding, which is acceptable. However, for initial assessments, annual assessments, and significant change requests, FedRAMP requires a clear understanding, on a per-control basis, where risks exist. Therefore, 3PAOs must also analyze compliance check findings as part of the controls assessment. Where a direct mapping exists, the 3PAO must document additional findings per control in the corresponding SAR Risk Exposure Table (RET), which are then documented in the CSP's Plan of Action and Milestones (POA&amp;M). This will likely result in the details of individual control findings overlapping with those in the combined CM-6 finding, which is acceptable.</p>
 						<p>During monthly continuous monitoring, new findings from CSP compliance checks may be combined into a single CM-6 POA&amp;M item. CSPs are not required to map the findings to specific controls because controls are only assessed during initial assessments, annual assessments, and significant change requests.</p>
@@ -5232,9 +5232,9 @@
 		</alter>
 		<alter control-id="cm-7">
 			<add position="ending" by-id="cm-7_smt">
-				<part id="cm-7_fr" name="item">
+				<part id="cm-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-7 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-7_fr_smt.1" name="item">
+					<part id="cm-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
 						<p>The service provider shall use Security guidelines (See CM-6) to establish list of prohibited or restricted functions, ports, protocols, and/or services or establishes its own list of prohibited or restricted functions, ports, protocols, and/or services if STIGs or CIS is not available.</p>
 					</part>
@@ -5282,9 +5282,9 @@
 		</alter>
 		<alter control-id="cm-7.2">
 			<add position="ending" by-id="cm-7.2_smt">
-				<part id="cm-7.2_fr" name="item">
+				<part id="cm-7.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-7 (2) Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-7.2_fr_gdn.1" name="guidance">
+					<part id="cm-7.2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>This control refers to software deployment by CSP personnel into the production environment. The control requires a policy that states conditions for deploying software. This control shall be implemented in a technical manner on the information system to only allow programs to run that adhere to the policy (i.e. allow-listing). This control is not to be based off of strictly written policy on what is allowed or not allowed to run.</p>
 					</part>
@@ -5331,9 +5331,9 @@
 		</alter>
 		<alter control-id="cm-8">
 			<add position="ending" by-id="cm-8_smt">
-				<part id="cm-8_fr" name="item">
+				<part id="cm-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-8_fr_smt.1" name="item">
+					<part id="cm-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>must be provided at least monthly or when there is a change.</p>
 					</part>
@@ -5427,7 +5427,7 @@
 		</alter>
 		<alter control-id="cm-9">
 			<add position="ending" by-id="cm-9_smt">
-				<part id="cm-9_fr_gdn.1" name="guidance">
+				<part id="cm-9_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 					<prop name="label" value="Guidance:"/>
 					<p>FedRAMP does not provide a template for the Configuration Management Plan. However, NIST SP 800-128, Guide for Security-Focused Configuration Management of Information Systems, provides guidelines for the implementation of CM controls as well as a sample CMP outline in Appendix D of the Guide</p>
 				</part>
@@ -5484,9 +5484,9 @@
 		</alter>
 		<alter control-id="cm-12">
 			<add position="ending" by-id="cm-12_smt">
-				<part id="cm-12_fr" name="item">
+				<part id="cm-12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-12 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-12_fr_smt.1" name="item">
+					<part id="cm-12_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>According to FedRAMP Authorization Boundary Guidance</p>
 					</part>
@@ -5529,9 +5529,9 @@
 		</alter>
 		<alter control-id="cm-12.1">
 			<add position="ending" by-id="cm-12.1_smt">
-				<part id="cm-12.1_fr" name="item">
+				<part id="cm-12.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-12 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-12.1_fr_smt.1" name="item">
+					<part id="cm-12.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>According to FedRAMP Authorization Boundary Guidance.</p>
 					</part>
@@ -5547,7 +5547,7 @@
 		</alter>
 		<alter control-id="cm-14">
 			<add position="ending" by-id="cm-14_smt">
-				<part id="cm-14_fr_gdn.1" name="guidance">
+				<part id="cm-14_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 					<prop name="label" value="Guidance:"/>
 					<p>If digital signatures/certificates are unavailable, alternative cryptographic integrity checks (hashes, self-signed certs, etc.) can be utilized.</p>
 				</part>
@@ -5652,13 +5652,13 @@
 		</alter>
 		<alter control-id="cp-2">
 			<add position="ending" by-id="cp-2_smt">
-				<part id="cp-2_fr" name="item">
+				<part id="cp-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-2_fr_smt.1" name="item">
+					<part id="cp-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>For JAB authorizations the contingency lists include designated FedRAMP personnel.</p>
 					</part>
-					<part id="cp-2_fr_smt.2" name="item">
+					<part id="cp-2_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSPs must use the FedRAMP Information System Contingency Plan (ISCP) Template (available on the fedramp.gov: https://www.fedramp.gov/assets/resources/templates/SSP-A06-FedRAMP-ISCP-Template.docx).</p>
 					</part>
@@ -5824,9 +5824,9 @@
 		</alter>
 		<alter control-id="cp-3">
 			<add position="ending" by-id="cp-3_smt">
-				<part id="cp-3_fr" name="item">
+				<part id="cp-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-3 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-3_fr_smt.1" name="item">
+					<part id="cp-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>Privileged admins and engineers must take the basic contingency training within 10 days. Consideration must be given for those privileged admins and engineers with critical contingency-related roles, to gain enough system context and situational awareness to understand the full impact of contingency training as it applies to their respective level. Newly hired critical contingency personnel must take this more in-depth training within 60 days of hire date when the training will have more impact.</p>
 					</part>
@@ -5877,13 +5877,13 @@
 		</alter>
 		<alter control-id="cp-4">
 			<add position="ending" by-id="cp-4_smt">
-				<part id="cp-4_fr" name="item">
+				<part id="cp-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-4 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-4_fr_smt.1" name="item">
+					<part id="cp-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider develops test plans in accordance with NIST Special Publication 800-34 (as amended); plans are approved by the JAB/AO prior to initiating testing.</p>
 					</part>
-					<part id="cp-4_fr_smt.1" name="item">
+					<part id="cp-4_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
 						<p>The service provider must include the Contingency Plan test results with the security package within the Contingency Plan-designated appendix (Appendix G, Contingency Plan Test Report).</p>
 					</part>
@@ -6026,9 +6026,9 @@
 		</alter>
 		<alter control-id="cp-7">
 			<add position="ending" by-id="cp-7_smt">
-				<part id="cp-7_fr" name="item">
+				<part id="cp-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-7 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-7_fr_smt.1" name="item">
+					<part id="cp-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider defines a time period consistent with the recovery time objectives and business impact analysis.</p>
 					</part>
@@ -6070,9 +6070,9 @@
 		</alter>
 		<alter control-id="cp-7.1">
 			<add position="ending" by-id="cp-7.1_smt">
-				<part id="cp-7.1_fr" name="item">
+				<part id="cp-7.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-7 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-7.1_fr_smt.1" name="guidance">
+					<part id="cp-7.1_fr_smt.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The service provider may determine what is considered a sufficient degree of separation between the primary and alternate processing sites, based on the types of threats that are of concern. For one particular type of threat (i.e., hostile cyber attack), the degree of separation between sites will be less relevant.</p>
 					</part>
@@ -6125,9 +6125,9 @@
 		</alter>
 		<alter control-id="cp-8">
 			<add position="ending" by-id="cp-8_smt">
-				<part id="cp-8_fr" name="item">
+				<part id="cp-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-8_fr_gdn.1" name="item">
+					<part id="cp-8_fr_gdn.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider defines a time period consistent with the recovery time objectives and business impact analysis.</p>
 					</part>
@@ -6211,21 +6211,21 @@
 		</alter>
 		<alter control-id="cp-9">
 			<add position="ending" by-id="cp-9_smt">
-				<part id="cp-9_fr" name="item">
+				<part id="cp-9_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-9 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-9_fr_smt.1" name="item">
+					<part id="cp-9_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider shall determine what elements of the cloud environment require the Information System Backup control. The service provider shall determine how Information System Backup is going to be verified and appropriate periodicity of the check.</p>
 					</part>
-					<part id="cp-9_fr_smt.2" name="item">
+					<part id="cp-9_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider maintains at least three backup copies of user-level information (at least one of which is available online) or provides an equivalent alternative.</p>
 					</part>
-					<part id="cp-9_fr_smt.3" name="item">
+					<part id="cp-9_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
 						<p>The service provider maintains at least three backup copies of system-level information (at least one of which is available online) or provides an equivalent alternative.</p>
 					</part>
-					<part id="cp-9_fr_smt.4" name="item">
+					<part id="cp-9_fr_smt.4" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(c) Requirement:"/>
 						<p>The service provider maintains at least three backup copies of information system documentation including security information (at least one of which is available online) or provides an equivalent alternative.</p>
 					</part>
@@ -6318,9 +6318,9 @@
 		</alter>
 		<alter control-id="cp-9.8">
 			<add position="ending" by-id="cp-9.8_smt">
-				<part id="cp-9.8_fr" name="item">
+				<part id="cp-9.8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-9 (8) Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-9.8_fr_gdn.1" name="guidance">
+					<part id="cp-9.8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Note that this enhancement requires the use of cryptography which must be compliant with Federal requirements and utilize FIPS validated or NSA approved cryptography (see SC-13.)</p>
 					</part>
@@ -6425,21 +6425,21 @@
 		</alter>
 		<alter control-id="ia-2">
 			<add position="ending" by-id="ia-2_smt">
-				<part id="ia-2_fr" name="item">
+				<part id="ia-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-2_fr_smt.1" name="item">
+					<part id="ia-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>For all control enhancements that specify multifactor authentication, the implementation must adhere to the Digital Identity Guidelines specified in NIST Special Publication 800-63B.</p>
 					</part>
-					<part id="ia-2_fr_smt.2" name="item">
+					<part id="ia-2_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Multi-factor authentication must be phishing-resistant.</p>
 					</part>
-					<part id="ia-2_fr_smt.3" name="item">
+					<part id="ia-2_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>All uses of encrypted virtual private networks must meet all applicable Federal requirements and architecture, dataflow, and security and privacy controls must be documented, assessed, and authorized to operate.</p>
 					</part>
-					<part id="ia-2_fr_gdn.1" name="guidance">
+					<part id="ia-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>&quot;Phishing-resistant&quot; authentication refers to authentication processes designed to detect and prevent disclosure of authentication secrets and outputs to a website or application masquerading as a legitimate system.</p>
 					</part>
@@ -6466,17 +6466,17 @@
 		</alter>
 		<alter control-id="ia-2.1">
 			<add position="ending" by-id="ia-2.1_smt">
-				<part id="ia-2.1_fr" name="item">
+				<part id="ia-2.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-2 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-2.1_fr_smt.1" name="item">
+					<part id="ia-2.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>According to SP 800-63-3, SP 800-63A (IAL), SP 800-63B (AAL), and SP 800-63C (FAL).</p>
 					</part>
-					<part id="ia-2.1_fr_smt.2" name="item">
+					<part id="ia-2.1_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Multi-factor authentication must be phishing-resistant.</p>
 					</part>
-					<part id="ia-2.1_fr_gdn.1" name="guidance">
+					<part id="ia-2.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Multi-factor authentication to subsequent components in the same user domain is not required.</p>
 					</part>
@@ -6495,17 +6495,17 @@
 		</alter>
 		<alter control-id="ia-2.2">
 			<add position="ending" by-id="ia-2.2_smt">
-				<part id="ia-2.2_fr" name="item">
+				<part id="ia-2.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-2 (2) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-2.2_fr_smt.1" name="item">
+					<part id="ia-2.2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>According to SP 800-63-3, SP 800-63A (IAL), SP 800-63B (AAL), and SP 800-63C (FAL).</p>
 					</part>
-					<part id="ia-2.2_fr_smt.2" name="item">
+					<part id="ia-2.2_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Multi-factor authentication must be phishing-resistant.</p>
 					</part>
-					<part id="ia-2.2_fr_gdn.1" name="guidance">
+					<part id="ia-2.2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Multi-factor authentication to subsequent components in the same user domain is not required.</p>
 					</part>
@@ -6536,13 +6536,13 @@
 		</alter>
 		<alter control-id="ia-2.6">
 			<add position="ending" by-id="ia-2.6_smt">
-				<part id="ia-2.6_fr" name="item">
+				<part id="ia-2.6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-2 (6) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-2.6_fr_gdn.1" name="guidance">
+					<part id="ia-2.6_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>PIV=separate device. Please refer to NIST SP 800-157 Guidelines for Derived Personal Identity Verification (PIV) Credentials.</p>
 					</part>
-					<part id="ia-2.6_fr_gdn.2" name="guidance">
+					<part id="ia-2.6_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See SC-13 Guidance for more information on FIPS-validated or NSA-approved cryptography.</p>
 					</part>
@@ -6570,9 +6570,9 @@
 		</alter>
 		<alter control-id="ia-2.12">
 			<add position="ending" by-id="ia-2.12_smt">
-				<part id="ia-2.12_fr" name="item">
+				<part id="ia-2.12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-2 (12) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-2.12_fr_gdn.1" name="guidance">
+					<part id="ia-2.12_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Include Common Access Card (CAC), i.e., the DoD technical implementation of PIV/FIPS 201/HSPD-12.</p>
 					</part>
@@ -6662,13 +6662,13 @@
 		</alter>
 		<alter control-id="ia-5">
 			<add position="ending" by-id="ia-5_smt">
-				<part id="ia-5_fr" name="item">
+				<part id="ia-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-5 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-5_fr_smt.1" name="item">
+					<part id="ia-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Authenticators must be compliant with NIST SP 800-63-3 Digital Identity Guidelines IAL, AAL, FAL level 3. Link https://pages.nist.gov/800-63-3</p>
 					</part>
-					<part id="ia-5_fr_gdn.1" name="guidance">
+					<part id="ia-5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>SP 800-63C Section 6.2.3 Encrypted Assertion requires that authentication assertions be encrypted when passed through third parties, such as a browser. For example, a SAML assertion can be encrypted using XML-Encryption, or an OpenID Connect ID Token can be encrypted using JSON Web Encryption (JWE).</p>
 					</part>
@@ -6757,18 +6757,18 @@
 		</alter>
 		<alter control-id="ia-5.1">
 			<add position="ending" by-id="ia-5.1_smt">
-				<part id="ia-5.1_fr" name="item">
+				<part id="ia-5.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-5 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-5.1_fr_smt.1" name="item">
+					<part id="ia-5.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Password policies must be compliant with NIST SP 800-63B for all memorized, lookup, out-of-band, or One-Time-Passwords (OTP). Password policies shall not enforce special character or minimum password rotation requirements for memorized secrets of users.</p>
 					</part>
-					<part id="ia-5.1_fr_smt.2" name="item">
+					<part id="ia-5.1_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(h) Requirement:"/>
 						<p>For cases where technology doesn't allow multi-factor authentication, these rules should be enforced: must have a minimum length of 14 characters and must support all printable ASCII characters.</p>
 						<p>For emergency use accounts, these rules should be enforced: must have a minimum length of 14 characters, must support all printable ASCII characters, and passwords must be changed if used.</p>
 					</part>
-					<part id="ia-5.1_fr_gdn.1" name="guidance">
+					<part id="ia-5.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Note that (c) and (d) require the use of cryptography which must be compliant with Federal requirements and utilize FIPS validated or NSA approved cryptography (see SC-13).</p>
 					</part>
@@ -6869,9 +6869,9 @@
 		</alter>
 		<alter control-id="ia-5.7">
 			<add position="ending" by-id="ia-5.7_smt">
-				<part id="ia-5.7_fr" name="item">
+				<part id="ia-5.7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-5 (7) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-5.7_fr_gdn.1" name="guidance">
+					<part id="ia-5.7_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>In this context, prohibited static storage refers to any storage where unencrypted authenticators, such as passwords, persist beyond the time required to complete the access process.</p>
 					</part>
@@ -6887,9 +6887,9 @@
 		</alter>
 		<alter control-id="ia-5.8">
 			<add position="ending" by-id="ia-5.8_smt">
-				<part id="ia-5.8_fr" name="item">
+				<part id="ia-5.8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-5 (8) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-5.8_fr_gdn.x" name="guidance">
+					<part id="ia-5.8_fr_gdn.x" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>If a single user authentication domain is used to access multiple systems, such as in single-sign-on, then only a single authenticator is required.</p>
 					</part>
@@ -6906,9 +6906,9 @@
 		</alter>
 		<alter control-id="ia-5.13">
 			<add position="ending" by-id="ia-5.13_smt">
-				<part id="ia-5.13_fr" name="item">
+				<part id="ia-5.13_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-5 (13) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-5.13_fr_gdn.1" name="guidance">
+					<part id="ia-5.13_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For components subject to configuration baseline(s) (such as STIG or CIS,) the time period should conform to the baseline standard.</p>
 					</part>
@@ -6925,9 +6925,9 @@
 		</alter>
 		<alter control-id="ia-11">
 			<add position="ending" by-id="ia-11_smt">
-				<part id="ia-11_fr" name="item">
+				<part id="ia-11_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-11 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-11_fr_gdn.1" name="guidance">
+					<part id="ia-11_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The fixed time period cannot exceed the limits set in SP 800-63. At this writing they are:</p>
 						<ul>
@@ -6952,9 +6952,9 @@
 		</alter>
 		<alter control-id="ia-12">
 			<add position="ending" by-id="ia-12_smt">
-				<part id="ia-12_fr" name="item">
+				<part id="ia-12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-12 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-12_fr_gdn.1" name="guidance">
+					<part id="ia-12_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>In accordance with NIST SP 800-63A Enrollment and Identity Proofing</p>
 					</part>
@@ -6988,9 +6988,9 @@
 		</alter>
 		<alter control-id="ia-12.5">
 			<add position="ending" by-id="ia-12.5_smt">
-				<part id="ia-12.5_fr" name="item">
+				<part id="ia-12.5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-12 (5) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-12.5_fr_gdn.1" name="guidance">
+					<part id="ia-12.5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>In accordance with NIST SP 800-63A Enrollment and Identity Proofing</p>
 					</part>
@@ -7181,9 +7181,9 @@
 		</alter>
 		<alter control-id="ir-3">
 			<add position="ending" by-id="ir-3_smt">
-				<part id="ir-3_fr" name="item">
+				<part id="ir-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IR-3-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ir-3_fr_smt.1" name="item">
+					<part id="ir-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider defines tests and/or exercises in accordance with NIST Special Publication 800-61 (as amended). Functional testing must occur prior to testing for initial authorization. Annual functional testing may be concurrent with required penetration tests (see CA-8). The service provider provides test plans to the JAB/AO annually. Test plans are approved and accepted by the JAB/AO prior to test commencing.</p>
 					</part>
@@ -7213,13 +7213,13 @@
 		</alter>
 		<alter control-id="ir-4">
 			<add position="ending" by-id="ir-4_smt">
-				<part id="ir-4_fr" name="item">
+				<part id="ir-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IR-4 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ir-4_fr_smt.1" name="item">
+					<part id="ir-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The FISMA definition of &quot;incident&quot; shall be used: &quot;An occurrence that actually or imminently jeopardizes, without lawful authority, the confidentiality, integrity, or availability of information or an information system; or constitutes a violation or imminent threat of violation of law, security policies, security procedures, or acceptable use policies.&quot;</p>
 					</part>
-					<part id="ir-4_fr_smt.2" name="item">
+					<part id="ir-4_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider ensures that individuals conducting incident handling meet personnel security requirements commensurate with the criticality/sensitivity of the information being processed, stored, and transmitted by the information system.</p>
 					</part>
@@ -7361,9 +7361,9 @@
 		</alter>
 		<alter control-id="ir-6">
 			<add position="ending" by-id="ir-6_smt">
-				<part id="ir-6_fr" name="item">
+				<part id="ir-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IR-6 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ir-6_fr_smt.1" name="item">
+					<part id="ir-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Reports security incident information according to FedRAMP Incident Communications Procedure.</p>
 					</part>
@@ -7435,13 +7435,13 @@
 		</alter>
 		<alter control-id="ir-8">
 			<add position="ending" by-id="ir-8_smt">
-				<part id="ir-8_fr" name="item">
+				<part id="ir-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IR-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ir-8_fr_smt.1" name="item">
+					<part id="ir-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
 						<p>The service provider defines a list of incident response personnel (identified by name and/or by role) and organizational elements. The incident response list includes designated FedRAMP personnel.</p>
 					</part>
-					<part id="ir-8_fr_smt.2" name="item">
+					<part id="ir-8_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(d) Requirement:"/>
 						<p>The service provider defines a list of incident response personnel (identified by name and/or by role) and organizational elements. The incident response list includes designated FedRAMP personnel.</p>
 					</part>
@@ -8001,9 +8001,9 @@
 		</alter>
 		<alter control-id="mp-3">
 			<add position="ending" by-id="mp-3_smt">
-				<part id="mp-3_fr" name="item">
+				<part id="mp-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>MP-3 Additional FedRAMP Requirements and Guidance</title>
-					<part id="mp-3_fr_gdn.1" name="guidance">
+					<part id="mp-3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Guidance:"/>
 						<p>Second parameter not-applicable</p>
 					</part>
@@ -8026,9 +8026,9 @@
 		</alter>
 		<alter control-id="mp-4">
 			<add position="ending" by-id="mp-4_smt">
-				<part id="mp-4_fr" name="item">
+				<part id="mp-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>MP-4 Additional FedRAMP Requirements and Guidance</title>
-					<part id="mp-4_fr_smt.1" name="item">
+					<part id="mp-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider defines controlled areas within facilities where the information and information system reside.</p>
 					</part>
@@ -8073,9 +8073,9 @@
 		</alter>
 		<alter control-id="mp-5">
 			<add position="ending" by-id="mp-5_smt">
-				<part id="mp-5_fr" name="item">
+				<part id="mp-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>MP-5 Additional FedRAMP Requirements and Guidance</title>
-					<part id="mp-5_fr_smt.1" name="item">
+					<part id="mp-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider defines security measures to protect digital and non-digital media in transport. The security measures are approved and accepted by the JAB/AO.</p>
 					</part>
@@ -8141,9 +8141,9 @@
 		</alter>
 		<alter control-id="mp-6.1">
 			<add position="ending" by-id="mp-6.1_smt">
-				<part id="mp-6.1_fr" name="item">
+				<part id="mp-6.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>MP-6 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="mp-6.1_fr_smt.1" name="item">
+					<part id="mp-6.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Must comply with NIST SP 800-88</p>
 					</part>
@@ -8159,9 +8159,9 @@
 		</alter>
 		<alter control-id="mp-6.2">
 			<add position="ending" by-id="mp-6.2_smt">
-				<part id="mp-6.2_fr" name="item">
+				<part id="mp-6.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>MP-6 (2) Additional FedRAMP Requirements and Guidance</title>
-					<part id="mp-6.2_fr_smt.1" name="guidance">
+					<part id="mp-6.2_fr_smt.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Equipment and procedures may be tested or validated for effectiveness</p>
 					</part>
@@ -8177,9 +8177,9 @@
 		</alter>
 		<alter control-id="mp-6.3">
 			<add position="ending" by-id="mp-6.3_smt">
-				<part id="mp-6.3_fr" name="item">
+				<part id="mp-6.3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>MP-6 (3) Additional FedRAMP Requirements and Guidance</title>
-					<part id="mp-6.3_fr_smt.1" name="item">
+					<part id="mp-6.3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Must comply with NIST SP 800-88</p>
 					</part>
@@ -8424,9 +8424,9 @@
 		</alter>
 		<alter control-id="pe-14">
 			<add position="ending" by-id="pe-14_smt">
-				<part id="pe-14_fr" name="item">
+				<part id="pe-14_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>PE-14 Additional FedRAMP Requirements and Guidance</title>
-					<part id="pe-14_fr_smt.1" name="item">
+					<part id="pe-14_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider measures temperature at server inlets and humidity levels by dew point.</p>
 					</part>
@@ -9086,9 +9086,9 @@
 		</alter>
 		<alter control-id="pl-8">
 			<add position="ending" by-id="pl-8_smt">
-				<part id="pl-8_fr" name="item">
+				<part id="pl-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>PL-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="pl-8_fr_gdn.1" name="guidance">
+					<part id="pl-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Guidance:"/>
 						<p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F.</p>
 					</part>
@@ -9159,9 +9159,9 @@
 		</alter>
 		<alter control-id="pl-10">
 			<add position="ending" by-id="pl-10_smt">
-				<part id="pl-10_fr" name="item">
+				<part id="pl-10_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>PL-10 Additional FedRAMP Requirements and Guidance</title>
-					<part id="pl-10_fr_smt.1" name="item">
+					<part id="pl-10_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Select the appropriate FedRAMP Baseline</p>
 					</part>
@@ -9556,13 +9556,13 @@
 		</alter>
 		<alter control-id="ra-3">
 			<add position="ending" by-id="ra-3_smt">
-				<part id="ra-3_fr" name="item">
+				<part id="ra-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>RA-3 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ra-3_fr_gdn.1" name="guidance">
+					<part id="ra-3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F.</p>
 					</part>
-					<part id="ra-3_fr_smt.1" name="item">
+					<part id="ra-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Requirement:"/>
 						<p>Include all Authorizing Officials; for JAB authorizations to include FedRAMP.</p>
 					</part>
@@ -9646,25 +9646,25 @@
 		</alter>
 		<alter control-id="ra-5">
 			<add position="ending" by-id="ra-5_smt">
-				<part id="ra-5_fr" name="item">
+				<part id="ra-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>RA-5 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ra-5_fr_gdn.1" name="guidance">
+					<part id="ra-5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See the FedRAMP Documents page&gt; Vulnerability Scanning Requirements https://www.FedRAMP.gov/documents/</p>
 					</part>
-					<part id="ra-5_fr_smt.1" name="item">
+					<part id="ra-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>an accredited independent assessor scans operating systems/infrastructure, web applications, and databases once annually.</p>
 					</part>
-					<part id="ra-5_fr_smt.2" name="item">
+					<part id="ra-5_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(d) Requirement:"/>
 						<p>If a vulnerability is listed among the CISA Known Exploited Vulnerability (KEV) Catalog (https://www.cisa.gov/known-exploited-vulnerabilities-catalog) the KEV remediation date supersedes the FedRAMP parameter requirement.</p>
 					</part>
-					<part id="ra-5_fr_smt.3" name="item">
+					<part id="ra-5_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Requirement:"/>
 						<p>to include all Authorizing Officials; for JAB authorizations to include FedRAMP</p>
 					</part>
-					<part id="ra-5_fr_gdn.2" name="guidance">
+					<part id="ra-5_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Informational findings from a scanner are detailed as a returned result that holds no vulnerability risk or severity and for FedRAMP does not require an entry onto the POA&amp;M or entry onto the RET during any assessment phase.</p>
 						<p>Warning findings, on the other hand, are given a risk rating (low, moderate, high or critical) by the scanning solution and should be treated like any other finding with a risk or severity rating for tracking purposes onto either the POA&amp;M or RET depending on when the findings originated (during assessments or during monthly continuous monitoring). If a warning is received during scanning, but further validation turns up no actual issue then this item should be categorized as a false positive. If this situation presents itself during an assessment phase (initial assessment, annual assessment or any SCR), follow guidance on how to report false positives in the Security Assessment Report (SAR). If this situation happens during monthly continuous monitoring, a deviation request will need to be submitted per the FedRAMP Vulnerability Deviation Request Form.</p>
@@ -9802,9 +9802,9 @@
 		</alter>
 		<alter control-id="ra-5.8">
 			<add position="ending" by-id="ra-5.8_smt">
-				<part id="ra-5.8_fr" name="item">
+				<part id="ra-5.8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>RA-5(8) Additional FedRAMP Requirement</title>
-					<part id="ra-5.8_fr_smt.1" name="item">
+					<part id="ra-5.8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>This enhancement is required for all high (or critical) vulnerability scan findings.</p>
 					</part>
@@ -10281,13 +10281,13 @@
 		</alter>
 		<alter control-id="sa-4">
 			<add position="ending" by-id="sa-4_smt">
-				<part id="sa-4_fr" name="item">
+				<part id="sa-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SA-4 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sa-4_fr_smt.1" name="item">
+					<part id="sa-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider must comply with Federal Acquisition Regulation (FAR) Subpart 7.103, and Section 889 of the John S. McCain National Defense Authorization Act (NDAA) for Fiscal Year 2019 (Pub. L. 115-232), and FAR Subpart 4.21, which implements Section 889 (as well as any added updates related to FISMA to address security concerns in the system acquisitions process).</p>
 					</part>
-					<part id="sa-4_fr_gdn.1" name="guidance">
+					<part id="sa-4_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The use of Common Criteria (ISO/IEC 15408) evaluated products is strongly preferred.</p>
 						<p>See https://www.niap-ccevs.org/Product/index.cfm or https://www.commoncriteriaportal.org/products/.</p>
@@ -10384,9 +10384,9 @@
 		</alter>
 		<alter control-id="sa-10">
 			<add position="ending" by-id="sa-10_smt">
-				<part id="sa-10_fr" name="item">
+				<part id="sa-10_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SA-10 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sa-10_fr_smt.1" name="item">
+					<part id="sa-10_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Requirement:"/>
 						<p>track security flaws and flaw resolution within the system, component, or service and report findings to organization-defined personnel, to include FedRAMP.</p>
 					</part>
@@ -10436,9 +10436,9 @@
 		</alter>
 		<alter control-id="sa-11.1">
 			<add position="ending" by-id="sa-11.1_smt">
-				<part id="sa-11.1_fr" name="item">
+				<part id="sa-11.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SA-11(1) Additional FedRAMP Requirements</title>
-					<part id="sa-11.1_fr_smt.1" name="item">
+					<part id="sa-11.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider must document its methodology for reviewing newly developed code for the Service in its Continuous Monitoring Plan.</p>
 						<p>If Static code analysis cannot be performed (for example, when the source code is not available), then dynamic code analysis must be performed (see SA-11 (8))</p>
@@ -10965,9 +10965,9 @@
 		</alter>
 		<alter control-id="sc-7">
 			<add position="ending" by-id="sc-7_smt">
-				<part id="sc-7_fr" name="item">
+				<part id="sc-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-7 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-7_fr_gdn.1" name="guidance">
+					<part id="sc-7_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Guidance:"/>
 						<p>SC-7 (b) should be met by subnet isolation. A subnetwork (subnet) is a physically or logically segmented section of a larger network defined at TCP/IP Layer 3, to both minimize traffic and, important for a FedRAMP Authorization, add a crucial layer of network isolation. Subnets are distinct from VLANs (Layer 2), security groups, and VPCs and are specifically required to satisfy SC-7 part b and other controls. See the FedRAMP Subnets White Paper (https://www.fedramp.gov/assets/resources/documents/FedRAMP_subnets_white_paper.pdf) for additional information.</p>
 					</part>
@@ -11182,9 +11182,9 @@
 		</alter>
 		<alter control-id="sc-7.5">
 			<add position="ending" by-id="sc-7.5_smt">
-				<part id="sc-7.5_fr" name="item">
+				<part id="sc-7.5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-7 (5) Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-7.5_fr_gdn.1" name="guidance">
+					<part id="sc-7.5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For JAB Authorization, CSPs shall include details of this control in their Architecture Briefing</p>
 					</part>
@@ -11233,9 +11233,9 @@
 		</alter>
 		<alter control-id="sc-8">
 			<add position="ending" by-id="sc-8_smt">
-				<part id="sc-8_fr" name="item">
+				<part id="sc-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-8_fr_gdn.1" name="guidance">
+					<part id="sc-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For each instance of data in transit, confidentiality AND integrity should be through cryptography as specified in SC-8 (1), physical means as specified in SC-8 (5), or in combination.</p>
 						<p/>
@@ -11255,7 +11255,7 @@
 						<p>SC-8 (5)-1 [a hardened or alarmed carrier Protective Distribution System (PDS) when outside of Controlled Access Area (CAA)]</p>
 						<p>SC-8 (5)-2 [prevent unauthorized disclosure of information AND detect changes to information]</p>
 					</part>
-					<part id="sc-8_fr_gdn.2" name="guidance">
+					<part id="sc-8_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>SC-8 (5) applies when physical protection has been selected as the method to protect confidentiality and integrity. For physical protection, data in transit must be in either a Controlled Access Area (CAA), or a Hardened or alarmed PDS.</p>
 						<p/>
@@ -11288,22 +11288,22 @@
 		</alter>
 		<alter control-id="sc-8.1">
 			<add position="ending" by-id="sc-8.1_smt">
-				<part id="sc-8.1_fr" name="item">
+				<part id="sc-8.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-8 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-8.1_fr_smt.1" name="item">
+					<part id="sc-8.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Please ensure SSP Section 10.3 Cryptographic Modules Implemented for Data At Rest (DAR) and Data In Transit (DIT) is fully populated for reference in this control.</p>
 					</part>
-					<part id="sc-8.1_fr_gdn.1" name="guidance">
+					<part id="sc-8.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See M-22-09, including &quot;Agencies encrypt all DNS requests and HTTP traffic within their environment&quot;</p>
 						<p>SC-8 (1) applies when encryption has been selected as the method to protect confidentiality and integrity. Otherwise refer to SC-8 (5). SC-8 (1) is strongly encouraged.</p>
 					</part>
-					<part id="sc-8.1_fr_gdn.2" name="guidance">
+					<part id="sc-8.1_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Note that this enhancement requires the use of cryptography which must be compliant with Federal requirements and utilize FIPS validated or NSA approved cryptography (see SC-13.)</p>
 					</part>
-					<part id="sc-8.1_fr_gdn.3" name="guidance">
+					<part id="sc-8.1_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>When leveraging encryption from the underlying IaaS/PaaS: While some IaaS/PaaS services provide encryption by default, many require encryption to be configured, and enabled by the customer. The CSP has the responsibility to verify encryption is properly configured.</p>
 					</part>
@@ -11321,17 +11321,17 @@
 		</alter>
 		<alter control-id="sc-12">
 			<add position="ending" by-id="sc-12_smt">
-				<part id="sc-12_fr" name="item">
+				<part id="sc-12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-12 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-12_fr_gdn.1" name="guidance">
+					<part id="sc-12_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See references in NIST 800-53 documentation.</p>
 					</part>
-					<part id="sc-12_fr_gdn.2" name="guidance">
+					<part id="sc-12_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Must meet applicable Federal Cryptographic Requirements. See References Section of control.</p>
 					</part>
-					<part id="sc-12_fr_gdn.3" name="guidance">
+					<part id="sc-12_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Wildcard certificates may be used internally within the system, but are not permitted for external customer access to the system.</p>
 					</part>
@@ -11352,10 +11352,10 @@
 		</alter>
 		<alter control-id="sc-13">
 			<add position="ending" by-id="sc-13_smt">
-				<part id="sc-13_fr" name="item">
+				<part id="sc-13_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-13 Additional FedRAMP Requirements and Guidance</title>
 
-					<part id="sc-13_fr_gdn.1" name="guidance">
+					<part id="sc-13_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>This control applies to all use of cryptography. In addition to encryption, this includes functions such as hashing, random number generation, and key generation. Examples include the following:</p>
 						<ul>
@@ -11368,16 +11368,16 @@
 						<p>The requirement for FIPS 140 validation, as well as timelines for acceptance of FIPS 140-2, and 140-3 can be found at the NIST Cryptographic Module Validation Program (CMVP).</p>
 						<p>https://csrc.nist.gov/projects/cryptographic-module-validation-program</p>
 					</part>
-					<part id="sc-13_fr_gdn.2" name="guidance">
+					<part id="sc-13_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For NSA-approved cryptography, the National Information Assurance Partnership (NIAP) oversees a national program to evaluate Commercial IT Products for Use in National Security Systems. The NIAP Product Compliant List can be found at the following location:</p>
 						<p>https://www.niap-ccevs.org/Product/index.cfm</p>
 					</part>
-					<part id="sc-13_fr_gdn.3" name="guidance">
+					<part id="sc-13_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>When leveraging encryption from underlying IaaS/PaaS: While some IaaS/PaaS provide encryption by default, many require encryption to be configured, and enabled by the customer. The CSP has the responsibility to verify encryption is properly configured.</p>
 					</part>
-					<part id="sc-13_fr_gdn.4" name="guidance">
+					<part id="sc-13_fr_gdn.4" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Moving to non-FIPS CM or product is acceptable when:</p>
 						<ul>
@@ -11388,7 +11388,7 @@
 							<li>POA&amp;M is added to track approval, and deployment when ready</li>
 						</ul>
 					</part>
-					<part id="sc-13_fr_gdn.5" name="guidance">
+					<part id="sc-13_fr_gdn.5" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>At a minimum, this control applies to cryptography in use for the following controls: AU-9(3), CP-9(8), IA-2(6), IA-5(1), MP-5, SC-8(1), and SC-28(1).</p>
 					</part>
@@ -11417,9 +11417,9 @@
 		</alter>
 		<alter control-id="sc-15">
 			<add position="ending" by-id="sc-15_smt">
-				<part id="sc-15_fr" name="item">
+				<part id="sc-15_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-15 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-15_fr_smt.1" name="item">
+					<part id="sc-15_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The information system provides disablement (instead of physical disconnect) of collaborative computing devices in a manner that supports ease of use.</p>
 					</part>
@@ -11445,25 +11445,25 @@
 		</alter>
 		<alter control-id="sc-20">
 			<add position="ending" by-id="sc-20_smt">
-				<part id="sc-20_fr" name="item">
+				<part id="sc-20_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-20 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-20_fr_smt.1" name="item">
+					<part id="sc-20_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Control Description should include how DNSSEC is implemented on authoritative DNS servers to supply valid responses to external DNSSEC requests.</p>
 					</part>
-					<part id="sc-20_fr_smt.2" name="item">
+					<part id="sc-20_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Authoritative DNS servers must be geolocated in accordance with SA-9 (5).</p>
 					</part>
-					<part id="sc-20_fr_gdn.1" name="guidance">
+					<part id="sc-20_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>SC-20 applies to use of external authoritative DNS to access a CSO from outside the boundary.</p>
 					</part>
-					<part id="sc-20_fr_gdn.2" name="guidance">
+					<part id="sc-20_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>External authoritative DNS servers may be located outside an authorized environment. Positioning these servers inside an authorized boundary is encouraged.</p>
 					</part>
-					<part id="sc-20_fr_gdn.3" name="guidance">
+					<part id="sc-20_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>CSPs are recommended to self-check DNSSEC configuration through one of many available analyzers such as Sandia National Labs (https://dnsviz.net)</p>
 					</part>
@@ -11496,9 +11496,9 @@
 		</alter>
 		<alter control-id="sc-21">
 			<add position="ending" by-id="sc-21_smt">
-				<part id="sc-21_fr" name="item">
+				<part id="sc-21_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-21 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-21_fr_smt.1" name="item">
+					<part id="sc-21_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Control description should include how DNSSEC is implemented on recursive DNS servers to make DNSSEC requests when resolving DNS requests from internal components to domains external to the CSO boundary.</p>
 						<ul>
@@ -11509,15 +11509,15 @@
 							</li>
 						</ul>
 					</part>
-					<part id="sc-21_fr_smt.2" name="item">
+					<part id="sc-21_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Internal recursive DNS servers must be located inside an authorized environment. It is typically within the boundary, or leveraged from an underlying IaaS/PaaS.</p>
 					</part>
-					<part id="sc-21_fr_gdn.1" name="guidance">
+					<part id="sc-21_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Accepting an unsigned reply is acceptable</p>
 					</part>
-					<part id="sc-21_fr_gdn.2" name="guidance">
+					<part id="sc-21_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>SC-21 applies to use of internal recursive DNS to access a domain outside the boundary by a component inside the boundary.</p>
 						<p>- DNSSEC resolution to access a component inside the boundary is excluded.</p>
@@ -11539,17 +11539,17 @@
 		</alter>
 		<alter control-id="sc-28">
 			<add position="ending" by-id="sc-28_smt">
-				<part id="sc-28_fr" name="item">
+				<part id="sc-28_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-28 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-28_fr_gdn.1" name="guidance">
+					<part id="sc-28_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The organization supports the capability to use cryptographic mechanisms to protect information at rest.</p>
 					</part>
-					<part id="sc-28_fr_gdn.2" name="guidance">
+					<part id="sc-28_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>When leveraging encryption from underlying IaaS/PaaS: While some IaaS/PaaS services provide encryption by default, many require encryption to be configured, and enabled by the customer. The CSP has the responsibility to verify encryption is properly configured.</p>
 					</part>
-					<part id="sc-28_fr_gdn.3" name="guidance">
+					<part id="sc-28_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Note that this enhancement requires the use of cryptography in accordance with SC-13.</p>
 					</part>
@@ -11570,9 +11570,9 @@
 		</alter>
 		<alter control-id="sc-28.1">
 			<add position="ending" by-id="sc-28.1_smt">
-				<part id="sc-28.1_fr" name="item">
+				<part id="sc-28.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-28 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-28.1_fr_gdn.1" name="guidance">
+					<part id="sc-28.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Organizations should select a mode of protection that is targeted towards the relevant threat scenarios.</p>
 						<p>Examples:</p>
@@ -11594,17 +11594,17 @@
 		</alter>
 		<alter control-id="sc-45.1">
 			<add position="ending" by-id="sc-45.1_smt">
-				<part id="sc-45.1_fr" name="item">
+				<part id="sc-45.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-45(1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-45.1_fr_smt.1" name="item">
+					<part id="sc-45.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider selects primary and secondary time servers used by the NIST Internet time service. The secondary server is selected from a different geographic region than the primary server.</p>
 					</part>
-					<part id="sc-45.1_fr_smt.2" name="item">
+					<part id="sc-45.1_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider synchronizes the system clocks of network computers that run operating systems other than Windows to the Windows Server Domain Controller emulator or to the same time source for that server.</p>
 					</part>
-					<part id="sc-45.1_fr_gdn.1" name="guidance">
+					<part id="sc-45.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Synchronization of system clocks improves the accuracy of log analysis.</p>
 					</part>
@@ -11840,9 +11840,9 @@
 		</alter>
 		<alter control-id="si-4">
 			<add position="ending" by-id="si-4_smt">
-				<part id="si-4_fr" name="item">
+				<part id="si-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-4 Additional FedRAMP Requirements and Guidance</title>
-					<part id="si-4_fr_gdn.1" name="guidance">
+					<part id="si-4_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See US-CERT Incident Response Reporting Guidelines.</p>
 					</part>
@@ -12088,9 +12088,9 @@
 		</alter>
 		<alter control-id="si-4.5">
 			<add position="ending" by-id="si-4.5_smt">
-				<part id="si-4.5_fr" name="item">
+				<part id="si-4.5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-4 (5) Additional FedRAMP Requirements and Guidance</title>
-					<part id="si-4.5_fr_gdn.1" name="guidance">
+					<part id="si-4.5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>In accordance with the incident response plan.</p>
 					</part>
@@ -12108,9 +12108,9 @@
 		</alter>
 		<alter control-id="si-4.10">
 			<add position="ending" by-id="si-4.10_smt">
-				<part id="si-4.10_fr" name="item">
+				<part id="si-4.10_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-4 (10) Additional FedRAMP Requirements and Guidance</title>
-					<part id="si-4.10_fr_smt.1" name="item">
+					<part id="si-4.10_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider must support Agency requirements to comply with M-21-31 (https://www.whitehouse.gov/wp-content/uploads/2021/08/M-21-31-Improving-the-Federal-Governments-Investigative-and-Remediation-Capabilities-Related-to-Cybersecurity-Incidents.pdf) and M-22-09 (https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf).</p>
 					</part>
@@ -12130,7 +12130,7 @@
 		</alter>
 		<alter control-id="si-5">
 			<add position="ending" by-id="si-5_smt">
-				<part id="si-5_fr_smt.1" name="item">
+				<part id="si-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-5 Additional FedRAMP Requirements and Guidance</title>
 					<prop name="label" value="Requirement:"/>
 					<p>Service Providers must address the CISA Emergency and Binding Operational Directives applicable to their cloud service offering per FedRAMP guidance. This includes listing the applicable directives and stating compliance status.</p>
@@ -12297,14 +12297,14 @@
 		</alter>
 		<alter control-id="si-8">
 			<add position="ending" by-id="si-8_smt">
-				<part id="si-8_fr" name="item">
+				<part id="si-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="si-8_fr_gdn.1" name="guidance">
+					<part id="si-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>When CSO sends email on behalf of the government as part of the business offering, Control Description should include implementation of Domain-based Message Authentication, Reporting &amp; Conformance (DMARC) on the sending domain for outgoing messages as described in DHS Binding Operational Directive (BOD) 18-01.</p>
 						<p>https://cyber.dhs.gov/bod/18-01/</p>
 					</part>
-					<part id="si-8_fr_gdn.2" name="guidance">
+					<part id="si-8_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>CSPs should confirm DMARC configuration (where appropriate) to ensure that policy=reject and the rua parameter includes reports@dmarc.cyber.dhs.gov. DMARC compliance should be documented in the SI-08 control implementation solution description, and list the FROM: domain(s) that will be seen by email recipients.</p>
 					</part>
@@ -12329,9 +12329,9 @@
 		</alter>
 		<alter control-id="si-10">
 			<add position="ending" by-id="si-10_smt">
-				<part id="si-10_fr" name="item">
+				<part id="si-10_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-10 Additional FedRAMP Requirements and Guidance</title>
-					<part id="si-10_fr_smt.1" name="item">
+					<part id="si-10_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Validate all information inputs and document any exceptions</p>
 					</part>
@@ -12524,9 +12524,9 @@
 		</alter>
 		<alter control-id="sr-3">
 			<add position="ending" by-id="sr-3_smt">
-				<part id="sr-3_fr" name="item">
+				<part id="sr-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SR-3 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sr-3_fr_smt.1" name="item">
+					<part id="sr-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSO must document and maintain the supply chain custody, including replacement devices, to ensure the integrity of the devices before being introduced to the boundary.</p>
 					</part>
@@ -12575,9 +12575,9 @@
 		</alter>
 		<alter control-id="sr-6">
 			<add position="ending" by-id="sr-6_smt">
-				<part id="sr-6_fr" name="item">
+				<part id="sr-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SR-6 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sr-6_fr_smt.1" name="item">
+					<part id="sr-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSOs must ensure that their supply chain vendors build and test their systems in alignment with NIST SP 800-171 or a commensurate security and compliance framework. CSOs must ensure that vendors are compliant with physical facility access and logical access controls to supplied products.</p>
 					</part>
@@ -12594,9 +12594,9 @@
 		</alter>
 		<alter control-id="sr-8">
 			<add position="ending" by-id="sr-8_smt">
-				<part id="sr-8_fr" name="item">
+				<part id="sr-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SR-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sr-8_fr_smt.1" name="item">
+					<part id="sr-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSOs must ensure and document how they receive notifications from their supply chain vendor of newly discovered vulnerabilities including zero-day vulnerabilities.</p>
 					</part>
@@ -12613,9 +12613,9 @@
 		</alter>
 		<alter control-id="sr-9">
 			<add position="ending" by-id="sr-9_smt">
-				<part id="sr-9_fr" name="item">
+				<part id="sr-9_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SR-9 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sr-9_fr_smt.1" name="item">
+					<part id="sr-9_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSOs must ensure vendors provide authenticity of software and patches supplied to the service provider including documenting the safeguards in place.</p>
 					</part>
@@ -12642,9 +12642,9 @@
 		</alter>
 		<alter control-id="sr-11">
 			<add position="ending" by-id="sr-11_smt">
-				<part id="sr-11_fr" name="item">
+				<part id="sr-11_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SR-11 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sr-11_fr_smt.1" name="item">
+					<part id="sr-11_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSOs must ensure that their supply chain vendors provide authenticity of software and patches and the vendor must have a plan to protect the development pipeline.</p>
 					</part>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="ece2fd2d-87f7-476a-a295-6e1ec8153771">
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="34972a30-1cbb-4271-8f37-39a84993c5e0">
     <metadata>
         <title>FedRAMP Rev 5 Tailored Low Impact Software as a Service (LI-SaaS) Baseline</title>
         <published>2024-09-24T02:24:00Z</published>
-        <last-modified>2024-09-24T02:24:00Z</last-modified>
-        <version>fedramp2.1.0-oscal1.0.4</version>
-        <oscal-version>1.0.4</oscal-version>
+		<last-modified>2025-01-15T00:00:00Z</last-modified>
+		<version>fedramp-3.0.0rc1-oscal-1.1.2</version>
+		<oscal-version>1.1.2</oscal-version>
         <role id="prepared-by">
             <title>Document creator</title>
         </role>
@@ -1337,28 +1337,28 @@
             </add>
             <add position="ending">
                 <prop ns="http://fedramp.gov/ns/oscal" name="method" class="FedRAMP-Tailored-LI-SaaS" value="ASSESS"/>
-                <part id="ac-2_obj_fr" name="assessment-objective">
+                <part id="ac-2_obj_fr" name="assessment-objective" ns="http://fedramp.gov/ns/oscal">
                     <prop ns="http://fedramp.gov/ns/oscal" name="response-point" value="Required"/>
                     <prop ns="http://fedramp.gov/ns/oscal" name="method" class="fedramp" value="EXAMINE"/>
                     <prop ns="http://fedramp.gov/ns/oscal" name="method" class="fedramp" value="INTERVIEW"/>
                     <prop ns="http://fedramp.gov/ns/oscal" name="method" class="fedramp" value="TEST"/>
                     <p>Determine if the organization defines information system account types to be identified and selected to support organizational missions/business functions.</p>
                 </part>
-                <part id="ac-2_asmt_fr.1" name="assessment-method">
+                <part id="ac-2_asmt_fr.1" name="assessment-method" ns="http://fedramp.gov/ns/oscal">
                     <prop ns="http://fedramp.gov/ns/oscal" name="method" value="EXAMINE"/>
-                    <part name="assessment-objects">
+                    <part name="assessment-objects" ns="http://fedramp.gov/ns/oscal">
                         <p>Access control policy; procedures addressing account management; security plan; information system design documentation; information system configuration settings and associated documentation; list of active system accounts along with the name of the individual associated with each account; list of conditions for group and role membership; notifications or records of recently transferred, separated, or terminated employees; list of recently disabled information system accounts along with the name of the individual associated with each account; access authorization records; account management compliance reviews; information system monitoring records; information system audit records; other relevant documents or records.</p>
                     </part>
                 </part>
-                <part id="ac-2_asmt_fr.2" name="assessment-method">
+                <part id="ac-2_asmt_fr.2" name="assessment-method" ns="http://fedramp.gov/ns/oscal">
                     <prop ns="http://fedramp.gov/ns/oscal" name="method" value="INTERVIEW"/>
-                    <part name="assessment-objects">
+                    <part name="assessment-objects" ns="http://fedramp.gov/ns/oscal">
                         <p>Organizational personnel with account management responsibilities; system/network administrators; organizational personnel with information security responsibilities.</p>
                     </part>
                 </part>
-                <part id="ac-2_asmt_fr.3" name="assessment-method">
+                <part id="ac-2_asmt_fr.3" name="assessment-method" ns="http://fedramp.gov/ns/oscal">
                     <prop ns="http://fedramp.gov/ns/oscal" name="method" value="TEST"/>
-                    <part name="assessment-objects">
+                    <part name="assessment-objects" ns="http://fedramp.gov/ns/oscal">
                         <p>Organizational processes for account management on the information system; automated mechanisms for implementing account management.</p>
                     </part>
                 </part>
@@ -1751,17 +1751,17 @@
                 <part name="guidance" class="FedRAMP-Tailored-LI-SaaS">
                     <p>Required - Specifically include details of least functionality.</p>
                 </part>
-                <part id="cm-6_fr" name="item">
+                <part id="cm-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CM-6(a) Additional FedRAMP Requirements and Guidance</title>
-                    <part id="cm-6_fr_smt.1" name="item">
+                    <part id="cm-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement 1:"/>
                         <p>The service provider shall use the Center for Internet Security guidelines (Level 1) to establish configuration settings or establishes its own configuration settings if USGCB is not available.</p>
                     </part>
-                    <part id="cm-6_fr_smt.2" name="item">
+                    <part id="cm-6_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement 2:"/>
                         <p>The service provider shall ensure that checklists for configuration settings are Security Content Automation Protocol (SCAP) (<a href="http://scap.nist.gov/">http://scap.nist.gov/</a>) validated or SCAP compatible (if validated checklists are not available).</p>
                     </part>
-                    <part id="cm-6_fr_gdn.1" name="guidance">
+                    <part id="cm-6_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Information on the USGCB checklists can be found at: <a href="https://csrc.nist.gov/Projects/United-States-Government-Configuration-Baseline">https://csrc.nist.gov/Projects/United-States-Government-Configuration-Baseline</a>.</p>
                     </part>
@@ -1901,9 +1901,9 @@
             </add>
             <add position="ending">
                 <prop ns="http://fedramp.gov/ns/oscal" name="method" class="FedRAMP-Tailored-LI-SaaS" value="ASSESS"/>
-                <part id="ia-2.1_fr" name="item">
+                <part id="ia-2.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IA-2(1) Additional FedRAMP Requirements and Guidance</title>
-                    <part name="guidance" class="FedRAMP-Tailored-LI-SaaS">
+                    <part name="guidance" ns="http://fedramp.gov/ns/oscal" class="FedRAMP-Tailored-LI-SaaS">
                         <p>FedRAMP requires a minimum of multi-factor authentication for all Federal privileged users, if acceptance of PIV credentials is not supported. The implementation status and details of how this control is implemented must be clearly defined by the CSP.</p>
                     </part>
                 </part>
@@ -1939,7 +1939,7 @@
             <add position="ending">
                 <prop ns="http://fedramp.gov/ns/oscal" name="method" class="FedRAMP-Tailored-LI-SaaS" value="ASSESS"/>
                 <prop ns="http://fedramp.gov/ns/oscal" name="method" class="FedRAMP-Tailored-LI-SaaS" value="CONDITIONAL"/>
-                <part id="ia-2.12_obj_fr" name="objective">
+                <part id="ia-2.12_obj_fr" name="objective" ns="http://fedramp.gov/ns/oscal">
                     <prop ns="http://fedramp.gov/ns/oscal" name="response-point" value="Required"/>
                     <prop ns="http://fedramp.gov/ns/oscal" name="method" class="fedramp" value="EXAMINE"/>
                     <prop ns="http://fedramp.gov/ns/oscal" name="method" class="fedramp" value="INTERVIEW"/>
@@ -2311,9 +2311,9 @@
                 </part>
             </add>
             <add by-id="pe-14_smt" position="ending">
-                <part id="pe-14_fr" name="item">
+                <part id="pe-14_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>PE-14(a) Additional FedRAMP Requirements and Guidance</title>
-                    <part id="pe-14_fr_smt.a" name="item">
+                    <part id="pe-14_fr_smt.a" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(a) Requirement:"/>
                         <p>The service provider measures temperature at server inlets and humidity levels by dew point.</p>
                     </part>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
@@ -4,9 +4,9 @@
     <metadata>
         <title>FedRAMP Rev 5 Tailored Low Impact Software as a Service (LI-SaaS) Baseline</title>
         <published>2024-09-24T02:24:00Z</published>
-		<last-modified>2025-01-15T00:00:00Z</last-modified>
-		<version>fedramp-3.0.0rc1-oscal-1.1.2</version>
-		<oscal-version>1.1.2</oscal-version>
+        <last-modified>2025-01-15T00:00:00Z</last-modified>
+	<version>fedramp-3.0.0rc1-oscal-1.1.2</version>
+	<oscal-version>1.1.2</oscal-version>
         <role id="prepared-by">
             <title>Document creator</title>
         </role>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
@@ -4,9 +4,9 @@
     <metadata>
         <title>FedRAMP Rev 5 Low Baseline</title>
         <published>2024-09-24T02:24:00Z</published>
-        <last-modified>2024-09-24T02:24:00Z</last-modified>
-        <version>fedramp2.1.0-oscal1.0.4</version>
-        <oscal-version>1.0.4</oscal-version>
+		<last-modified>2025-01-15T00:00:00Z</last-modified>
+		<version>fedramp-3.0.0rc1-oscal-1.1.2</version>
+		<oscal-version>1.1.2</oscal-version>
         <role id="prepared-by">
             <title>Document creator</title>
         </role>
@@ -1605,9 +1605,9 @@
         <alter control-id="ac-7">
 
             <add position="ending" by-id="ac-7_smt">
-                <part id="ac-7_fr" name="item">
+                <part id="ac-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>AC-7 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ac-7_fr_smt.1" name="item">
+                    <part id="ac-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>In alignment with NIST SP 800-63B</p>
                     </part>
@@ -1632,21 +1632,21 @@
         </alter>
         <alter control-id="ac-8">
             <add position="ending" by-id="ac-8_smt">
-                <part id="ac-8_fr" name="item">
+                <part id="ac-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>AC-8 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ac-8_fr_smt.1" name="item">
+                    <part id="ac-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>The service provider shall determine elements of the cloud environment that require the System Use Notification control. The elements of the cloud environment that require System Use Notification are approved and accepted by the JAB/AO. </p>
                     </part>
-                    <part id="ac-8_fr_smt.2" name="item">
+                    <part id="ac-8_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>The service provider shall determine how System Use Notification is going to be verified and provide appropriate periodicity of the check. The System Use Notification verification and periodicity are approved and accepted by the JAB/AO.</p>
                     </part>
-                    <part id="ac-8_fr_smt.3" name="item">
+                    <part id="ac-8_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>If not performed as part of a Configuration Baseline check, then there must be documented agreement on how to provide results of verification and the necessary periodicity of the verification by the service provider. The documented agreement on how to provide verification of the results are approved and accepted by the JAB/AO.</p>
                     </part>
-                    <part id="ac-8_fr_gdn.1" name="guidance">
+                    <part id="ac-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>If performed as part of a Configuration Baseline check, then the % of items requiring setting that are checked and that pass (or fail) check can be provided.</p>
                     </part>
@@ -1696,9 +1696,9 @@
 
         <alter control-id="ac-20">
             <add position="ending" by-id="ac-20_smt">
-                <part id="ac-20_fr" name="item">
+                <part id="ac-20_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>AC-20 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ac-20_fr_gdn.1" name="guidance">
+                    <part id="ac-20_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>The interrelated controls of AC-20, CA-3, and SA-9 should be differentiated as follows:</p>
                         <p>AC-20 describes system access to and from external systems.</p>
@@ -1984,13 +1984,13 @@
         <alter control-id="au-2">
 
             <add position="ending" by-id="au-2_smt">
-                <part id="au-2_fr" name="item">
+                <part id="au-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>AU-2 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="au-2_fr_smt.1" name="item">
+                    <part id="au-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Coordination between service provider and consumer shall be documented and accepted by the JAB/AO.</p>
                     </part>
-                    <part id="au-2_fr_gdn.1" name="guidance">
+                    <part id="au-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(e) Guidance:"/>
                         <p>Annually or whenever changes in the threat environment are communicated to the service provider by the JAB/AO.</p>
                     </part>
@@ -2108,9 +2108,9 @@
         <alter control-id="au-6">
 
             <add position="ending" by-id="au-6_smt">
-                <part id="au-6_fr" name="item">
+                <part id="au-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>AU-6 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="au-6_fr_smt.1" name="item">
+                    <part id="au-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Coordination between service provider and consumer shall be documented and accepted by the JAB/AO. In multi-tenant environments, capability and means for providing review, analysis, and reporting to consumer for data pertaining to consumer shall be documented.</p>
                     </part>
@@ -2147,17 +2147,17 @@
         <alter control-id="au-11">
 
             <add position="ending" by-id="au-11_smt">
-                <part id="au-11_fr" name="item">
+                <part id="au-11_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>AU-11 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="au-11_fr_smt.1" name="item">
+                    <part id="au-11_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>The service provider retains audit records on-line for at least ninety days and further preserves audit records off-line for a period that is in accordance with NARA requirements.</p>
                     </part>
-                    <part id="au-11_fr_smt.2" name="item">
+                    <part id="au-11_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>The service provider must support Agency requirements to comply with M-21-31 (https://www.whitehouse.gov/wp-content/uploads/2021/08/M-21-31-Improving-the-Federal-Governments-Investigative-and-Remediation-Capabilities-Related-to-Cybersecurity-Incidents.pdf)</p>
                     </part>
-                    <part id="au-11_fr_gdn.1" name="guidance">
+                    <part id="au-11_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>The service provider is encouraged to align with M-21-31 where possible</p>
                     </part>
@@ -2274,9 +2274,9 @@
         <alter control-id="ca-2">
 
             <add position="ending" by-id="ca-2_smt">
-                <part id="ca-2_fr" name="item">
+                <part id="ca-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CA-2 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ca-2_fr_gdn.1" name="guidance">
+                    <part id="ca-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Reference FedRAMP Annual Assessment Guidance.</p>
                     </part>
@@ -2378,13 +2378,13 @@
         <alter control-id="ca-5">
 
             <add position="ending" by-id="ca-5_smt">
-                <part id="ca-5_fr" name="item">
+                <part id="ca-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CA-5 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ca-5_fr_gdn.1" name="item">
+                    <part id="ca-5_fr_gdn.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>POA&amp;Ms must be provided at least monthly.</p>
                     </part>
-                    <part id="ca-5_fr_smt.1" name="guidance">
+                    <part id="ca-5_fr_smt.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Reference FedRAMP-POAM-Template</p>
                     </part>
@@ -2409,9 +2409,9 @@
         </alter>
         <alter control-id="ca-6">
             <add position="ending" by-id="ca-6_smt">
-                <part id="ca-6_fr" name="item">
+                <part id="ca-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CA-6 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ca-6_fr_gdn.1" name="guidance">
+                    <part id="ca-6_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(e) Guidance:"/>
                         <p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F and according to FedRAMP Significant Change Policies and Procedures. The service provider describes the types of changes to the information system or the environment of operations that would impact the risk posture. The types of changes are approved and accepted by the JAB/AO.</p>
                     </part>
@@ -2465,17 +2465,17 @@
         <alter control-id="ca-7">
 
             <add position="ending" by-id="ca-7_smt">
-                <part id="ca-7_fr" name="item">
+                <part id="ca-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CA-7 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ca-7_fr_smt.1" name="item">
+                    <part id="ca-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Operating System, Database, Web Application, Container, and Service Configuration Scans: at least monthly. All scans performed by Independent Assessor: at least annually.</p>
                     </part>
-                    <part id="ca-7_fr_smt.2" name="item">
+                    <part id="ca-7_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>CSOs with more than one agency ATO must implement a collaborative Continuous Monitoring (ConMon) approach described in the FedRAMP Guide for Multi-Agency Continuous Monitoring. This requirement applies to CSOs authorized via the Agency path as each agency customer is responsible for performing ConMon oversight. It does not apply to CSOs authorized via the JAB path because the JAB performs ConMon oversight.</p>
                     </part>
-                    <part id="ca-7_fr_gdn.1" name="guidance">
+                    <part id="ca-7_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>FedRAMP does not provide a template for the Continuous Monitoring Plan. CSPs should reference the FedRAMP Continuous Monitoring Strategy Guide when developing the Continuous Monitoring Plan.</p>
                     </part>
@@ -2582,9 +2582,9 @@
         </alter>
         <alter control-id="ca-8">
             <add position="ending" by-id="ca-8_smt">
-                <part id="ca-8_fr" name="item">
+                <part id="ca-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CA-8 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ca-8_fr_gdn.1" name="guidance">
+                    <part id="ca-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Scope can be limited to public facing applications in alignment with M-22-09. Reference the FedRAMP Penetration Test Guidance.</p>
                     </part>
@@ -2743,9 +2743,9 @@
         </alter>
         <alter control-id="cm-2">
             <add position="ending" by-id="cm-2_smt">
-                <part id="cm-2_fr" name="item">
+                <part id="cm-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CM-2 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="cm-2_fr_gdn.1" name="guidance">
+                    <part id="cm-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(b) (1) Guidance:"/>
                         <p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F.</p>
                     </part>
@@ -2804,17 +2804,17 @@
         <alter control-id="cm-6">
 
             <add position="ending" by-id="cm-6_smt">
-                <part id="cm-6_fr" name="item">
+                <part id="cm-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CM-6 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="cm-6_fr_smt.1" name="item">
+                    <part id="cm-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(a) Requirement 1:"/>
                         <p>The service provider shall use the DoD STIGs or Center for Internet Security guidelines to establish configuration settings;</p>
                     </part>
-                    <part id="cm-6_fr_smt.2" name="item">
+                    <part id="cm-6_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(a) Requirement 2:"/>
                         <p>The service provider shall ensure that checklists for configuration settings are Security Content Automation Protocol (SCAP) validated or SCAP compatible (if validated checklists are not available).</p>
                     </part>
-                    <part id="cm-6_fr_gdn.1" name="guidance">
+                    <part id="cm-6_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Compliance checks are used to evaluate configuration settings and provide general insight into the overall effectiveness of configuration management activities. CSPs and 3PAOs typically combine compliance check findings into a single CM-6 finding, which is acceptable. However, for initial assessments, annual assessments, and significant change requests, FedRAMP requires a clear understanding, on a per-control basis, where risks exist. Therefore, 3PAOs must also analyze compliance check findings as part of the controls assessment. Where a direct mapping exists, the 3PAO must document additional findings per control in the corresponding SAR Risk Exposure Table (RET), which are then documented in the CSP's Plan of Action and Milestones (POA&amp;M). This will likely result in the details of individual control findings overlapping with those in the combined CM-6 finding, which is acceptable.</p>
                         <p>During monthly continuous monitoring, new findings from CSP compliance checks may be combined into a single CM-6 POA&amp;M item. CSPs are not required to map the findings to specific controls because controls are only assessed during initial assessments, annual assessments, and significant change requests.</p>
@@ -2858,9 +2858,9 @@
         </alter>
         <alter control-id="cm-7">
             <add position="ending" by-id="cm-7_smt">
-                <part id="cm-7_fr" name="item">
+                <part id="cm-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CM-7 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="cm-7_fr_smt.1" name="item">
+                    <part id="cm-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(b) Requirement:"/>
                         <p>The service provider shall use Security guidelines (See CM-6) to establish list of prohibited or restricted functions, ports, protocols, and/or services or establishes its own list of prohibited or restricted functions, ports, protocols, and/or services if STIGs or CIS is not available.</p>
                     </part>
@@ -2888,9 +2888,9 @@
         <alter control-id="cm-8">
 
             <add position="ending" by-id="cm-8_smt">
-                <part id="cm-8_fr" name="item">
+                <part id="cm-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CM-8 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="cm-8_fr_smt.1" name="item">
+                    <part id="cm-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>must be provided at least monthly or when there is a change.</p>
                     </part>
@@ -3007,13 +3007,13 @@
         <alter control-id="cp-2">
 
             <add position="ending" by-id="cp-2_smt">
-                <part id="cp-2_fr" name="item">
+                <part id="cp-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CP-2 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="cp-2_fr_smt.1" name="item">
+                    <part id="cp-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>For JAB authorizations the contingency lists include designated FedRAMP personnel.</p>
                     </part>
-                    <part id="cp-2_fr_smt.2" name="item">
+                    <part id="cp-2_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>CSPs must use the FedRAMP Information System Contingency Plan (ISCP) Template (available on the fedramp.gov: https://www.fedramp.gov/assets/resources/templates/SSP-A06-FedRAMP-ISCP-Template.docx).</p>
                     </part>
@@ -3121,9 +3121,9 @@
         <alter control-id="cp-3">
 
             <add position="ending" by-id="cp-3_smt">
-                <part id="cp-3_fr" name="item">
+                <part id="cp-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CP-3 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="cp-3_fr_smt.1" name="item">
+                    <part id="cp-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(a) Requirement:"/>
                         <p>Privileged admins and engineers must take the basic contingency training within 10 days. Consideration must be given for those privileged admins and engineers with critical contingency-related roles, to gain enough system context and situational awareness to understand the full impact of contingency training as it applies to their respective level. Newly hired critical contingency personnel must take this more in-depth training within 60 days of hire date when the training will have more impact.</p>
                     </part>
@@ -3164,13 +3164,13 @@
         <alter control-id="cp-4">
 
             <add position="ending" by-id="cp-4_smt">
-                <part id="cp-4_fr" name="item">
+                <part id="cp-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CP-4 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="cp-4_fr_smt.1" name="item">
+                    <part id="cp-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(a) Requirement:"/>
                         <p>The service provider develops test plans in accordance with NIST Special Publication 800-34 (as amended); plans are approved by the JAB/AO prior to initiating testing.</p>
                     </part>
-                    <part id="cp-4_fr_smt.2" name="item">
+                    <part id="cp-4_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(b) Requirement:"/>
                         <p>The service provider must include the Contingency Plan test results with the security package within the Contingency Plan-designated appendix (Appendix G, Contingency Plan Test Report).</p>
                     </part>
@@ -3219,21 +3219,21 @@
         </alter>
         <alter control-id="cp-9">
             <add position="ending" by-id="cp-9_smt">
-                <part id="cp-9_fr" name="item">
+                <part id="cp-9_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>CP-9 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="cp-9_fr_smt.1" name="item">
+                    <part id="cp-9_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>The service provider shall determine what elements of the cloud environment require the Information System Backup control. The service provider shall determine how Information System Backup is going to be verified and appropriate periodicity of the check.</p>
                     </part>
-                    <part id="cp-9_fr_smt.2" name="item">
+                    <part id="cp-9_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(a) Requirement:"/>
                         <p>The service provider maintains at least three backup copies of user-level information (at least one of which is available online) or provides an equivalent alternative.</p>
                     </part>
-                    <part id="cp-9_fr_smt.3" name="item">
+                    <part id="cp-9_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(b) Requirement:"/>
                         <p>The service provider maintains at least three backup copies of system-level information (at least one of which is available online) or provides an equivalent alternative.</p>
                     </part>
-                    <part id="cp-9_fr_smt.4" name="item">
+                    <part id="cp-9_fr_smt.4" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(c) Requirement:"/>
                         <p>The service provider maintains at least three backup copies of information system documentation including security information (at least one of which is available online) or provides an equivalent alternative.</p>
                     </part>
@@ -3334,21 +3334,21 @@
         </alter>
         <alter control-id="ia-2">
             <add position="ending" by-id="ia-2_smt">
-                <part id="ia-2_fr" name="item">
+                <part id="ia-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IA-2 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ia-2_fr_smt.1" name="item">
+                    <part id="ia-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>For all control enhancements that specify multifactor authentication, the implementation must adhere to the Digital Identity Guidelines specified in NIST Special Publication 800-63B.</p>
                     </part>
-                    <part id="ia-2_fr_smt.2" name="item">
+                    <part id="ia-2_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Multi-factor authentication must be phishing-resistant.</p>
                     </part>
-                    <part id="ia-2_fr_gdn.1" name="guidance">
+                    <part id="ia-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>&quot;Phishing-resistant&quot; authentication refers to authentication processes designed to detect and prevent disclosure of authentication secrets and outputs to a website or application masquerading as a legitimate system.</p>
                     </part>
-                    <part id="ia-2_fr_gdn.2" name="guidance">
+                    <part id="ia-2_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>All uses of encrypted virtual private networks must meet all applicable Federal requirements and architecture, dataflow, and security and privacy controls must be documented, assessed, and authorized to operate.</p>
                     </part>
@@ -3375,17 +3375,17 @@
         </alter>
         <alter control-id="ia-2.1">
             <add position="ending" by-id="ia-2.1_smt">
-                <part id="ia-2.1_fr" name="item">
+                <part id="ia-2.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IA-2 (1) Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ia-2.1_fr_smt.1" name="item">
+                    <part id="ia-2.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>According to SP 800-63-3, SP 800-63A (IAL), SP 800-63B (AAL), and SP 800-63C (FAL).</p>
                     </part>
-                    <part id="ia-2.1_fr_smt.2" name="item">
+                    <part id="ia-2.1_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Multi-factor authentication must be phishing-resistant.</p>
                     </part>
-                    <part id="ia-2.1_fr_gdn.1" name="guidance">
+                    <part id="ia-2.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Multi-factor authentication to subsequent components in the same user domain is not required.</p>
                     </part>
@@ -3404,17 +3404,17 @@
         </alter>
         <alter control-id="ia-2.2">
             <add position="ending" by-id="ia-2.2_smt">
-                <part id="ia-2.2_fr" name="item">
+                <part id="ia-2.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IA-2 (2) Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ia-2.2_fr_smt.1" name="item">
+                    <part id="ia-2.2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>According to SP 800-63-3, SP 800-63A (IAL), SP 800-63B (AAL), and SP 800-63C (FAL).</p>
                     </part>
-                    <part id="ia-2.2_fr_smt.2" name="item">
+                    <part id="ia-2.2_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Multi-factor authentication must be phishing-resistant.</p>
                     </part>
-                    <part id="ia-2.2_fr_gdn.1" name="guidance">
+                    <part id="ia-2.2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Multi-factor authentication to subsequent components in the same user domain is not required.</p>
                     </part>
@@ -3434,9 +3434,9 @@
 
         <alter control-id="ia-2.12">
             <add position="ending" by-id="ia-2.12_smt">
-                <part id="ia-2.12_fr" name="item">
+                <part id="ia-2.12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IA-2 (12) Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ia-2.12_fr_gdn.1" name="guidance">
+                    <part id="ia-2.12_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Include Common Access Card (CAC), i.e., the DoD technical implementation of PIV/FIPS 201/HSPD-12.</p>
                     </part>
@@ -3508,13 +3508,13 @@
         <alter control-id="ia-5">
 
             <add position="ending" by-id="ia-5_smt">
-                <part id="ia-5_fr" name="item">
+                <part id="ia-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IA-5 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ia-5_fr_smt.1" name="item">
+                    <part id="ia-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Authenticators must be compliant with NIST SP 800-63-3 Digital Identity Guidelines IAL, AAL, FAL level 1. Link https://pages.nist.gov/800-63-3</p>
                     </part>
-                    <part id="ia-5_fr_gdn.1" name="guidance">
+                    <part id="ia-5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>SP 800-63C Section 6.2.3 Encrypted Assertion requires that authentication assertions be encrypted when passed through third parties, such as a browser. For example, a SAML assertion can be encrypted using XML-Encryption, or an OpenID Connect ID Token can be encrypted using JSON Web Encryption (JWE).</p>
                     </part>
@@ -3603,18 +3603,18 @@
         </alter>
         <alter control-id="ia-5.1">
             <add position="ending" by-id="ia-5.1_smt">
-                <part id="ia-5.1_fr" name="item">
+                <part id="ia-5.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IA-5 (1) Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ia-5.1_fr_smt.1" name="item">
+                    <part id="ia-5.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Password policies must be compliant with NIST SP 800-63B for all memorized, lookup, out-of-band, or One-Time-Passwords (OTP). Password policies shall not enforce special character or minimum password rotation requirements for memorized secrets of users.</p>
                     </part>
-                    <part id="ia-5.1_fr_smt.2" name="item">
+                    <part id="ia-5.1_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(h) Requirement:"/>
                         <p>For cases where technology doesn't allow multi-factor authentication, these rules should be enforced: must have a minimum length of 14 characters and must support all printable ASCII characters.</p>
                         <p>For emergency use accounts, these rules should be enforced: must have a minimum length of 14 characters, must support all printable ASCII characters, and passwords must be changed if used.</p>
                     </part>
-                    <part id="ia-5.1_fr_gdn.1" name="guidance">
+                    <part id="ia-5.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Note that (c) and (d) require the use of cryptography which must be compliant with Federal requirements and utilize FIPS validated or NSA approved cryptography (see SC-13).</p>
                     </part>
@@ -3683,9 +3683,9 @@
         <alter control-id="ia-11">
 
             <add position="ending" by-id="ia-11_smt">
-                <part id="ia-11_fr" name="item">
+                <part id="ia-11_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IA-11 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ia-11_fr_gdn.1" name="guidance">
+                    <part id="ia-11_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>The fixed time period cannot exceed the limits set in SP 800-63. At this writing they are:</p>
                         <ul>
@@ -3867,13 +3867,13 @@
         </alter>
         <alter control-id="ir-4">
             <add position="ending" by-id="ir-4_smt">
-                <part id="ir-4_fr" name="item">
+                <part id="ir-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IR-4 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ir-4_fr_smt.1" name="item">
+                    <part id="ir-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>The FISMA definition of &quot;incident&quot; shall be used: &quot;An occurrence that actually or imminently jeopardizes, without lawful authority, the confidentiality, integrity, or availability of information or an information system; or constitutes a violation or imminent threat of violation of law, security policies, security procedures, or acceptable use policies.&quot;</p>
                     </part>
-                    <part id="ir-4_fr_smt.2" name="item">
+                    <part id="ir-4_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>The service provider ensures that individuals conducting incident handling meet personnel security requirements commensurate with the criticality/sensitivity of the information being processed, stored, and transmitted by the information system.</p>
                     </part>
@@ -3938,9 +3938,9 @@
         <alter control-id="ir-6">
 
             <add position="ending" by-id="ir-6_smt">
-                <part id="ir-6_fr" name="item">
+                <part id="ir-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IR-6 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ir-6_fr_smt.1" name="item">
+                    <part id="ir-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Reports security incident information according to FedRAMP Incident Communications Procedure.</p>
                     </part>
@@ -3981,13 +3981,13 @@
         <alter control-id="ir-8">
 
             <add position="ending" by-id="ir-8_smt">
-                <part id="ir-8_fr" name="item">
+                <part id="ir-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>IR-8 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ir-8_fr_smt.1" name="item">
+                    <part id="ir-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(b) Requirement:"/>
                         <p>The service provider defines a list of incident response personnel (identified by name and/or by role) and organizational elements. The incident response list includes designated FedRAMP personnel.</p>
                     </part>
-                    <part id="ir-8_fr_smt.2" name="item">
+                    <part id="ir-8_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(d) Requirement:"/>
                         <p>The service provider defines a list of incident response personnel (identified by name and/or by role) and organizational elements. The incident response list includes designated FedRAMP personnel.</p>
                     </part>
@@ -4479,9 +4479,9 @@
         </alter>
         <alter control-id="pe-14">
             <add position="ending" by-id="pe-14_smt">
-                <part id="pe-14_fr" name="item">
+                <part id="pe-14_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>PE-14 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="pe-14_fr_smt.1" name="item">
+                    <part id="pe-14_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(a) Requirement:"/>
                         <p>The service provider measures temperature at server inlets and humidity levels by dew point.</p>
                     </part>
@@ -5008,9 +5008,9 @@
         <alter control-id="pl-8">
 
             <add position="ending" by-id="pl-8_smt">
-                <part id="pl-8_fr" name="item">
+                <part id="pl-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>PL-8 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="pl-8_fr_gdn.1" name="guidance">
+                    <part id="pl-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(b) Guidance:"/>
                         <p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F.</p>
                     </part>
@@ -5082,9 +5082,9 @@
         <alter control-id="pl-10">
 
             <add position="ending" by-id="pl-10_smt">
-                <part id="pl-10_fr" name="item">
+                <part id="pl-10_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>PL-10 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="pl-10_fr_smt.1" name="item">
+                    <part id="pl-10_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Select the appropriate FedRAMP Baseline</p>
                     </part>
@@ -5464,13 +5464,13 @@
         </alter>
         <alter control-id="ra-3">
             <add position="ending" by-id="ra-3_smt">
-                <part id="ra-3_fr" name="item">
+                <part id="ra-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>RA-3 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ra-3_fr_gdn.1" name="guidance">
+                    <part id="ra-3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F.</p>
                     </part>
-                    <part id="ra-3_fr_smt.1" name="item">
+                    <part id="ra-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(e) Requirement:"/>
                         <p>Include all Authorizing Officials; for JAB authorizations to include FedRAMP.</p>
                     </part>
@@ -5556,25 +5556,25 @@
         <alter control-id="ra-5">
 
             <add position="ending" by-id="ra-5_smt">
-                <part id="ra-5_fr" name="item">
+                <part id="ra-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>RA-5 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="ra-5_fr_gdn.1" name="guidance">
+                    <part id="ra-5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>See the FedRAMP Documents page&gt; Vulnerability Scanning Requirements https://www.FedRAMP.gov/documents/</p>
                     </part>
-                    <part id="ra-5_fr_smt.1" name="item">
+                    <part id="ra-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(a) Requirement:"/>
                         <p>an accredited independent assessor scans operating systems/infrastructure, web applications, and databases once annually.</p>
                     </part>
-                    <part id="ra-5_fr_smt.2" name="item">
+                    <part id="ra-5_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(d) Requirement:"/>
                         <p>If a vulnerability is listed among the CISA Known Exploited Vulnerability (KEV) Catalog (https://www.cisa.gov/known-exploited-vulnerabilities-catalog) the KEV remediation date supersedes the FedRAMP parameter requirement.</p>
                     </part>
-                    <part id="ra-5_fr_smt.3" name="item">
+                    <part id="ra-5_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(e) Requirement:"/>
                         <p>to include all Authorizing Officials; for JAB authorizations to include FedRAMP</p>
                     </part>
-                    <part id="ra-5_fr_gdn.2" name="guidance">
+                    <part id="ra-5_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Informational findings from a scanner are detailed as a returned result that holds no vulnerability risk or severity and for FedRAMP does not require an entry onto the POA&amp;M or entry onto the RET during any assessment phase.</p>
                         <p>Warning findings, on the other hand, are given a risk rating (low, moderate, high or critical) by the scanning solution and should be treated like any other finding with a risk or severity rating for tracking purposes onto either the POA&amp;M or RET depending on when the findings originated (during assessments or during monthly continuous monitoring). If a warning is received during scanning, but further validation turns up no actual issue then this item should be categorized as a false positive. If this situation presents itself during an assessment phase (initial assessment, annual assessment or any SCR), follow guidance on how to report false positives in the Security Assessment Report (SAR). If this situation happens during monthly continuous monitoring, a deviation request will need to be submitted per the FedRAMP Vulnerability Deviation Request Form.</p>
@@ -5857,13 +5857,13 @@
         </alter>
         <alter control-id="sa-4">
             <add position="ending" by-id="sa-4_smt">
-                <part id="sa-4_fr" name="item">
+                <part id="sa-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SA-4 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sa-4_fr_smt.1" name="item">
+                    <part id="sa-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>The service provider must comply with Federal Acquisition Regulation (FAR) Subpart 7.103, and Section 889 of the John S. McCain National Defense Authorization Act (NDAA) for Fiscal Year 2019 (Pub. L. 115-232), and FAR Subpart 4.21, which implements Section 889 (as well as any added updates related to FISMA to address security concerns in the system acquisitions process).</p>
                     </part>
-                    <part id="sa-4_fr_gdn.1" name="guidance">
+                    <part id="sa-4_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>The use of Common Criteria (ISO/IEC 15408) evaluated products is strongly preferred.</p>
                         <p>See https://www.niap-ccevs.org/Product/index.cfm or https://www.commoncriteriaportal.org/products/.</p>
@@ -6264,9 +6264,9 @@
         </alter>
         <alter control-id="sc-7">
             <add position="ending" by-id="sc-7_smt">
-                <part id="sc-7_fr" name="item">
+                <part id="sc-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SC-7 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sc-7_fr_gdn.1" name="guidance">
+                    <part id="sc-7_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="(b) Guidance:"/>
                         <p>SC-7 (b) should be met by subnet isolation. A subnetwork (subnet) is a physically or logically segmented section of a larger network defined at TCP/IP Layer 3, to both minimize traffic and, important for a FedRAMP Authorization, add a crucial layer of network isolation. Subnets are distinct from VLANs (Layer 2), security groups, and VPCs and are specifically required to satisfy SC-7 part b and other controls. See the FedRAMP Subnets White Paper (https://www.fedramp.gov/assets/resources/documents/FedRAMP_subnets_white_paper.pdf) for additional information.</p>
                     </part>
@@ -6319,9 +6319,9 @@
         </alter>
         <alter control-id="sc-8">
             <add position="ending" by-id="sc-8_smt">
-                <part id="sc-8_fr" name="item">
+                <part id="sc-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SC-8 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sc-8_fr_gdn.1" name="guidance">
+                    <part id="sc-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>For each instance of data in transit, confidentiality AND integrity should be through cryptography as specified in SC-8 (1), physical means as specified in SC-8 (5), or in combination.</p>
                         <p> </p>
@@ -6341,7 +6341,7 @@
                         <p>SC-8 (5)-1 [a hardened or alarmed carrier Protective Distribution System (PDS) when outside of Controlled Access Area (CAA)]</p>
                         <p>SC-8 (5)-2 [prevent unauthorized disclosure of information AND detect changes to information] </p>
                     </part>
-                    <part id="sc-8_fr_gdn.2" name="guidance">
+                    <part id="sc-8_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>SC-8 (5) applies when physical protection has been selected as the method to protect confidentiality and integrity. For physical protection, data in transit must be in either a Controlled Access Area (CAA), or a Hardened or alarmed PDS.</p>
                         <p> </p>
@@ -6374,22 +6374,22 @@
         </alter>
         <alter control-id="sc-8.1">
             <add position="ending" by-id="sc-8.1_smt">
-                <part id="sc-8.1_fr" name="item">
+                <part id="sc-8.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SC-8 (1) Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sc-8.1_fr_smt.1" name="item">
+                    <part id="sc-8.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Please ensure SSP Section 10.3 Cryptographic Modules Implemented for Data At Rest (DAR) and Data In Transit (DIT) is fully populated for reference in this control.</p>
                     </part>
-                    <part id="sc-8.1_fr_gdn.1" name="guidance">
+                    <part id="sc-8.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>See M-22-09, including &quot;Agencies encrypt all DNS requests and HTTP traffic within their environment&quot;</p>
                         <p>SC-8 (1) applies when encryption has been selected as the method to protect confidentiality and integrity. Otherwise refer to SC-8 (5). SC-8 (1) is strongly encouraged.</p>
                     </part>
-                    <part id="sc-8.1_fr_gdn.2" name="guidance">
+                    <part id="sc-8.1_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Note that this enhancement requires the use of cryptography which must be compliant with Federal requirements and utilize FIPS validated or NSA approved cryptography (see SC-13.)</p>
                     </part>
-                    <part id="sc-8.1_fr_gdn.3" name="guidance">
+                    <part id="sc-8.1_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>When leveraging encryption from the underlying IaaS/PaaS: While some IaaS/PaaS services provide encryption by default, many require encryption to be configured, and enabled by the customer. The CSP has the responsibility to verify encryption is properly configured.</p>
                     </part>
@@ -6407,17 +6407,17 @@
         </alter>
         <alter control-id="sc-12">
             <add position="ending" by-id="sc-12_smt">
-                <part id="sc-12_fr" name="item">
+                <part id="sc-12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SC-12 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sc-12_fr_gdn.1" name="guidance">
+                    <part id="sc-12_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>See references in NIST 800-53 documentation.</p>
                     </part>
-                    <part id="sc-12_fr_gdn.2" name="guidance">
+                    <part id="sc-12_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Must meet applicable Federal Cryptographic Requirements. See References Section of control.</p>
                     </part>
-                    <part id="sc-12_fr_gdn.3" name="guidance">
+                    <part id="sc-12_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Wildcard certificates may be used internally within the system, but are not permitted for external customer access to the system.</p>
                     </part>
@@ -6439,10 +6439,10 @@
         <alter control-id="sc-13">
 
             <add position="ending" by-id="sc-13_smt">
-                <part id="sc-13_fr" name="item">
+                <part id="sc-13_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SC-13 Additional FedRAMP Requirements and Guidance</title>
 
-                    <part id="sc-13_fr_gdn.1" name="guidance">
+                    <part id="sc-13_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>This control applies to all use of cryptography. In addition to encryption, this includes functions such as hashing, random number generation, and key generation. Examples include the following:</p>
                         <ul>
@@ -6455,16 +6455,16 @@
                         <p>The requirement for FIPS 140 validation, as well as timelines for acceptance of FIPS 140-2, and 140-3 can be found at the NIST Cryptographic Module Validation Program (CMVP).</p>
                         <p>https://csrc.nist.gov/projects/cryptographic-module-validation-program</p>
                     </part>
-                    <part id="sc-13_fr_gdn.2" name="guidance">
+                    <part id="sc-13_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>For NSA-approved cryptography, the National Information Assurance Partnership (NIAP) oversees a national program to evaluate Commercial IT Products for Use in National Security Systems. The NIAP Product Compliant List can be found at the following location:</p>
                         <p>https://www.niap-ccevs.org/Product/index.cfm</p>
                     </part>
-                    <part id="sc-13_fr_gdn.3" name="guidance">
+                    <part id="sc-13_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>When leveraging encryption from underlying IaaS/PaaS: While some IaaS/PaaS provide encryption by default, many require encryption to be configured, and enabled by the customer. The CSP has the responsibility to verify encryption is properly configured.</p>
                     </part>
-                    <part id="sc-13_fr_gdn.4" name="guidance">
+                    <part id="sc-13_fr_gdn.4" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Moving to non-FIPS CM or product is acceptable when:</p>
                         <ul>
@@ -6475,7 +6475,7 @@
                             <li>POA&amp;M is added to track approval, and deployment when ready</li>
                         </ul>
                     </part>
-                    <part id="sc-13_fr_gdn.5" name="guidance">
+                    <part id="sc-13_fr_gdn.5" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>At a minimum, this control applies to cryptography in use for the following controls: AU-9(3), CP-9(8), IA-2(6), IA-5(1), MP-5, SC-8(1), and SC-28(1).</p>
                     </part>
@@ -6504,9 +6504,9 @@
         </alter>
         <alter control-id="sc-15">
             <add position="ending" by-id="sc-15_smt">
-                <part id="sc-15_fr" name="item">
+                <part id="sc-15_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SC-15 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sc-15_fr_smt.1" name="item">
+                    <part id="sc-15_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>The information system provides disablement (instead of physical disconnect) of collaborative computing devices in a manner that supports ease of use.</p>
                     </part>
@@ -6532,21 +6532,21 @@
         </alter>
         <alter control-id="sc-20">
             <add position="ending" by-id="sc-20_smt">
-                <part id="sc-20_fr" name="item">
+                <part id="sc-20_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SC-20 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sc-20_fr_smt.1" name="item">
+                    <part id="sc-20_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Control Description should include how DNSSEC is implemented on authoritative DNS servers to supply valid responses to external DNSSEC requests.</p>
                     </part>
-                    <part id="sc-20_fr_gdn.1" name="guidance">
+                    <part id="sc-20_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>SC-20 applies to use of external authoritative DNS to access a CSO from outside the boundary.</p>
                     </part>
-                    <part id="sc-20_fr_gdn.2" name="guidance">
+                    <part id="sc-20_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>External authoritative DNS servers may be located outside an authorized environment. Positioning these servers inside an authorized boundary is encouraged.</p>
                     </part>
-                    <part id="sc-20_fr_gdn.3" name="guidance">
+                    <part id="sc-20_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>CSPs are recommended to self-check DNSSEC configuration through one of many available analyzers such as Sandia National Labs (https://dnsviz.net)</p>
                     </part>
@@ -6579,9 +6579,9 @@
         </alter>
         <alter control-id="sc-21">
             <add position="ending" by-id="sc-21_smt">
-                <part id="sc-21_fr" name="item">
+                <part id="sc-21_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SC-21 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sc-21_fr_smt.1" name="item">
+                    <part id="sc-21_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Control description should include how DNSSEC is implemented on recursive DNS servers to make DNSSEC requests when resolving DNS requests from internal components to domains external to the CSO boundary.</p>
                         <ul>
@@ -6592,15 +6592,15 @@
                             </li>
                         </ul>
                     </part>
-                    <part id="sc-21_fr_smt.2" name="item">
+                    <part id="sc-21_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>Internal recursive DNS servers must be located inside an authorized environment. It is typically within the boundary, or leveraged from an underlying IaaS/PaaS.</p>
                     </part>
-                    <part id="sc-21_fr_gdn.1" name="guidance">
+                    <part id="sc-21_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Accepting an unsigned reply is acceptable</p>
                     </part>
-                    <part id="sc-21_fr_gdn.2" name="guidance">
+                    <part id="sc-21_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>SC-21 applies to use of internal recursive DNS to access a domain outside the boundary by a component inside the boundary.</p>
                         <ul>
@@ -6624,17 +6624,17 @@
         </alter>
         <alter control-id="sc-28">
             <add position="ending" by-id="sc-28_smt">
-                <part id="sc-28_fr" name="item">
+                <part id="sc-28_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SC-28 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sc-28_fr_gdn.1" name="guidance">
+                    <part id="sc-28_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>The organization supports the capability to use cryptographic mechanisms to protect information at rest.</p>
                     </part>
-                    <part id="sc-28_fr_gdn.2" name="guidance">
+                    <part id="sc-28_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>When leveraging encryption from underlying IaaS/PaaS: While some IaaS/PaaS services provide encryption by default, many require encryption to be configured, and enabled by the customer. The CSP has the responsibility to verify encryption is properly configured.</p>
                     </part>
-                    <part id="sc-28_fr_gdn.3" name="guidance">
+                    <part id="sc-28_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Note that this enhancement requires the use of cryptography in accordance with SC-13.</p>
                     </part>
@@ -6655,9 +6655,9 @@
         </alter>
         <alter control-id="sc-28.1">
             <add position="ending" by-id="sc-28.1_smt">
-                <part id="sc-28.1_fr" name="item">
+                <part id="sc-28.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SC-28 (1) Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sc-28.1_fr_gdn.1" name="guidance">
+                    <part id="sc-28.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>Organizations should select a mode of protection that is targeted towards the relevant threat scenarios.</p>
                         <p>Examples:</p>
@@ -6836,9 +6836,9 @@
         <alter control-id="si-4">
 
             <add position="ending" by-id="si-4_smt">
-                <part id="si-4_fr" name="item">
+                <part id="si-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SI-4 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="si-4_fr_gdn.1" name="guidance">
+                    <part id="si-4_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Guidance:"/>
                         <p>See US-CERT Incident Response Reporting Guidelines.</p>
                     </part>
@@ -6918,7 +6918,7 @@
         </alter>
         <alter control-id="si-5">
             <add position="ending" by-id="si-5_smt">
-                <part id="si-5_fr_smt.1" name="item">
+                <part id="si-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SI-5 Additional FedRAMP Requirements and Guidance</title>
                     <prop name="label" value="Requirement:"/>
                     <p>Service Providers must address the CISA Emergency and Binding Operational Directives applicable to their cloud service offering per FedRAMP guidance. This includes listing the applicable directives and stating compliance status.</p>
@@ -7129,9 +7129,9 @@
         <alter control-id="sr-3">
 
             <add position="ending" by-id="sr-3_smt">
-                <part id="sr-3_fr" name="item">
+                <part id="sr-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SR-3 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sr-3_fr_smt.1" name="item">
+                    <part id="sr-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>CSO must document and maintain the supply chain custody, including replacement devices, to ensure the integrity of the devices before being introduced to the boundary.</p>
                     </part>
@@ -7182,9 +7182,9 @@
         <alter control-id="sr-8">
 
             <add position="ending" by-id="sr-8_smt">
-                <part id="sr-8_fr" name="item">
+                <part id="sr-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SR-8 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sr-8_fr_smt.1" name="item">
+                    <part id="sr-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>CSOs must ensure and document how they receive notifications from their supply chain vendor of newly discovered vulnerabilities including zero-day vulnerabilities.</p>
                     </part>
@@ -7203,9 +7203,9 @@
         <alter control-id="sr-11">
 
             <add position="ending" by-id="sr-11_smt">
-                <part id="sr-11_fr" name="item">
+                <part id="sr-11_fr" name="item" ns="http://fedramp.gov/ns/oscal">
                     <title>SR-11 Additional FedRAMP Requirements and Guidance</title>
-                    <part id="sr-11_fr_smt.1" name="item">
+                    <part id="sr-11_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
                         <prop name="label" value="Requirement:"/>
                         <p>CSOs must ensure that their supply chain vendors provide authenticity of software and patches and the vendor must have a plan to protect the development pipeline.</p>
                     </part>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_complete_schema.xsd" schematypens="http://www.w3.org/2001/XMLSchema" title="OSCAL complete schema"?>
-<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="b3d53132-0160-417a-ae1b-c9da8385d698">
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="dbe9dc76-abaf-4be6-a092-9a264110af1a">
 	<metadata>
 		<title>FedRAMP Rev 5 Moderate Baseline</title>
 		<published>2024-09-24T02:24:00Z</published>
-		<last-modified>2024-09-24T02:24:00Z</last-modified>
-		<version>fedramp2.1.0-oscal1.0.4</version>
-		<oscal-version>1.0.4</oscal-version>
+		<last-modified>2025-01-15T00:00:00Z</last-modified>
+		<version>fedramp-3.0.0rc1-oscal-1.1.2</version>
+		<oscal-version>1.1.2</oscal-version>
 		<role id="prepared-by">
 			<title>Document creator</title>
 		</role>
@@ -2494,17 +2494,17 @@
 		<alter control-id="ac-2.3">
 
 			<add position="ending" by-id="ac-2.3_smt">
-				<part id="ac-2.3_fr" name="item">
+				<part id="ac-2.3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-2 (3) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-2.3_fr_smt.1" name="item">
+					<part id="ac-2.3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider defines the time period for non-user accounts (e.g., accounts associated with devices). The time periods are approved and accepted by the JAB/AO. Where user management is a function of the service, reports of activity of consumer users shall be made available.</p>
 					</part>
-					<part id="ac-2.3_fr_smt.2" name="item">
+					<part id="ac-2.3_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(d) Requirement:"/>
 						<p>The service provider defines the time period of inactivity for device identifiers.</p>
 					</part>
-					<part id="ac-2.3_fr_gdn.1" name="guidance">
+					<part id="ac-2.3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For DoD clouds, see DoD cloud website for specific DoD requirements that go above and beyond FedRAMP https://public.cyber.mil/dccs/.</p>
 					</part>
@@ -2562,9 +2562,9 @@
 		<alter control-id="ac-2.5">
 
 			<add position="ending" by-id="ac-2.5_smt">
-				<part id="ac-2.5_fr" name="item">
+				<part id="ac-2.5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-2 (5) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-2.5_fr_gdn.1" name="guidance">
+					<part id="ac-2.5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Should use a shorter timeframe than AC-12.</p>
 					</part>
@@ -2621,9 +2621,9 @@
 		</alter>
 		<alter control-id="ac-2.9">
 			<add position="ending" by-id="ac-2.9_smt">
-				<part id="ac-2.9_fr" name="item">
+				<part id="ac-2.9_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-2 (9) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-2.9_fr_smt.1" name="item">
+					<part id="ac-2.9_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Required if shared/group accounts are deployed.</p>
 					</part>
@@ -2644,13 +2644,13 @@
 		<alter control-id="ac-2.12">
 
 			<add position="ending" by-id="ac-2.12_smt">
-				<part id="ac-2.12_fr" name="item">
+				<part id="ac-2.12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-2 (12) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-2.12_fr_smt.1" name="item">
+					<part id="ac-2.12_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>Required for privileged accounts.</p>
 					</part>
-					<part id="ac-2.12_fr_smt.2" name="item">
+					<part id="ac-2.12_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
 						<p>Required for privileged accounts.</p>
 					</part>
@@ -2792,9 +2792,9 @@
 		</alter>
 		<alter control-id="ac-5">
 			<add position="ending" by-id="ac-5_smt">
-				<part id="ac-5_fr" name="item">
+				<part id="ac-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-5 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-5_fr_gdn.1" name="guidance">
+					<part id="ac-5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>CSPs have the option to provide a separation of duties matrix as an attachment to the SSP.</p>
 					</part>
@@ -2861,9 +2861,9 @@
 		</alter>
 		<alter control-id="ac-6.2">
 			<add position="ending" by-id="ac-6.2_smt">
-				<part id="ac-6.2_fr" name="item">
+				<part id="ac-6.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-6 (2) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-6.2_fr_gdn.1" name="guidance">
+					<part id="ac-6.2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Examples of security functions include but are not limited to: establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters, system programming, system and security administration, other privileged functions.</p>
 					</part>
@@ -2926,9 +2926,9 @@
 		<alter control-id="ac-7">
 
 			<add position="ending" by-id="ac-7_smt">
-				<part id="ac-7_fr" name="item">
+				<part id="ac-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-7 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-7_fr_smt.1" name="item">
+					<part id="ac-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>In alignment with NIST SP 800-63B</p>
 					</part>
@@ -2953,21 +2953,21 @@
 		</alter>
 		<alter control-id="ac-8">
 			<add position="ending" by-id="ac-8_smt">
-				<part id="ac-8_fr" name="item">
+				<part id="ac-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-8_fr_smt.1" name="item">
+					<part id="ac-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider shall determine elements of the cloud environment that require the System Use Notification control. The elements of the cloud environment that require System Use Notification are approved and accepted by the JAB/AO.</p>
 					</part>
-					<part id="ac-8_fr_smt.2" name="item">
+					<part id="ac-8_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider shall determine how System Use Notification is going to be verified and provide appropriate periodicity of the check. The System Use Notification verification and periodicity are approved and accepted by the JAB/AO.</p>
 					</part>
-					<part id="ac-8_fr_smt.3" name="item">
+					<part id="ac-8_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>If not performed as part of a Configuration Baseline check, then there must be documented agreement on how to provide results of verification and the necessary periodicity of the verification by the service provider. The documented agreement on how to provide verification of the results are approved and accepted by the JAB/AO.</p>
 					</part>
-					<part id="ac-8_fr_gdn.1" name="guidance">
+					<part id="ac-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>If performed as part of a Configuration Baseline check, then the % of items requiring setting that are checked and that pass (or fail) check can be provided.</p>
 					</part>
@@ -3020,9 +3020,9 @@
 
 		<alter control-id="ac-20">
 			<add position="ending" by-id="ac-20_smt">
-				<part id="ac-20_fr" name="item">
+				<part id="ac-20_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AC-20 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ac-20_fr_gdn.1" name="guidance">
+					<part id="ac-20_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The interrelated controls of AC-20, CA-3, and SA-9 should be differentiated as follows:</p>
 						<p>AC-20 describes system access to and from external systems.</p>
@@ -3318,13 +3318,13 @@
 		<alter control-id="au-2">
 
 			<add position="ending" by-id="au-2_smt">
-				<part id="au-2_fr" name="item">
+				<part id="au-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AU-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="au-2_fr_smt.1" name="item">
+					<part id="au-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Coordination between service provider and consumer shall be documented and accepted by the JAB/AO.</p>
 					</part>
-					<part id="au-2_fr_gdn.1" name="guidance">
+					<part id="au-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Guidance:"/>
 						<p>Annually or whenever changes in the threat environment are communicated to the service provider by the JAB/AO.</p>
 					</part>
@@ -3407,9 +3407,9 @@
 		</alter>
 		<alter control-id="au-3.1">
 			<add position="ending" by-id="au-3.1_smt">
-				<part id="au-3.1_fr" name="item">
+				<part id="au-3.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AU-3 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="au-3.1_fr_gdn.1" name="guidance">
+					<part id="au-3.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For client-server transactions, the number of bytes sent and received gives bidirectional transfer information that can be helpful during an investigation or inquiry.</p>
 					</part>
@@ -3464,9 +3464,9 @@
 		<alter control-id="au-6">
 
 			<add position="ending" by-id="au-6_smt">
-				<part id="au-6_fr" name="item">
+				<part id="au-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AU-6 Additional FedRAMP Requirements and Guidance</title>
-					<part id="au-6_fr_smt.1" name="item">
+					<part id="au-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Coordination between service provider and consumer shall be documented and accepted by the JAB/AO. In multi-tenant environments, capability and means for providing review, analysis, and reporting to consumer for data pertaining to consumer shall be documented.</p>
 					</part>
@@ -3506,17 +3506,17 @@
 		<alter control-id="au-11">
 
 			<add position="ending" by-id="au-11_smt">
-				<part id="au-11_fr" name="item">
+				<part id="au-11_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>AU-11 Additional FedRAMP Requirements and Guidance</title>
-					<part id="au-11_fr_smt.1" name="item">
+					<part id="au-11_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider retains audit records on-line for at least ninety days and further preserves audit records off-line for a period that is in accordance with NARA requirements.</p>
 					</part>
-					<part id="au-11_fr_smt.2" name="item">
+					<part id="au-11_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider must support Agency requirements to comply with M-21-31 (https://www.whitehouse.gov/wp-content/uploads/2021/08/M-21-31-Improving-the-Federal-Governments-Investigative-and-Remediation-Capabilities-Related-to-Cybersecurity-Incidents.pdf)</p>
 					</part>
-					<part id="au-11_fr_gdn.1" name="guidance">
+					<part id="au-11_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The service provider is encouraged to align with M-21-31 where possible</p>
 					</part>
@@ -3698,9 +3698,9 @@
 		<alter control-id="ca-2">
 
 			<add position="ending" by-id="ca-2_smt">
-				<part id="ca-2_fr" name="item">
+				<part id="ca-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-2_fr_gdn.1" name="guidance">
+					<part id="ca-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Reference FedRAMP Annual Assessment Guidance.</p>
 					</part>
@@ -3764,9 +3764,9 @@
 		</alter>
 		<alter control-id="ca-2.1">
 			<add position="ending" by-id="ca-2.1_smt">
-				<part id="ca-2.1_fr" name="item">
+				<part id="ca-2.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-2 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-2.1_fr_smt.1" name="item">
+					<part id="ca-2.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>For JAB Authorization, must use an accredited 3PAO.</p>
 					</part>
@@ -3822,13 +3822,13 @@
 		<alter control-id="ca-5">
 
 			<add position="ending" by-id="ca-5_smt">
-				<part id="ca-5_fr" name="item">
+				<part id="ca-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-5 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-5_fr_smt.1" name="item">
+					<part id="ca-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>POA&amp;Ms must be provided at least monthly.</p>
 					</part>
-					<part id="ca-5_fr_gdn.1" name="guidance">
+					<part id="ca-5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Reference FedRAMP-POAM-Template</p>
 					</part>
@@ -3853,9 +3853,9 @@
 		</alter>
 		<alter control-id="ca-6">
 			<add position="ending" by-id="ca-6_smt">
-				<part id="ca-6_fr" name="item">
+				<part id="ca-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-6 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-6_fr_gdn.1" name="guidance">
+					<part id="ca-6_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Guidance:"/>
 						<p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F and according to FedRAMP Significant Change Policies and Procedures. The service provider describes the types of changes to the information system or the environment of operations that would impact the risk posture. The types of changes are approved and accepted by the JAB/AO.</p>
 					</part>
@@ -3909,17 +3909,17 @@
 		<alter control-id="ca-7">
 
 			<add position="ending" by-id="ca-7_smt">
-				<part id="ca-7_fr" name="item">
+				<part id="ca-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-7 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-7_fr_smt.1" name="item">
+					<part id="ca-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Operating System, Database, Web Application, Container, and Service Configuration Scans: at least monthly. All scans performed by Independent Assessor: at least annually.</p>
 					</part>
-					<part id="ca-7_fr_smt.2" name="item">
+					<part id="ca-7_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSOs with more than one agency ATO must implement a collaborative Continuous Monitoring (Con Mon) approach described in the FedRAMP Guide for Multi-Agency Continuous Monitoring. This requirement applies to CSPs authorized via the Agency path as each agency customer is responsible for performing Con Mon oversight. It does not apply to CSPs authorized via the JAB path because the JAB performs Con Mon oversight.</p>
 					</part>
-					<part id="ca-7_fr_gdn.1" name="guidance">
+					<part id="ca-7_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>FedRAMP does not provide a template for the Continuous Monitoring Plan. CSPs should reference the FedRAMP Continuous Monitoring Strategy Guide when developing the Continuous Monitoring Plan.</p>
 					</part>
@@ -4037,9 +4037,9 @@
 		<alter control-id="ca-8">
 
 			<add position="ending" by-id="ca-8_smt">
-				<part id="ca-8_fr" name="item">
+				<part id="ca-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-8_fr_gdn.1" name="guidance">
+					<part id="ca-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Reference the FedRAMP Penetration Test Guidance.</p>
 					</part>
@@ -4066,9 +4066,9 @@
 		</alter>
 		<alter control-id="ca-8.2">
 			<add position="ending" by-id="ca-8.2_smt">
-				<part id="ca-8.2_fr" name="item">
+				<part id="ca-8.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CA-8(2) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-8.2_fr_gdn.1" name="guidance">
+					<part id="ca-8.2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See the FedRAMP Documents page&gt; Penetration Test Guidance</p>
 						<p>https://www.FedRAMP.gov/documents/</p>
@@ -4232,9 +4232,9 @@
 		<alter control-id="cm-2">
 
 			<add position="ending" by-id="cm-2_smt">
-				<part id="cm-2_fr" name="item">
+				<part id="cm-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-2_fr_gdn.1" name="guidance">
+					<part id="cm-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) (1) Guidance:"/>
 						<p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F.</p>
 					</part>
@@ -4306,13 +4306,13 @@
 		<alter control-id="cm-3">
 
 			<add position="ending" by-id="cm-3_smt">
-				<part id="cm-3_fr" name="item">
+				<part id="cm-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-3 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-3_fr_smt.1" name="item">
+					<part id="cm-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider establishes a central means of communicating major changes to or developments in the information system or environment of operations that may affect its services to the federal government and associated service consumers (e.g., electronic bulletin board, web status page). The means of communication are approved and accepted by the JAB/AO.</p>
 					</part>
-					<part id="cm-3_fr_gdn.1" name="guidance">
+					<part id="cm-3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Guidance:"/>
 						<p>In accordance with record retention policies and procedures.</p>
 					</part>
@@ -4470,17 +4470,17 @@
 		<alter control-id="cm-6">
 
 			<add position="ending" by-id="cm-6_smt">
-				<part id="cm-6_fr" name="item">
+				<part id="cm-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-6 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-6_fr_smt.1" name="item">
+					<part id="cm-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement 1:"/>
 						<p>The service provider shall use the DoD STIGs to establish configuration settings; Center for Internet Security up to Level 2 (CIS Level 2) guidelines shall be used if STIGs are not available; Custom baselines shall be used if CIS is not available.</p>
 					</part>
-					<part id="cm-6_fr_smt.2" name="item">
+					<part id="cm-6_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement 2:"/>
 						<p>The service provider shall ensure that checklists for configuration settings are Security Content Automation Protocol (SCAP) validated or SCAP compatible (if validated checklists are not available).</p>
 					</part>
-					<part id="cm-6_fr_gdn.1" name="guidance">
+					<part id="cm-6_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Compliance checks are used to evaluate configuration settings and provide general insight into the overall effectiveness of configuration management activities. CSPs and 3PAOs typically combine compliance check findings into a single CM-6 finding, which is acceptable. However, for initial assessments, annual assessments, and significant change requests, FedRAMP requires a clear understanding, on a per-control basis, where risks exist. Therefore, 3PAOs must also analyze compliance check findings as part of the controls assessment. Where a direct mapping exists, the 3PAO must document additional findings per control in the corresponding SAR Risk Exposure Table (RET), which are then documented in the CSP's Plan of Action and Milestones (POA&amp;M). This will likely result in the details of individual control findings overlapping with those in the combined CM-6 finding, which is acceptable.</p>
 						<p>During monthly continuous monitoring, new findings from CSP compliance checks may be combined into a single CM-6 POA&amp;M item. CSPs are not required to map the findings to specific controls because controls are only assessed during initial assessments, annual assessments, and significant change requests.</p>
@@ -4536,9 +4536,9 @@
 		</alter>
 		<alter control-id="cm-7">
 			<add position="ending" by-id="cm-7_smt">
-				<part id="cm-7_fr" name="item">
+				<part id="cm-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-7 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-7_fr_smt.1" name="item">
+					<part id="cm-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
 						<p>The service provider shall use Security guidelines (See CM-6) to establish list of prohibited or restricted functions, ports, protocols, and/or services or establishes its own list of prohibited or restricted functions, ports, protocols, and/or services if STIGs or CIS is not available.</p>
 					</part>
@@ -4587,9 +4587,9 @@
 		</alter>
 		<alter control-id="cm-7.2">
 			<add position="ending" by-id="cm-7.2_smt">
-				<part id="cm-7.2_fr" name="item">
+				<part id="cm-7.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-7 (2) Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-7.2_fr_gdn.1" name="guidance">
+					<part id="cm-7.2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>This control refers to software deployment by CSP personnel into the production environment. The control requires a policy that states conditions for deploying software. This control shall be implemented in a technical manner on the information system to only allow programs to run that adhere to the policy (i.e. allow-listing). This control is not to be based off of strictly written policy on what is allowed or not allowed to run.</p>
 					</part>
@@ -4638,9 +4638,9 @@
 		<alter control-id="cm-8">
 
 			<add position="ending" by-id="cm-8_smt">
-				<part id="cm-8_fr" name="item">
+				<part id="cm-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-8_fr_smt.1" name="item">
+					<part id="cm-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>must be provided at least monthly or when there is a change.</p>
 					</part>
@@ -4716,7 +4716,7 @@
 		<alter control-id="cm-9">
 
 			<add position="ending" by-id="cm-9_smt">
-				<part id="cm-9_fr_gdn.1" name="guidance">
+				<part id="cm-9_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 					<prop name="label" value="Guidance:"/>
 					<p>FedRAMP does not provide a template for the Configuration Management Plan. However, NIST SP 800-128, Guide for Security-Focused Configuration Management of Information Systems, provides guidelines for the implementation of CM controls as well as a sample CMP outline in Appendix D of the Guide</p>
 				</part>
@@ -4774,9 +4774,9 @@
 		<alter control-id="cm-12">
 
 			<add position="ending" by-id="cm-12_smt">
-				<part id="cm-12_fr" name="item">
+				<part id="cm-12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-12 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-12_fr_smt.1" name="item">
+					<part id="cm-12_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>According to FedRAMP Authorization Boundary Guidance</p>
 					</part>
@@ -4820,9 +4820,9 @@
 		<alter control-id="cm-12.1">
 
 			<add position="ending" by-id="cm-12.1_smt">
-				<part id="cm-12.1_fr" name="item">
+				<part id="cm-12.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CM-12 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="cm-12.1_fr_smt.1" name="item">
+					<part id="cm-12.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>According to FedRAMP Authorization Boundary Guidance.</p>
 					</part>
@@ -4919,13 +4919,13 @@
 		<alter control-id="cp-2">
 
 			<add position="ending" by-id="cp-2_smt">
-				<part id="cp-2_fr" name="item">
+				<part id="cp-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-2_fr_smt.1" name="item">
+					<part id="cp-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>For JAB authorizations the contingency lists include designated FedRAMP personnel.</p>
 					</part>
-					<part id="cp-2_fr_smt.2" name="item">
+					<part id="cp-2_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSPs must use the FedRAMP Information System Contingency Plan (ISCP) Template (available on the fedramp.gov: https://www.fedramp.gov/assets/resources/templates/SSP-A06-FedRAMP-ISCP-Template.docx).</p>
 					</part>
@@ -5063,9 +5063,9 @@
 		<alter control-id="cp-3">
 
 			<add position="ending" by-id="cp-3_smt">
-				<part id="cp-3_fr" name="item">
+				<part id="cp-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-3 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-3_fr_smt.1" name="item">
+					<part id="cp-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>Privileged admins and engineers must take the basic contingency training within 10 days. Consideration must be given for those privileged admins and engineers with critical contingency-related roles, to gain enough system context and situational awareness to understand the full impact of contingency training as it applies to their respective level. Newly hired critical contingency personnel must take this more in-depth training within 60 days of hire date when the training will have more impact.</p>
 					</part>
@@ -5106,13 +5106,13 @@
 		<alter control-id="cp-4">
 
 			<add position="ending" by-id="cp-4_smt">
-				<part id="cp-4_fr" name="item">
+				<part id="cp-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-4 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-4_fr_smt.1" name="item">
+					<part id="cp-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider develops test plans in accordance with NIST Special Publication 800-34 (as amended); plans are approved by the JAB/AO prior to initiating testing.</p>
 					</part>
-					<part id="cp-4_fr_smt.1" name="item">
+					<part id="cp-4_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
 						<p>The service provider must include the Contingency Plan test results with the security package within the Contingency Plan-designated appendix (Appendix G, Contingency Plan Test Report).</p>
 					</part>
@@ -5224,9 +5224,9 @@
 		</alter>
 		<alter control-id="cp-7">
 			<add position="ending" by-id="cp-7_smt">
-				<part id="cp-7_fr" name="item">
+				<part id="cp-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-7 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-7_fr_smt.1" name="item">
+					<part id="cp-7_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider defines a time period consistent with the recovery time objectives and business impact analysis.</p>
 					</part>
@@ -5268,9 +5268,9 @@
 		</alter>
 		<alter control-id="cp-7.1">
 			<add position="ending" by-id="cp-7.1_smt">
-				<part id="cp-7.1_fr" name="item">
+				<part id="cp-7.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-7 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-7.1_fr_smt.1" name="guidance">
+					<part id="cp-7.1_fr_smt.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The service provider may determine what is considered a sufficient degree of separation between the primary and alternate processing sites, based on the types of threats that are of concern. For one particular type of threat (i.e., hostile cyber attack), the degree of separation between sites will be less relevant.</p>
 					</part>
@@ -5312,9 +5312,9 @@
 		</alter>
 		<alter control-id="cp-8">
 			<add position="ending" by-id="cp-8_smt">
-				<part id="cp-8_fr" name="item">
+				<part id="cp-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-8_fr_gdn.1" name="item">
+					<part id="cp-8_fr_gdn.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider defines a time period consistent with the recovery time objectives and business impact analysis.</p>
 					</part>
@@ -5362,21 +5362,21 @@
 		</alter>
 		<alter control-id="cp-9">
 			<add position="ending" by-id="cp-9_smt">
-				<part id="cp-9_fr" name="item">
+				<part id="cp-9_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-9 Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-9_fr_smt.1" name="item">
+					<part id="cp-9_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider shall determine what elements of the cloud environment require the Information System Backup control. The service provider shall determine how Information System Backup is going to be verified and appropriate periodicity of the check.</p>
 					</part>
-					<part id="cp-9_fr_smt.2" name="item">
+					<part id="cp-9_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider maintains at least three backup copies of user-level information (at least one of which is available online) or provides an equivalent alternative.</p>
 					</part>
-					<part id="cp-9_fr_smt.3" name="item">
+					<part id="cp-9_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
 						<p>The service provider maintains at least three backup copies of system-level information (at least one of which is available online) or provides an equivalent alternative.</p>
 					</part>
-					<part id="cp-9_fr_smt.4" name="item">
+					<part id="cp-9_fr_smt.4" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(c) Requirement:"/>
 						<p>The service provider maintains at least three backup copies of information system documentation including security information (at least one of which is available online) or provides an equivalent alternative.</p>
 					</part>
@@ -5433,9 +5433,9 @@
 		<alter control-id="cp-9.8">
 
 			<add position="ending" by-id="cp-9.8_smt">
-				<part id="cp-9.8_fr" name="item">
+				<part id="cp-9.8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>CP-9 (8) Additional FedRAMP Requirements and Guidance</title>
-					<part id="cp-9.8_fr_gdn.1" name="guidance">
+					<part id="cp-9.8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Note that this enhancement requires the use of cryptography which must be compliant with Federal requirements and utilize FIPS validated or NSA approved cryptography (see SC-13.)</p>
 					</part>
@@ -5531,21 +5531,21 @@
 		</alter>
 		<alter control-id="ia-2">
 			<add position="ending" by-id="ia-2_smt">
-				<part id="ia-2_fr" name="item">
+				<part id="ia-2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-2_fr_smt.1" name="item">
+					<part id="ia-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>For all control enhancements that specify multifactor authentication, the implementation must adhere to the Digital Identity Guidelines specified in NIST Special Publication 800-63B.</p>
 					</part>
-					<part id="ia-2_fr_smt.2" name="item">
+					<part id="ia-2_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Multi-factor authentication must be phishing-resistant.</p>
 					</part>
-					<part id="ia-2_fr_smt.3" name="item">
+					<part id="ia-2_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>All uses of encrypted virtual private networks must meet all applicable Federal requirements and architecture, dataflow, and security and privacy controls must be documented, assessed, and authorized to operate.</p>
 					</part>
-					<part id="ia-2_fr_gdn.1" name="guidance">
+					<part id="ia-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>&quot;Phishing-resistant&quot; authentication refers to authentication processes designed to detect and prevent disclosure of authentication secrets and outputs to a website or application masquerading as a legitimate system.</p>
 					</part>
@@ -5572,17 +5572,17 @@
 		</alter>
 		<alter control-id="ia-2.1">
 			<add position="ending" by-id="ia-2.1_smt">
-				<part id="ia-2.1_fr" name="item">
+				<part id="ia-2.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-2 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-2.1_fr_smt.1" name="item">
+					<part id="ia-2.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>According to SP 800-63-3, SP 800-63A (IAL), SP 800-63B (AAL), and SP 800-63C (FAL).</p>
 					</part>
-					<part id="ia-2.1_fr_smt.2" name="item">
+					<part id="ia-2.1_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Multi-factor authentication must be phishing-resistant.</p>
 					</part>
-					<part id="ia-2.1_fr_gdn.1" name="guidance">
+					<part id="ia-2.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Multi-factor authentication to subsequent components in the same user domain is not required.</p>
 					</part>
@@ -5601,17 +5601,17 @@
 		</alter>
 		<alter control-id="ia-2.2">
 			<add position="ending" by-id="ia-2.2_smt">
-				<part id="ia-2.2_fr" name="item">
+				<part id="ia-2.2_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-2 (2) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-2.2_fr_smt.1" name="item">
+					<part id="ia-2.2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>According to SP 800-63-3, SP 800-63A (IAL), SP 800-63B (AAL), and SP 800-63C (FAL).</p>
 					</part>
-					<part id="ia-2.2_fr_smt.2" name="item">
+					<part id="ia-2.2_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Multi-factor authentication must be phishing-resistant.</p>
 					</part>
-					<part id="ia-2.2_fr_gdn.1" name="guidance">
+					<part id="ia-2.2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Multi-factor authentication to subsequent components in the same user domain is not required.</p>
 					</part>
@@ -5642,13 +5642,13 @@
 		</alter>
 		<alter control-id="ia-2.6">
 			<add position="ending" by-id="ia-2.6_smt">
-				<part id="ia-2.6_fr" name="item">
+				<part id="ia-2.6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-2 (6) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-2.6_fr_gdn.1" name="guidance">
+					<part id="ia-2.6_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>PIV=separate device. Please refer to NIST SP 800-157 Guidelines for Derived Personal Identity Verification (PIV) Credentials.</p>
 					</part>
-					<part id="ia-2.6_fr_gdn.2" name="guidance">
+					<part id="ia-2.6_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See SC-13 Guidance for more information on FIPS-validated or NSA-approved cryptography.</p>
 					</part>
@@ -5676,9 +5676,9 @@
 		</alter>
 		<alter control-id="ia-2.12">
 			<add position="ending" by-id="ia-2.12_smt">
-				<part id="ia-2.12_fr" name="item">
+				<part id="ia-2.12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-2 (12) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-2.12_fr_gdn.1" name="guidance">
+					<part id="ia-2.12_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Include Common Access Card (CAC), i.e., the DoD technical implementation of PIV/FIPS 201/HSPD-12.</p>
 					</part>
@@ -5770,13 +5770,13 @@
 		<alter control-id="ia-5">
 
 			<add position="ending" by-id="ia-5_smt">
-				<part id="ia-5_fr" name="item">
+				<part id="ia-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-5 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-5_fr_smt.1" name="item">
+					<part id="ia-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Authenticators must be compliant with NIST SP 800-63-3 Digital Identity Guidelines IAL, AAL, FAL level 2. Link https://pages.nist.gov/800-63-3</p>
 					</part>
-					<part id="ia-5_fr_gdn.1" name="guidance">
+					<part id="ia-5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>SP 800-63C Section 6.2.3 Encrypted Assertion requires that authentication assertions be encrypted when passed through third parties, such as a browser. For example, a SAML assertion can be encrypted using XML-Encryption, or an OpenID Connect ID Token can be encrypted using JSON Web Encryption (JWE).</p>
 					</part>
@@ -5865,18 +5865,18 @@
 		</alter>
 		<alter control-id="ia-5.1">
 			<add position="ending" by-id="ia-5.1_smt">
-				<part id="ia-5.1_fr" name="item">
+				<part id="ia-5.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-5 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-5.1_fr_smt.1" name="item">
+					<part id="ia-5.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Password policies must be compliant with NIST SP 800-63B for all memorized, lookup, out-of-band, or One-Time-Passwords (OTP). Password policies shall not enforce special character or minimum password rotation requirements for memorized secrets of users.</p>
 					</part>
-					<part id="ia-5.1_fr_smt.2" name="item">
+					<part id="ia-5.1_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(h) Requirement:"/>
 						<p>For cases where technology doesn't allow multi-factor authentication, these rules should be enforced: must have a minimum length of 14 characters and must support all printable ASCII characters.</p>
 						<p>For emergency use accounts, these rules should be enforced: must have a minimum length of 14 characters, must support all printable ASCII characters, and passwords must be changed if used.</p>
 					</part>
-					<part id="ia-5.1_fr_gdn.1" name="guidance">
+					<part id="ia-5.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Note that (c) and (d) require the use of cryptography which must be compliant with Federal requirements and utilize FIPS validated or NSA approved cryptography (see SC-13).</p>
 					</part>
@@ -5977,9 +5977,9 @@
 		</alter>
 		<alter control-id="ia-5.7">
 			<add position="ending" by-id="ia-5.7_smt">
-				<part id="ia-5.7_fr" name="item">
+				<part id="ia-5.7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-5 (7) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-5.7_fr_gdn.1" name="guidance">
+					<part id="ia-5.7_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>In this context, prohibited static storage refers to any storage where unencrypted authenticators, such as passwords, persist beyond the time required to complete the access process.</p>
 					</part>
@@ -5998,9 +5998,9 @@
 		<alter control-id="ia-11">
 
 			<add position="ending" by-id="ia-11_smt">
-				<part id="ia-11_fr" name="item">
+				<part id="ia-11_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-11 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-11_fr_gdn.1" name="guidance">
+					<part id="ia-11_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The fixed time period cannot exceed the limits set in SP 800-63. At this writing they are:</p>
 						<ul>
@@ -6026,9 +6026,9 @@
 		<alter control-id="ia-12">
 
 			<add position="ending" by-id="ia-12_smt">
-				<part id="ia-12_fr" name="item">
+				<part id="ia-12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-12 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-12_fr_gdn.1" name="guidance">
+					<part id="ia-12_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>In accordance with NIST SP 800-63A Enrollment and Identity Proofing</p>
 					</part>
@@ -6066,9 +6066,9 @@
 		<alter control-id="ia-12.5">
 
 			<add position="ending" by-id="ia-12.5_smt">
-				<part id="ia-12.5_fr" name="item">
+				<part id="ia-12.5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IA-12 (5) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ia-12.5_fr_gdn.1" name="guidance">
+					<part id="ia-12.5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>In accordance with NIST SP 800-63A Enrollment and Identity Proofing</p>
 					</part>
@@ -6243,9 +6243,9 @@
 		<alter control-id="ir-3">
 
 			<add position="ending" by-id="ir-3_smt">
-				<part id="ir-3_fr" name="item">
+				<part id="ir-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IR-3-2 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ir-3_fr_smt.1" name="item">
+					<part id="ir-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider defines tests and/or exercises in accordance with NIST Special Publication 800-61 (as amended). Functional testing must occur prior to testing for initial authorization. Annual functional testing may be concurrent with required penetration tests (see CA-8). The service provider provides test plans to the JAB/AO annually. Test plans are approved and accepted by the JAB/AO prior to test commencing.</p>
 					</part>
@@ -6275,13 +6275,13 @@
 		</alter>
 		<alter control-id="ir-4">
 			<add position="ending" by-id="ir-4_smt">
-				<part id="ir-4_fr" name="item">
+				<part id="ir-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IR-4 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ir-4_fr_smt.1" name="item">
+					<part id="ir-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The FISMA definition of &quot;incident&quot; shall be used: &quot;An occurrence that actually or imminently jeopardizes, without lawful authority, the confidentiality, integrity, or availability of information or an information system; or constitutes a violation or imminent threat of violation of law, security policies, security procedures, or acceptable use policies.&quot;</p>
 					</part>
-					<part id="ir-4_fr_smt.2" name="item">
+					<part id="ir-4_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider ensures that individuals conducting incident handling meet personnel security requirements commensurate with the criticality/sensitivity of the information being processed, stored, and transmitted by the information system.</p>
 					</part>
@@ -6360,9 +6360,9 @@
 		<alter control-id="ir-6">
 
 			<add position="ending" by-id="ir-6_smt">
-				<part id="ir-6_fr" name="item">
+				<part id="ir-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IR-6 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ir-6_fr_smt.1" name="item">
+					<part id="ir-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Reports security incident information according to FedRAMP Incident Communications Procedure.</p>
 					</part>
@@ -6436,13 +6436,13 @@
 		<alter control-id="ir-8">
 
 			<add position="ending" by-id="ir-8_smt">
-				<part id="ir-8_fr" name="item">
+				<part id="ir-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>IR-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ir-8_fr_smt.1" name="item">
+					<part id="ir-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
 						<p>The service provider defines a list of incident response personnel (identified by name and/or by role) and organizational elements. The incident response list includes designated FedRAMP personnel.</p>
 					</part>
-					<part id="ir-8_fr_smt.2" name="item">
+					<part id="ir-8_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(d) Requirement:"/>
 						<p>The service provider defines a list of incident response personnel (identified by name and/or by role) and organizational elements. The incident response list includes designated FedRAMP personnel.</p>
 					</part>
@@ -6854,9 +6854,9 @@
 		</alter>
 		<alter control-id="ma-5.1">
 			<add position="ending" by-id="ma-5.1_smt">
-				<part id="ma-5.1_fr" name="item">
+				<part id="ma-5.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>MA-5 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ma-5.1_fr_smt.1" name="item">
+					<part id="ma-5.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Only MA-5 (1) (a) (1) is required by FedRAMP Moderate Baseline</p>
 					</part>
@@ -6972,9 +6972,9 @@
 		</alter>
 		<alter control-id="mp-3">
 			<add position="ending" by-id="mp-3_smt">
-				<part id="mp-3_fr" name="item">
+				<part id="mp-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>MP-3 Additional FedRAMP Requirements and Guidance</title>
-					<part id="mp-3_fr_gdn.1" name="guidance">
+					<part id="mp-3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Guidance:"/>
 						<p>Second parameter not-applicable</p>
 					</part>
@@ -6997,9 +6997,9 @@
 		</alter>
 		<alter control-id="mp-4">
 			<add position="ending" by-id="mp-4_smt">
-				<part id="mp-4_fr" name="item">
+				<part id="mp-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>MP-4 Additional FedRAMP Requirements and Guidance</title>
-					<part id="mp-4_fr_smt.1" name="item">
+					<part id="mp-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider defines controlled areas within facilities where the information and information system reside.</p>
 					</part>
@@ -7044,9 +7044,9 @@
 		</alter>
 		<alter control-id="mp-5">
 			<add position="ending" by-id="mp-5_smt">
-				<part id="mp-5_fr" name="item">
+				<part id="mp-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>MP-5 Additional FedRAMP Requirements and Guidance</title>
-					<part id="mp-5_fr_smt.1" name="item">
+					<part id="mp-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider defines security measures to protect digital and non-digital media in transport. The security measures are approved and accepted by the JAB/AO.</p>
 					</part>
@@ -7333,9 +7333,9 @@
 		</alter>
 		<alter control-id="pe-14">
 			<add position="ending" by-id="pe-14_smt">
-				<part id="pe-14_fr" name="item">
+				<part id="pe-14_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>PE-14 Additional FedRAMP Requirements and Guidance</title>
-					<part id="pe-14_fr_smt.1" name="item">
+					<part id="pe-14_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>The service provider measures temperature at server inlets and humidity levels by dew point.</p>
 					</part>
@@ -7932,9 +7932,9 @@
 		<alter control-id="pl-8">
 
 			<add position="ending" by-id="pl-8_smt">
-				<part id="pl-8_fr" name="item">
+				<part id="pl-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>PL-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="pl-8_fr_gdn.1" name="guidance">
+					<part id="pl-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Guidance:"/>
 						<p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F.</p>
 					</part>
@@ -8006,9 +8006,9 @@
 		<alter control-id="pl-10">
 
 			<add position="ending" by-id="pl-10_smt">
-				<part id="pl-10_fr" name="item">
+				<part id="pl-10_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>PL-10 Additional FedRAMP Requirements and Guidance</title>
-					<part id="pl-10_fr_smt.1" name="item">
+					<part id="pl-10_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Select the appropriate FedRAMP Baseline</p>
 					</part>
@@ -8407,13 +8407,13 @@
 		</alter>
 		<alter control-id="ra-3">
 			<add position="ending" by-id="ra-3_smt">
-				<part id="ra-3_fr" name="item">
+				<part id="ra-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>RA-3 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ra-3_fr_gdn.1" name="guidance">
+					<part id="ra-3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F.</p>
 					</part>
-					<part id="ra-3_fr_smt.1" name="item">
+					<part id="ra-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Requirement:"/>
 						<p>Include all Authorizing Officials; for JAB authorizations to include FedRAMP.</p>
 					</part>
@@ -8499,25 +8499,25 @@
 		<alter control-id="ra-5">
 
 			<add position="ending" by-id="ra-5_smt">
-				<part id="ra-5_fr" name="item">
+				<part id="ra-5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>RA-5 Additional FedRAMP Requirements and Guidance</title>
-					<part id="ra-5_fr_gdn.1" name="guidance">
+					<part id="ra-5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See the FedRAMP Documents page&gt; Vulnerability Scanning Requirements https://www.FedRAMP.gov/documents/</p>
 					</part>
-					<part id="ra-5_fr_smt.1" name="item">
+					<part id="ra-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
 						<p>an accredited independent assessor scans operating systems/infrastructure, web applications, and databases once annually.</p>
 					</part>
-					<part id="ra-5_fr_smt.2" name="item">
+					<part id="ra-5_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(d) Requirement:"/>
 						<p>If a vulnerability is listed among the CISA Known Exploited Vulnerability (KEV) Catalog (https://www.cisa.gov/known-exploited-vulnerabilities-catalog) the KEV remediation date supersedes the FedRAMP parameter requirement.</p>
 					</part>
-					<part id="ra-5_fr_smt.3" name="item">
+					<part id="ra-5_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Requirement:"/>
 						<p>to include all Authorizing Officials; for JAB authorizations to include FedRAMP</p>
 					</part>
-					<part id="ra-5_fr_gdn.2" name="guidance">
+					<part id="ra-5_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Informational findings from a scanner are detailed as a returned result that holds no vulnerability risk or severity and for FedRAMP does not require an entry onto the POA&amp;M or entry onto the RET during any assessment phase.</p>
 						<p>Warning findings, on the other hand, are given a risk rating (low, moderate, high or critical) by the scanning solution and should be treated like any other finding with a risk or severity rating for tracking purposes onto either the POA&amp;M or RET depending on when the findings originated (during assessments or during monthly continuous monitoring). If a warning is received during scanning, but further validation turns up no actual issue then this item should be categorized as a false positive. If this situation presents itself during an assessment phase (initial assessment, annual assessment or any SCR), follow guidance on how to report false positives in the Security Assessment Report (SAR). If this situation happens during monthly continuous monitoring, a deviation request will need to be submitted per the FedRAMP Vulnerability Deviation Request Form.</p>
@@ -9038,13 +9038,13 @@
 		</alter>
 		<alter control-id="sa-4">
 			<add position="ending" by-id="sa-4_smt">
-				<part id="sa-4_fr" name="item">
+				<part id="sa-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SA-4 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sa-4_fr_smt.1" name="item">
+					<part id="sa-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider must comply with Federal Acquisition Regulation (FAR) Subpart 7.103, and Section 889 of the John S. McCain National Defense Authorization Act (NDAA) for Fiscal Year 2019 (Pub. L. 115-232), and FAR Subpart 4.21, which implements Section 889 (as well as any added updates related to FISMA to address security concerns in the system acquisitions process).</p>
 					</part>
-					<part id="sa-4_fr_gdn.1" name="guidance">
+					<part id="sa-4_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The use of Common Criteria (ISO/IEC 15408) evaluated products is strongly preferred.</p>
 						<p>See https://www.niap-ccevs.org/Product/index.cfm or https://www.commoncriteriaportal.org/products/.</p>
@@ -9142,9 +9142,9 @@
 
 		<alter control-id="sa-10">
 			<add position="ending" by-id="sa-10_smt">
-				<part id="sa-10_fr" name="item">
+				<part id="sa-10_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SA-10 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sa-10_fr_smt.1" name="item">
+					<part id="sa-10_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Requirement:"/>
 						<p>track security flaws and flaw resolution within the system, component, or service and report findings to organization-defined personnel, to include FedRAMP.</p>
 					</part>
@@ -9194,9 +9194,9 @@
 		</alter>
 		<alter control-id="sa-11.1">
 			<add position="ending" by-id="sa-11.1_smt">
-				<part id="sa-11.1_fr" name="item">
+				<part id="sa-11.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SA-11(1) Additional FedRAMP Requirements</title>
-					<part id="sa-11.1_fr_smt.1" name="item">
+					<part id="sa-11.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider must document its methodology for reviewing newly developed code for the Service in its Continuous Monitoring Plan.</p>
 						<p>If Static code analysis cannot be performed (for example, when the source code is not available), then dynamic code analysis must be performed (see SA-11 (8))</p>
@@ -9677,9 +9677,9 @@
 		</alter>
 		<alter control-id="sc-7">
 			<add position="ending" by-id="sc-7_smt">
-				<part id="sc-7_fr" name="item">
+				<part id="sc-7_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-7 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-7_fr_gdn.1" name="guidance">
+					<part id="sc-7_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Guidance:"/>
 						<p>SC-7 (b) should be met by subnet isolation. A subnetwork (subnet) is a physically or logically segmented section of a larger network defined at TCP/IP Layer 3, to both minimize traffic and, important for a FedRAMP Authorization, add a crucial layer of network isolation. Subnets are distinct from VLANs (Layer 2), security groups, and VPCs and are specifically required to satisfy SC-7 part b and other controls. See the FedRAMP Subnets White Paper (https://www.fedramp.gov/assets/resources/documents/FedRAMP_subnets_white_paper.pdf) for additional information.</p>
 					</part>
@@ -9848,9 +9848,9 @@
 		</alter>
 		<alter control-id="sc-7.5">
 			<add position="ending" by-id="sc-7.5_smt">
-				<part id="sc-7.5_fr" name="item">
+				<part id="sc-7.5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-7 (5) Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-7.5_fr_gdn.1" name="guidance">
+					<part id="sc-7.5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For JAB Authorization, CSPs shall include details of this control in their Architecture Briefing</p>
 					</part>
@@ -9899,9 +9899,9 @@
 		</alter>
 		<alter control-id="sc-8">
 			<add position="ending" by-id="sc-8_smt">
-				<part id="sc-8_fr" name="item">
+				<part id="sc-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-8_fr_gdn.1" name="guidance">
+					<part id="sc-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For each instance of data in transit, confidentiality AND integrity should be through cryptography as specified in SC-8 (1), physical means as specified in SC-8 (5), or in combination.</p>
 						<p/>
@@ -9921,7 +9921,7 @@
 						<p>SC-8 (5)-1 [a hardened or alarmed carrier Protective Distribution System (PDS) when outside of Controlled Access Area (CAA)]</p>
 						<p>SC-8 (5)-2 [prevent unauthorized disclosure of information AND detect changes to information]</p>
 					</part>
-					<part id="sc-8_fr_gdn.2" name="guidance">
+					<part id="sc-8_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>SC-8 (5) applies when physical protection has been selected as the method to protect confidentiality and integrity. For physical protection, data in transit must be in either a Controlled Access Area (CAA), or a Hardened or alarmed PDS.</p>
 						<p/>
@@ -9954,22 +9954,22 @@
 		</alter>
 		<alter control-id="sc-8.1">
 			<add position="ending" by-id="sc-8.1_smt">
-				<part id="sc-8.1_fr" name="item">
+				<part id="sc-8.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-8 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-8.1_fr_smt.1" name="item">
+					<part id="sc-8.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Please ensure SSP Section 10.3 Cryptographic Modules Implemented for Data At Rest (DAR) and Data In Transit (DIT) is fully populated for reference in this control.</p>
 					</part>
-					<part id="sc-8.1_fr_gdn.1" name="guidance">
+					<part id="sc-8.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See M-22-09, including &quot;Agencies encrypt all DNS requests and HTTP traffic within their environment&quot;</p>
 						<p>SC-8 (1) applies when encryption has been selected as the method to protect confidentiality and integrity. Otherwise refer to SC-8 (5). SC-8 (1) is strongly encouraged.</p>
 					</part>
-					<part id="sc-8.1_fr_gdn.2" name="guidance">
+					<part id="sc-8.1_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Note that this enhancement requires the use of cryptography which must be compliant with Federal requirements and utilize FIPS validated or NSA approved cryptography (see SC-13.)</p>
 					</part>
-					<part id="sc-8.1_fr_gdn.3" name="guidance">
+					<part id="sc-8.1_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>When leveraging encryption from the underlying IaaS/PaaS: While some IaaS/PaaS services provide encryption by default, many require encryption to be configured, and enabled by the customer. The CSP has the responsibility to verify encryption is properly configured.</p>
 					</part>
@@ -9987,17 +9987,17 @@
 		</alter>
 		<alter control-id="sc-12">
 			<add position="ending" by-id="sc-12_smt">
-				<part id="sc-12_fr" name="item">
+				<part id="sc-12_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-12 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-12_fr_gdn.1" name="guidance">
+					<part id="sc-12_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See references in NIST 800-53 documentation.</p>
 					</part>
-					<part id="sc-12_fr_gdn.2" name="guidance">
+					<part id="sc-12_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Must meet applicable Federal Cryptographic Requirements. See References Section of control.</p>
 					</part>
-					<part id="sc-12_fr_gdn.3" name="guidance">
+					<part id="sc-12_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Wildcard certificates may be used internally within the system, but are not permitted for external customer access to the system.</p>
 					</part>
@@ -10019,10 +10019,10 @@
 		<alter control-id="sc-13">
 
 			<add position="ending" by-id="sc-13_smt">
-				<part id="sc-13_fr" name="item">
+				<part id="sc-13_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-13 Additional FedRAMP Requirements and Guidance</title>
 
-					<part id="sc-13_fr_gdn.1" name="guidance">
+					<part id="sc-13_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>This control applies to all use of cryptography. In addition to encryption, this includes functions such as hashing, random number generation, and key generation. Examples include the following:</p>
 						<ul>
@@ -10035,16 +10035,16 @@
 						<p>The requirement for FIPS 140 validation, as well as timelines for acceptance of FIPS 140-2, and 140-3 can be found at the NIST Cryptographic Module Validation Program (CMVP).</p>
 						<p>https://csrc.nist.gov/projects/cryptographic-module-validation-program</p>
 					</part>
-					<part id="sc-13_fr_gdn.2" name="guidance">
+					<part id="sc-13_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>For NSA-approved cryptography, the National Information Assurance Partnership (NIAP) oversees a national program to evaluate Commercial IT Products for Use in National Security Systems. The NIAP Product Compliant List can be found at the following location:</p>
 						<p>https://www.niap-ccevs.org/Product/index.cfm</p>
 					</part>
-					<part id="sc-13_fr_gdn.3" name="guidance">
+					<part id="sc-13_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>When leveraging encryption from underlying IaaS/PaaS: While some IaaS/PaaS provide encryption by default, many require encryption to be configured, and enabled by the customer. The CSP has the responsibility to verify encryption is properly configured.</p>
 					</part>
-					<part id="sc-13_fr_gdn.4" name="guidance">
+					<part id="sc-13_fr_gdn.4" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Moving to non-FIPS CM or product is acceptable when:</p>
 						<ul>
@@ -10055,7 +10055,7 @@
 							<li>POA&amp;M is added to track approval, and deployment when ready</li>
 						</ul>
 					</part>
-					<part id="sc-13_fr_gdn.5" name="guidance">
+					<part id="sc-13_fr_gdn.5" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>At a minimum, this control applies to cryptography in use for the following controls: AU-9(3), CP-9(8), IA-2(6), IA-5(1), MP-5, SC-8(1), and SC-28(1).</p>
 					</part>
@@ -10084,9 +10084,9 @@
 		</alter>
 		<alter control-id="sc-15">
 			<add position="ending" by-id="sc-15_smt">
-				<part id="sc-15_fr" name="item">
+				<part id="sc-15_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-15 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-15_fr_smt.1" name="item">
+					<part id="sc-15_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The information system provides disablement (instead of physical disconnect) of collaborative computing devices in a manner that supports ease of use.</p>
 					</part>
@@ -10112,21 +10112,21 @@
 		</alter>
 		<alter control-id="sc-20">
 			<add position="ending" by-id="sc-20_smt">
-				<part id="sc-20_fr" name="item">
+				<part id="sc-20_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-20 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-20_fr_smt.1" name="item">
+					<part id="sc-20_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Control Description should include how DNSSEC is implemented on authoritative DNS servers to supply valid responses to external DNSSEC requests.</p>
 					</part>
-					<part id="sc-20_fr_gdn.1" name="guidance">
+					<part id="sc-20_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>SC-20 applies to use of external authoritative DNS to access a CSO from outside the boundary.</p>
 					</part>
-					<part id="sc-20_fr_gdn.2" name="guidance">
+					<part id="sc-20_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>External authoritative DNS servers may be located outside an authorized environment. Positioning these servers inside an authorized boundary is encouraged.</p>
 					</part>
-					<part id="sc-20_fr_gdn.3" name="guidance">
+					<part id="sc-20_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>CSPs are recommended to self-check DNSSEC configuration through one of many available analyzers such as Sandia National Labs (https://dnsviz.net)</p>
 					</part>
@@ -10159,9 +10159,9 @@
 		</alter>
 		<alter control-id="sc-21">
 			<add position="ending" by-id="sc-21_smt">
-				<part id="sc-21_fr" name="item">
+				<part id="sc-21_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-21 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-21_fr_smt.1" name="item">
+					<part id="sc-21_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Control description should include how DNSSEC is implemented on recursive DNS servers to make DNSSEC requests when resolving DNS requests from internal components to domains external to the CSO boundary.</p>
 						<ul>
@@ -10172,15 +10172,15 @@
 							</li>
 						</ul>
 					</part>
-					<part id="sc-21_fr_smt.2" name="item">
+					<part id="sc-21_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Internal recursive DNS servers must be located inside an authorized environment. It is typically within the boundary, or leveraged from an underlying IaaS/PaaS.</p>
 					</part>
-					<part id="sc-21_fr_gdn.1" name="guidance">
+					<part id="sc-21_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Accepting an unsigned reply is acceptable</p>
 					</part>
-					<part id="sc-21_fr_gdn.2" name="guidance">
+					<part id="sc-21_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>SC-21 applies to use of internal recursive DNS to access a domain outside the boundary by a component inside the boundary.</p>
 						<ul>
@@ -10204,17 +10204,17 @@
 		</alter>
 		<alter control-id="sc-28">
 			<add position="ending" by-id="sc-28_smt">
-				<part id="sc-28_fr" name="item">
+				<part id="sc-28_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-28 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-28_fr_gdn.1" name="guidance">
+					<part id="sc-28_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>The organization supports the capability to use cryptographic mechanisms to protect information at rest.</p>
 					</part>
-					<part id="sc-28_fr_gdn.2" name="guidance">
+					<part id="sc-28_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>When leveraging encryption from underlying IaaS/PaaS: While some IaaS/PaaS services provide encryption by default, many require encryption to be configured, and enabled by the customer. The CSP has the responsibility to verify encryption is properly configured.</p>
 					</part>
-					<part id="sc-28_fr_gdn.3" name="guidance">
+					<part id="sc-28_fr_gdn.3" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Note that this enhancement requires the use of cryptography in accordance with SC-13.</p>
 					</part>
@@ -10235,9 +10235,9 @@
 		</alter>
 		<alter control-id="sc-28.1">
 			<add position="ending" by-id="sc-28.1_smt">
-				<part id="sc-28.1_fr" name="item">
+				<part id="sc-28.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-28 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-28.1_fr_gdn.1" name="guidance">
+					<part id="sc-28.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Organizations should select a mode of protection that is targeted towards the relevant threat scenarios.</p>
 						<p>Examples:</p>
@@ -10260,17 +10260,17 @@
 		<alter control-id="sc-45.1">
 
 			<add position="ending" by-id="sc-45.1_smt">
-				<part id="sc-45.1_fr" name="item">
+				<part id="sc-45.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-45(1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-45.1_fr_smt.1" name="item">
+					<part id="sc-45.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider selects primary and secondary time servers used by the NIST Internet time service. The secondary server is selected from a different geographic region than the primary server.</p>
 					</part>
-					<part id="sc-45.1_fr_smt.2" name="item">
+					<part id="sc-45.1_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>The service provider synchronizes the system clocks of network computers that run operating systems other than Windows to the Windows Server Domain Controller emulator or to the same time source for that server.</p>
 					</part>
-					<part id="sc-45.1_fr_gdn.1" name="guidance">
+					<part id="sc-45.1_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>Synchronization of system clocks improves the accuracy of log analysis.</p>
 					</part>
@@ -10511,9 +10511,9 @@
 		<alter control-id="si-4">
 
 			<add position="ending" by-id="si-4_smt">
-				<part id="si-4_fr" name="item">
+				<part id="si-4_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-4 Additional FedRAMP Requirements and Guidance</title>
-					<part id="si-4_fr_gdn.1" name="guidance">
+					<part id="si-4_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>See US-CERT Incident Response Reporting Guidelines.</p>
 					</part>
@@ -10682,9 +10682,9 @@
 		</alter>
 		<alter control-id="si-4.5">
 			<add position="ending" by-id="si-4.5_smt">
-				<part id="si-4.5_fr" name="item">
+				<part id="si-4.5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-4 (5) Additional FedRAMP Requirements and Guidance</title>
-					<part id="si-4.5_fr_gdn.1" name="guidance">
+					<part id="si-4.5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>In accordance with the incident response plan.</p>
 					</part>
@@ -10705,7 +10705,7 @@
 
 		<alter control-id="si-5">
 			<add position="ending" by-id="si-5_smt">
-				<part id="si-5_fr_smt.1" name="item">
+				<part id="si-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-5 Additional FedRAMP Requirements and Guidance</title>
 					<prop name="label" value="Requirement:"/>
 					<p>Service Providers must address the CISA Emergency and Binding Operational Directives applicable to their cloud service offering per FedRAMP guidance. This includes listing the applicable directives and stating compliance status.</p>
@@ -10833,14 +10833,14 @@
 		</alter>
 		<alter control-id="si-8">
 			<add position="ending" by-id="si-8_smt">
-				<part id="si-8_fr" name="item">
+				<part id="si-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="si-8_fr_gdn.1" name="guidance">
+					<part id="si-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>When CSO sends email on behalf of the government as part of the business offering, Control Description should include implementation of Domain-based Message Authentication, Reporting &amp; Conformance (DMARC) on the sending domain for outgoing messages as described in DHS Binding Operational Directive (BOD) 18-01.</p>
 						<p>https://cyber.dhs.gov/bod/18-01/</p>
 					</part>
-					<part id="si-8_fr_gdn.2" name="guidance">
+					<part id="si-8_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>CSPs should confirm DMARC configuration (where appropriate) to ensure that policy=reject and the rua parameter includes reports@dmarc.cyber.dhs.gov. DMARC compliance should be documented in the SI-08 control implementation solution description, and list the FROM: domain(s) that will be seen by email recipients.</p>
 					</part>
@@ -10866,9 +10866,9 @@
 
 		<alter control-id="si-10">
 			<add position="ending" by-id="si-10_smt">
-				<part id="si-10_fr" name="item">
+				<part id="si-10_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SI-10 Additional FedRAMP Requirements and Guidance</title>
-					<part id="si-10_fr_smt.1" name="item">
+					<part id="si-10_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>Validate all information inputs and document any exceptions</p>
 					</part>
@@ -11065,9 +11065,9 @@
 		<alter control-id="sr-3">
 
 			<add position="ending" by-id="sr-3_smt">
-				<part id="sr-3_fr" name="item">
+				<part id="sr-3_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SR-3 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sr-3_fr_smt.1" name="item">
+					<part id="sr-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSO must document and maintain the supply chain custody, including replacement devices, to ensure the integrity of the devices before being introduced to the boundary.</p>
 					</part>
@@ -11118,9 +11118,9 @@
 		<alter control-id="sr-6">
 
 			<add position="ending" by-id="sr-6_smt">
-				<part id="sr-6_fr" name="item">
+				<part id="sr-6_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SR-6 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sr-6_fr_smt.1" name="item">
+					<part id="sr-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSOs must ensure that their supply chain vendors build and test their systems in alignment with NIST SP 800-171 or a commensurate security and compliance framework. CSOs must ensure that vendors are compliant with physical facility access and logical access controls to supplied products.</p>
 					</part>
@@ -11138,9 +11138,9 @@
 		<alter control-id="sr-8">
 
 			<add position="ending" by-id="sr-8_smt">
-				<part id="sr-8_fr" name="item">
+				<part id="sr-8_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SR-8 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sr-8_fr_smt.1" name="item">
+					<part id="sr-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSOs must ensure and document how they receive notifications from their supply chain vendor of newly discovered vulnerabilities including zero-day vulnerabilities.</p>
 					</part>
@@ -11161,9 +11161,9 @@
 		<alter control-id="sr-11">
 
 			<add position="ending" by-id="sr-11_smt">
-				<part id="sr-11_fr" name="item">
+				<part id="sr-11_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SR-11 Additional FedRAMP Requirements and Guidance</title>
-					<part id="sr-11_fr_smt.1" name="item">
+					<part id="sr-11_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
 						<p>CSOs must ensure that their supply chain vendors provide authenticity of software and patches and the vendor must have a plan to protect the development pipeline.</p>
 					</part>


### PR DESCRIPTION
# Committer Notes

This PR fixes the reported issue #1102 by:
- Adding the FedRAMP namespace to any `part`s added in the FedRAMP (High, Moderate, Low, and LI-SaaS) profiles.  
  - This eliminates errors in resolved profiles due to unexpected parts (e.g., `<part name="guidance">..) in the resolved profile catalogs
  - This makes it easier for consumers of the FedRAMP resolved  profile catalogs to identify FedRAMP specific alterations (e.g., Additional FedRAMP requirements and guidance)
- Fixed duplicate part IDs in High and Moderate profiles.
- Updated the `last-updated`, `version`, and `oscal-version` in the metadata of the FedRAMP (High, Moderate, Low, and LI-SaaS) profiles.  

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
