### PR TITLE
Fix `security-sensitivity-level-matches-security-impact-level` Constraint

### DIFF
--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -563,10 +563,10 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>A FedRAMP SSP that defines a SaaS cloud service model MUST define at least one leveraged authorization.</message>
             </expect>
-            <expect id="security-sensitivity-level-matches-security-impact-level" target="security-sensitivity-level" test=". eq $security-impact-level" level="WARNING">
+            <expect id="security-sensitivity-level-matches-security-impact-level" target="security-sensitivity-level" test="$security-impact-level = 'fips-199-low' and matches(., '(fips-199-low|fips-199-moderate|fips-199-high)') or $security-impact-level = 'fips-199-moderate' and matches(., '(fips-199-moderate|fips-199-high)') or $security-impact-level = 'fips-199-high' and matches(., 'fips-199-high')" level="ERROR">
                 <formal-name>Security Sensitivity Level Matches Security Impact Level</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#system-sensitivity-level"/>
-                <message>A FedRAMP SSP SHOULD define its FIPS-199 security sensitivity level to match the highest security impact level for the system's confidentiality, integrity, and availability objectives.</message>
+                <message>A FedRAMP SSP MUST define its FIPS-199 security sensitivity level to be as high or higher than the highest security impact level/objective.</message>
             </expect>
         </constraints>
     </context>


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to fix the `security-sensitivity-level-matches-security-impact-level` constraint per issue #1098.

## Changes
- Changed the constraint to `ERROR`.
- Adjust constraint to check that the security sensitivity level is as high as or higher than the highest security impact level/objective.



### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.? 
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
