### PR TITLE
Add `inventory-item-asset-types` Constraint

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -127,6 +127,7 @@ Examples:
   | interconnection-security |
   | inventory-item-allows-authenticated-scan |
   | inventory-item-and-component-has-public |
+  | inventory-item-asset-types |
   | inventory-item-has-asset-type |
   | inventory-item-has-diagram-label |
   | inventory-item-has-function |
@@ -402,6 +403,8 @@ Examples:
   | inventory-item-allows-authenticated-scan-PASS.yaml |
   | inventory-item-and-component-has-public-FAIL.yaml |
   | inventory-item-and-component-has-public-PASS.yaml |
+  | inventory-item-asset-types-FAIL.yaml |
+  | inventory-item-asset-types-PASS.yaml |
   | inventory-item-has-asset-type-FAIL.yaml |
   | inventory-item-has-asset-type-PASS.yaml |
   | inventory-item-has-diagram-label-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -2493,7 +2493,7 @@ approved.</p>
       </description>
       <prop name='diagram-label' ns='http://fedramp.gov/ns/oscal' value='label'/>
       <prop name="asset-id" value="unique-asset-ID-04"/>
-      <prop name="asset-type" value="appliance"/>
+      <prop name="asset-type" value="hardware"/>
       <prop name="virtual" value="yes"/>
       <prop name="public" value="no"/>
       <prop name="ipv4-address" value="10.4.4.4"/>

--- a/src/validations/constraints/content/ssp-inventory-item-asset-types-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-asset-types-INVALID.xml
@@ -1,0 +1,7 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <inventory-item uuid="77777777-0000-4000-9000-000000000007">
+      <prop name="asset-type" value="hardware"/>
+    </inventory-item>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -548,6 +548,16 @@
                 <enum value="no">No</enum>
             </allowed-values>
 
+            <allowed-values id="inventory-item-asset-types" target="//inventory-item/prop[@name='asset-type']/@value" allow-other="yes" level="ERROR">
+                <formal-name>Inventory Item Asset Types</formal-name>
+                <description>Identifies the inventory item asset types recognized by FedRAMP.</description>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/validation/catalog/?constraint-id=inventory-item-asset-types"/>
+                <enum value="hardware">Hardware</enum>
+                <enum value="infrastructure">Infrastructure</enum>
+                <enum value="network">Network</enum>
+                <enum value="software">Software</enum>
+            </allowed-values>
+
             <allowed-values id="inventory-item-public" target="(//inventory-item | //component)/prop[@name='public']/@value" allow-other="no" level="ERROR">
                 <formal-name>Public</formal-name>
                 <description>Indicates if the asset is exposed to the public Internet.</description>

--- a/src/validations/constraints/unit-tests/inventory-item-asset-types-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-asset-types-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-asset-types
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-asset-types
+  content: ../content/ssp-inventory-item-asset-types-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-asset-types
+      fail_count: 0

--- a/src/validations/constraints/unit-tests/inventory-item-asset-types-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-asset-types-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-asset-types
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-asset-types
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-asset-types
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the allowed values that should be recognized by FedRAMP.
### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ Not applicable. 
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
