### PR TITLE
Add `Validation Component` Constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -43,6 +43,9 @@ Examples:
   | component-has-non-provider-responsible-role |
   | component-has-provider-responsible-role |
   | component-has-used-by-link |
+  | component-has-valid-validation-details-link |
+  | component-has-validation-details-link |
+  | component-has-validation-reference |
   | component-type |
   | connection-security |
   | control-implementation-status |
@@ -195,6 +198,7 @@ Examples:
   | user-privilege-level |
   | user-sensitivity-level |
   | user-type |
+  | validation-reference-has-correct-format |
 #END_DYNAMIC_CONSTRAINT_IDS
 
 @constraints
@@ -246,6 +250,12 @@ Examples:
   | component-has-non-provider-responsible-role-PASS.yaml |
   | component-has-used-by-link-FAIL.yaml |
   | component-has-used-by-link-PASS.yaml |
+  | component-has-valid-validation-details-link-FAIL.yaml |
+  | component-has-valid-validation-details-link-PASS.yaml |
+  | component-has-validation-details-link-FAIL.yaml |
+  | component-has-validation-details-link-PASS.yaml |
+  | component-has-validation-reference-FAIL.yaml |
+  | component-has-validation-reference-PASS.yaml |
   | component-responsible-role-references-party-FAIL.yaml |
   | component-responsible-role-references-party-PASS.yaml |
   | component-type-FAIL.yaml |
@@ -552,6 +562,8 @@ Examples:
   | user-sensitivity-level-PASS.yaml |
   | user-type-FAIL.yaml |
   | user-type-PASS.yaml |
+  | validation-reference-has-correct-format-FAIL.yaml |
+  | validation-reference-has-correct-format-PASS.yaml |
 #END_DYNAMIC_TEST_CASES
 
 @style-guide

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1712,8 +1712,8 @@ compliance (e.g., Module in Process).</p>
       <!-- Provide the validation type for this CM -->
       <prop name="validation-type" value="fips-140-2"/>
       <!-- Provide the certificate number (CMVP #) -->
-      <prop name="validation-reference" value="3928"/>
-      <link rel="validation-details" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3928"/>
+      <prop name="validation-reference" value="4811"/>
+      <link rel="validation-details" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4811"/>
       <status state="operational"/>
     </component>
     <!-- List all cryptographic modules for Data-in-Transit (DIT) - must referenced by using component(s), provide CMVP #, FIPS validation status, Vendor Name, Module Name, and brief usage description -->
@@ -1731,8 +1731,8 @@ compliance (e.g., Module in Process).</p>
       <!-- Provide the validation type for this CM -->
       <prop name="validation-type" value="fips-140-3"/>
       <!-- Provide the certificate number (CMVP #) -->
-      <prop name="validation-reference" value="3920"/>
-      <link rel="validation-details" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3920"/>
+      <prop name="validation-reference" value="4811"/>
+      <link rel="validation-details" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4811"/>
       <status state="operational"/>
     </component>
 

--- a/src/validations/constraints/content/ssp-component-has-valid-validation-details-link-INVALID.xml
+++ b/src/validations/constraints/content/ssp-component-has-valid-validation-details-link-INVALID.xml
@@ -1,0 +1,10 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000000000" type="validation">
+      <prop ns="http://fedramp.gov/ns/oscal" name="asset-type" value="cryptographic-module"/>
+      <prop name="validation-type" value="fips-140-2"/>
+      <!-- Missing valid validation-details link. -->
+      <link rel="validation-details" href="invalid-link"/> 
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-component-has-validation-details-link-INVALID.xml
+++ b/src/validations/constraints/content/ssp-component-has-validation-details-link-INVALID.xml
@@ -1,0 +1,9 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000000000" type="validation">
+      <prop ns="http://fedramp.gov/ns/oscal" name="asset-type" value="cryptographic-module"/>
+      <prop name="validation-type" value="fips-140-2"/>
+      <!-- <link rel="validation-details" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4811"/> Missing validation-details link. -->
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-component-has-validation-reference-INVALID.xml
+++ b/src/validations/constraints/content/ssp-component-has-validation-reference-INVALID.xml
@@ -1,0 +1,9 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000000000" type="validation">
+      <prop ns="http://fedramp.gov/ns/oscal" name="asset-type" value="cryptographic-module"/>
+      <prop name="validation-type" value="fips-140-2"/>
+      <!-- <prop name="validation-reference" value="3928"/> Missing validation reference. -->
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-validation-reference-has-correct-format-INVALID.xml
+++ b/src/validations/constraints/content/ssp-validation-reference-has-correct-format-INVALID.xml
@@ -1,0 +1,10 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000000000" type="validation">
+      <prop ns="http://fedramp.gov/ns/oscal" name="asset-type" value="cryptographic-module"/>
+      <prop name="validation-type" value="fips-140-2"/>
+      <!-- Validation reference has incorrect format. -->
+      <prop name="validation-reference" value="abcd"/>
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -16,7 +16,7 @@
             <expect id="component-has-validation-details-link" target=".[@type='validation' and prop[@name='asset-type' and @value='cryptographic-module'] and prop[@name='validation-type' and @value=('fips-140-2', 'fips-140-3')]]" test="count(link[@rel='validation-details']) eq 1" level="ERROR">
                 <formal-name>Component Has Proof of Compliance Link</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
-                <message>In a FedRAMP SSP, a validation component MUST include a validation details link.</message>
+                <message>In a FedRAMP SSP, a cryptography validation component MUST include a validation details link.</message>
             </expect>
             <expect id="component-has-validation-reference" target=".[@type='validation' and prop[@name='asset-type' and @value='cryptographic-module'] and prop[@name='validation-type' and @value=('fips-140-2', 'fips-140-3')]]" test="count(prop[@name='validation-reference']) eq 1" level="ERROR">
                 <formal-name>Component Has Validation Reference</formal-name>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -21,7 +21,7 @@
             <expect id="component-has-validation-reference" target=".[@type='validation' and prop[@name='asset-type' and @value='cryptographic-module'] and prop[@name='validation-type' and @value=('fips-140-2', 'fips-140-3')]]" test="count(prop[@name='validation-reference']) eq 1" level="ERROR">
                 <formal-name>Component Has Validation Reference</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
-                <message>In a FedRAMP SSP, a validation component MUST include a validation reference.</message>
+                <message>In a FedRAMP SSP, a cryptography validation component MUST include a validation reference.</message>
             </expect>
             <expect id="cryptographic-module-component-has-function" target=".[@type='software' and prop[@name='asset-type' and @value='cryptographic-module']]" test="(count(prop[@name='function']) eq 1) and (if (prop[@name='function' and @value='other']) then exists(prop[@name='function' and @value='other']/remarks) else true())" level="ERROR">
                 <formal-name>Cryptographic Module Component Has Function</formal-name>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -8,6 +8,21 @@
     <context>
         <metapath target="//component"/>
         <constraints>
+            <expect id="component-has-valid-validation-details-link" target=".[@type='validation' and prop[@name='asset-type' and @value='cryptographic-module'] and prop[@name='validation-type' and @value=('fips-140-2', 'fips-140-3')]]/link[@rel='validation-details']" test="doc-available(@href)" level="ERROR">
+                <formal-name>Component Has Valid Proof of Compliance Link</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, a validation component MUST include a valid validation details link.</message>
+            </expect>
+            <expect id="component-has-validation-details-link" target=".[@type='validation' and prop[@name='asset-type' and @value='cryptographic-module'] and prop[@name='validation-type' and @value=('fips-140-2', 'fips-140-3')]]" test="count(link[@rel='validation-details']) eq 1" level="ERROR">
+                <formal-name>Component Has Proof of Compliance Link</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, a validation component MUST include a validation details link.</message>
+            </expect>
+            <expect id="component-has-validation-reference" target=".[@type='validation' and prop[@name='asset-type' and @value='cryptographic-module'] and prop[@name='validation-type' and @value=('fips-140-2', 'fips-140-3')]]" test="count(prop[@name='validation-reference']) eq 1" level="ERROR">
+                <formal-name>Component Has Validation Reference</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, a validation component MUST include a validation reference.</message>
+            </expect>
             <expect id="cryptographic-module-component-has-function" target=".[@type='software' and prop[@name='asset-type' and @value='cryptographic-module']]" test="(count(prop[@name='function']) eq 1) and (if (prop[@name='function' and @value='other']) then exists(prop[@name='function' and @value='other']/remarks) else true())" level="ERROR">
                 <formal-name>Cryptographic Module Component Has Function</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
@@ -27,6 +42,11 @@
                 <formal-name>Cryptographic Module Component Has Validation Link</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, a crytographic module component MUST include at least one "validation" link.</message>
+            </expect>
+            <expect id="validation-reference-has-correct-format" target=".[@type='validation' and prop[@name='asset-type' and @value='cryptographic-module'] and prop[@name='validation-type' and @value=('fips-140-2', 'fips-140-3')]]/prop[@name='validation-reference']" test="matches(@value, '^\d{4}$')" level="ERROR">
+                <formal-name>Validation Reference Has Correct Format</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, a validation component MUST include a validation reference with the correct 4-digit format.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -46,7 +46,7 @@
             <expect id="validation-reference-has-correct-format" target=".[@type='validation' and prop[@name='asset-type' and @value='cryptographic-module'] and prop[@name='validation-type' and @value=('fips-140-2', 'fips-140-3')]]/prop[@name='validation-reference']" test="matches(@value, '^\d{4}$')" level="ERROR">
                 <formal-name>Validation Reference Has Correct Format</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
-                <message>In a FedRAMP SSP, a validation component MUST include a validation reference with the correct 4-digit format.</message>
+                <message>In a FedRAMP SSP, a cryptography validation component MUST include a validation reference with the correct 4-digit format.</message>
             </expect>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -11,7 +11,7 @@
             <expect id="component-has-valid-validation-details-link" target=".[@type='validation' and prop[@name='asset-type' and @value='cryptographic-module'] and prop[@name='validation-type' and @value=('fips-140-2', 'fips-140-3')]]/link[@rel='validation-details']" test="doc-available(@href)" level="ERROR">
                 <formal-name>Component Has Valid Proof of Compliance Link</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
-                <message>In a FedRAMP SSP, a validation component MUST include a valid validation details link.</message>
+                <message>In a FedRAMP SSP, a cryptography validation component MUST include a valid validation details link.</message>
             </expect>
             <expect id="component-has-validation-details-link" target=".[@type='validation' and prop[@name='asset-type' and @value='cryptographic-module'] and prop[@name='validation-type' and @value=('fips-140-2', 'fips-140-3')]]" test="count(link[@rel='validation-details']) eq 1" level="ERROR">
                 <formal-name>Component Has Proof of Compliance Link</formal-name>

--- a/src/validations/constraints/unit-tests/component-has-valid-validation-details-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/component-has-valid-validation-details-link-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for component-has-valid-validation-details-link
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-valid-validation-details-link
+  content: ../content/ssp-component-has-valid-validation-details-link-INVALID.xml
+  expectations:
+    - constraint-id: component-has-valid-validation-details-link
+      result: fail

--- a/src/validations/constraints/unit-tests/component-has-valid-validation-details-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/component-has-valid-validation-details-link-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for component-has-valid-validation-details-link
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-valid-validation-details-link
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: component-has-valid-validation-details-link
+      result: pass

--- a/src/validations/constraints/unit-tests/component-has-validation-details-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/component-has-validation-details-link-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for component-has-validation-details-link
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-validation-details-link
+  content: ../content/ssp-component-has-validation-details-link-INVALID.xml
+  expectations:
+    - constraint-id: component-has-validation-details-link
+      result: fail

--- a/src/validations/constraints/unit-tests/component-has-validation-details-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/component-has-validation-details-link-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for component-has-validation-details
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-validation-details
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: component-has-validation-details
+      result: pass

--- a/src/validations/constraints/unit-tests/component-has-validation-details-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/component-has-validation-details-link-PASS.yaml
@@ -1,9 +1,9 @@
 test-case:
-  name: Positive Test for component-has-validation-details
+  name: Positive Test for component-has-validation-details-link
   description: >-
     This test case validates the behavior of constraint
-    component-has-validation-details
+    component-has-validation-details-link
   content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
   expectations:
-    - constraint-id: component-has-validation-details
+    - constraint-id: component-has-validation-details-link
       result: pass

--- a/src/validations/constraints/unit-tests/component-has-validation-reference-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/component-has-validation-reference-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for component-has-validation-reference
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-validation-reference
+  content: ../content/ssp-component-has-validation-reference-INVALID.xml
+  expectations:
+    - constraint-id: component-has-validation-reference
+      result: fail

--- a/src/validations/constraints/unit-tests/component-has-validation-reference-PASS.yaml
+++ b/src/validations/constraints/unit-tests/component-has-validation-reference-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for component-has-validation-reference
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-validation-reference
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: component-has-validation-reference
+      result: pass

--- a/src/validations/constraints/unit-tests/validation-reference-has-correct-format-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/validation-reference-has-correct-format-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for validation-reference-has-correct-format
+  description: >-
+    This test case validates the behavior of constraint
+    validation-reference-has-correct-format
+  content: ../content/ssp-validation-reference-has-correct-format-INVALID.xml
+  expectations:
+    - constraint-id: validation-reference-has-correct-format
+      result: fail

--- a/src/validations/constraints/unit-tests/validation-reference-has-correct-format-PASS.yaml
+++ b/src/validations/constraints/unit-tests/validation-reference-has-correct-format-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for validation-reference-has-correct-format
+  description: >-
+    This test case validates the behavior of constraint
+    validation-reference-has-correct-format
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: validation-reference-has-correct-format
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
The purpose of this PR is to add the `Validation Component` constraints from issue #1156. 

## Changes
Added 4 constraints: 
- `component-has-proof-of-compliance-link`
- `component-has-valid-proof-of-compliance-link`
- `component-has-validation-reference`
- `validation-reference-has-correct-format`



### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
