### PR TITLE
Add `Cryptographic Module` Constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -46,6 +46,10 @@ Examples:
   | component-type |
   | connection-security |
   | control-implementation-status |
+  | cryptographic-module-component-has-function |
+  | cryptographic-module-component-has-provided-by-link |
+  | cryptographic-module-component-has-used-by-link |
+  | cryptographic-module-component-has-validation-link |
   | data-center-alternate |
   | data-center-count |
   | data-center-country-code |
@@ -59,6 +63,7 @@ Examples:
   | fedramp-version |
   | fully-operational-date-is-valid |
   | fully-operational-date-type |
+  | function |
   | has-authenticator-assurance-level |
   | has-authorization-boundary-diagram |
   | has-authorization-boundary-diagram-caption |
@@ -243,6 +248,14 @@ Examples:
   | connection-security-PASS.yaml |
   | control-implementation-status-FAIL.yaml |
   | control-implementation-status-PASS.yaml |
+  | cryptographic-module-component-has-function-FAIL.yaml |
+  | cryptographic-module-component-has-function-PASS.yaml |
+  | cryptographic-module-component-has-provided-by-link-FAIL.yaml |
+  | cryptographic-module-component-has-provided-by-link-PASS.yaml |
+  | cryptographic-module-component-has-used-by-link-FAIL.yaml |
+  | cryptographic-module-component-has-used-by-link-PASS.yaml |
+  | cryptographic-module-component-has-validation-link-FAIL.yaml |
+  | cryptographic-module-component-has-validation-link-PASS.yaml |
   | data-center-alternate-FAIL.yaml |
   | data-center-alternate-PASS.yaml |
   | data-center-count-FAIL.yaml |
@@ -269,6 +282,8 @@ Examples:
   | fully-operational-date-is-valid-PASS.yaml |
   | fully-operational-date-type-FAIL.yaml |
   | fully-operational-date-type-PASS.yaml |
+  | function-FAIL.yaml |
+  | function-PASS.yaml |
   | has-authenticator-assurance-level-FAIL.yaml |
   | has-authenticator-assurance-level-PASS.yaml |
   | has-authorization-boundary-diagram-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1813,6 +1813,30 @@ compliance (e.g., Module in Process).</p>
       </remarks>
     </component>
 
+    <component type="software" uuid="11111111-2222-4000-8000-009000300012">
+      <title>Database Row Encryption Module</title>
+      <description>
+        <p>Briefly describe the cryptographic module.</p>
+      </description>
+      <prop name="asset-type" value="cryptographic-module"/>
+      <prop name="vendor-name" value="Databases-R-Us" ns="http://fedramp.gov/ns/oscal"/>
+      <prop name="diagram-label" value="Database Queries" ns="http://fedramp.gov/ns/oscal"/>
+      <prop name="function" value="data-at-rest" ns="http://fedramp.gov/ns/oscal">
+        <remarks>
+          <p>Used to encrypt and decrypt rows in the database.</p>
+        </remarks>
+      </prop>
+      <link rel="validation" href="#11111111-2222-4000-8000-009001200001">
+        <text>A link to the 3rd party validation information related to this cryptographic module.</text>
+      </link>
+      <link rel="provided-by" href="#11111111-2222-4000-8000-009000300004">
+        <text>A link to the operating system component that has this module embedded.</text>
+      </link>
+      <link rel="used-by" href="#11111111-2222-4000-8000-009000300002">
+        <text>A link to the software component that uses this module for encrypted communication.</text>
+      </link>
+      <status state="operational"/>
+    </component>
 
     <component uuid="11111111-2222-4000-8000-009000400001" type="hardware">
       <title>[SAMPLE]Product</title>

--- a/src/validations/constraints/content/ssp-cryptographic-module-component-has-function-INVALID.xml
+++ b/src/validations/constraints/content/ssp-cryptographic-module-component-has-function-INVALID.xml
@@ -1,0 +1,13 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component type="software" uuid="11111111-2222-4000-8000-009000300012">
+      <prop name="asset-type" value="cryptographic-module"/>
+      <!-- Missing "function" prop with remarks. -->
+      <!-- <prop name="function" value="data-at-rest" ns="http://fedramp.gov/ns/oscal">
+        <remarks>
+          <p>Used to encrypt and decrypt rows in the database.</p>
+        </remarks>
+      </prop> -->
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-cryptographic-module-component-has-provided-by-link-INVALID.xml
+++ b/src/validations/constraints/content/ssp-cryptographic-module-component-has-provided-by-link-INVALID.xml
@@ -1,0 +1,11 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component type="software" uuid="11111111-2222-4000-8000-009000300012">
+      <prop name="asset-type" value="cryptographic-module"/>
+      <!-- Missing "provided-by" link. -->
+      <!-- <link rel="provided-by" href="#">
+        <text>A link to the operating system component that has this module embedded.</text>
+      </link> -->
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-cryptographic-module-component-has-used-by-link-INVALID.xml
+++ b/src/validations/constraints/content/ssp-cryptographic-module-component-has-used-by-link-INVALID.xml
@@ -1,0 +1,11 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component type="software" uuid="11111111-2222-4000-8000-009000300012">
+      <prop name="asset-type" value="cryptographic-module"/>
+      <!-- Missing "used-by" link. -->
+      <!-- <link rel="used-by" href="#">
+        <text>A link to the software component that uses this module for encrypted communication.</text>
+      </link> -->
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-cryptographic-module-component-has-validation-link-INVALID.xml
+++ b/src/validations/constraints/content/ssp-cryptographic-module-component-has-validation-link-INVALID.xml
@@ -1,0 +1,11 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component type="software" uuid="11111111-2222-4000-8000-009000300012">
+      <prop name="asset-type" value="cryptographic-module"/>
+      <!-- Missing "validation" link. -->
+      <!-- <link rel="validation" href="#11111111-2222-4000-8000-009001200001">
+        <text>A link to the 3rd party validation information related to this cryptographic module.</text>
+      </link> -->
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-function-INVALID.xml
+++ b/src/validations/constraints/content/ssp-function-INVALID.xml
@@ -1,0 +1,13 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component type="software" uuid="11111111-2222-4000-8000-009000300012">
+      <prop name="asset-type" value="cryptographic-module"/>
+      <!-- Not a valid value for the "function" prop. -->
+      <prop name="function" value="invalid-value" ns="http://fedramp.gov/ns/oscal">
+        <remarks>
+          <p>Used to encrypt and decrypt rows in the database.</p>
+        </remarks>
+      </prop>
+    </component>
+  </system-implementation>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -162,6 +162,13 @@
                 <enum value="fedramp-3.0.0rc1-oscal-1.1.2">FedRAMP Version</enum>
             </allowed-values>
 
+            <allowed-values id="function" target="//component/prop[@name='function' and @ns='http://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
+                <formal-name>Function</formal-name>
+                <description>Identifies the data affected by a component.</description>
+                <enum value="data-at-rest">Data at Rest</enum>
+                <enum value="data-in-transit">Data in Transit</enum>
+                <enum value="other">Other</enum>
+            </allowed-values>
 
             <allowed-values id="information-type" target="//component/prop[@name='information-type' and @ns='http://fedramp.gov/ns/oscal']/@class" allow-other="no" level="ERROR">
                 <formal-name>Information Type</formal-name>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -6,6 +6,32 @@
     <!-- ================== -->
 
     <context>
+        <metapath target="//component"/>
+        <constraints>
+            <expect id="cryptographic-module-component-has-function" target=".[@type='software' and prop[@name='asset-type' and @value='cryptographic-module']]" test="(count(prop[@name='function']) eq 1) and (if (prop[@name='function' and @value='other']) then exists(prop[@name='function' and @value='other']/remarks) else true())" level="ERROR">
+                <formal-name>Cryptographic Module Component Has Function</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, a crytographic module component MUST include its function and use remarks to describe its function.</message>
+            </expect>
+            <expect id="cryptographic-module-component-has-provided-by-link" target=".[@type='software' and prop[@name='asset-type' and @value='cryptographic-module']]" test="count(link[@rel='provided-by']) >= 1" level="ERROR">
+                <formal-name>Cryptographic Module Component Has Provided By Link</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, a crytographic module component MUST include at least one "provided by" link.</message>
+            </expect>
+            <expect id="cryptographic-module-component-has-used-by-link" target=".[@type='software' and prop[@name='asset-type' and @value='cryptographic-module']]" test="count(link[@rel='used-by']) >= 1" level="ERROR">
+                <formal-name>Cryptographic Module Component Has Used By Link</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, a crytographic module component MUST include at least one "used by" link.</message>
+            </expect>
+            <expect id="cryptographic-module-component-has-validation-link" target=".[@type='software' and prop[@name='asset-type' and @value='cryptographic-module']]" test="count(link[@rel='validation']) >= 1" level="ERROR">
+                <formal-name>Cryptographic Module Component Has Validation Link</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, a crytographic module component MUST include at least one "validation" link.</message>
+            </expect>
+        </constraints>
+    </context>
+
+    <context>
         <metapath target="//user"/>
         <constraints>
             <expect id="user-has-authorized-privilege" target="." test="count(authorized-privilege) gt 0" level="ERROR">

--- a/src/validations/constraints/unit-tests/cryptographic-module-component-has-function-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/cryptographic-module-component-has-function-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for cryptographic-module-component-has-function
+  description: >-
+    This test case validates the behavior of constraint
+    cryptographic-module-component-has-function
+  content: ../content/ssp-cryptographic-module-component-has-function-INVALID.xml
+  expectations:
+    - constraint-id: cryptographic-module-component-has-function
+      result: fail

--- a/src/validations/constraints/unit-tests/cryptographic-module-component-has-function-PASS.yaml
+++ b/src/validations/constraints/unit-tests/cryptographic-module-component-has-function-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for cryptographic-module-component-has-function
+  description: >-
+    This test case validates the behavior of constraint
+    cryptographic-module-component-has-function
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: cryptographic-module-component-has-function
+      result: pass

--- a/src/validations/constraints/unit-tests/cryptographic-module-component-has-provided-by-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/cryptographic-module-component-has-provided-by-link-FAIL.yaml
@@ -1,0 +1,10 @@
+test-case:
+  name: Negative Test for cryptographic-module-component-has-provided-by-link
+  description: >-
+    This test case validates the behavior of constraint
+    cryptographic-module-component-has-provided-by-link
+  content: >-
+    ../content/ssp-cryptographic-module-component-has-provided-by-link-INVALID.xml
+  expectations:
+    - constraint-id: cryptographic-module-component-has-provided-by-link
+      result: fail

--- a/src/validations/constraints/unit-tests/cryptographic-module-component-has-provided-by-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/cryptographic-module-component-has-provided-by-link-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for cryptographic-module-component-has-provided-by-link
+  description: >-
+    This test case validates the behavior of constraint
+    cryptographic-module-component-has-provided-by-link
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: cryptographic-module-component-has-provided-by-link
+      result: pass

--- a/src/validations/constraints/unit-tests/cryptographic-module-component-has-used-by-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/cryptographic-module-component-has-used-by-link-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for cryptographic-module-component-has-used-by-link
+  description: >-
+    This test case validates the behavior of constraint
+    cryptographic-module-component-has-used-by-link
+  content: ../content/ssp-cryptographic-module-component-has-used-by-link-INVALID.xml
+  expectations:
+    - constraint-id: cryptographic-module-component-has-used-by-link
+      result: fail

--- a/src/validations/constraints/unit-tests/cryptographic-module-component-has-used-by-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/cryptographic-module-component-has-used-by-link-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for cryptographic-module-component-has-used-by-link
+  description: >-
+    This test case validates the behavior of constraint
+    cryptographic-module-component-has-used-by-link
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: cryptographic-module-component-has-used-by-link
+      result: pass

--- a/src/validations/constraints/unit-tests/cryptographic-module-component-has-validation-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/cryptographic-module-component-has-validation-link-FAIL.yaml
@@ -1,0 +1,10 @@
+test-case:
+  name: Negative Test for cryptographic-module-component-has-validation-link
+  description: >-
+    This test case validates the behavior of constraint
+    cryptographic-module-component-has-validation-link
+  content: >-
+    ../content/ssp-cryptographic-module-component-has-validation-link-INVALID.xml
+  expectations:
+    - constraint-id: cryptographic-module-component-has-validation-link
+      result: fail

--- a/src/validations/constraints/unit-tests/cryptographic-module-component-has-validation-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/cryptographic-module-component-has-validation-link-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for cryptographic-module-component-has-validation-link
+  description: >-
+    This test case validates the behavior of constraint
+    cryptographic-module-component-has-validation-link
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: cryptographic-module-component-has-validation-link
+      result: pass

--- a/src/validations/constraints/unit-tests/function-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/function-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for function
+  description: This test case validates the behavior of constraint function
+  content: ../content/ssp-function-INVALID.xml
+  expectations:
+    - constraint-id: function
+      result: fail

--- a/src/validations/constraints/unit-tests/function-PASS.yaml
+++ b/src/validations/constraints/unit-tests/function-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for function
+  description: This test case validates the behavior of constraint function
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: function
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `Cryptographic Module` constraints from issue #1155. 

## Changes
Added 5 Constraints:
-  cryptographic-module-component-has-function
- cryptographic-module-component-has-provided-by-link
- cryptographic-module-component-has-used-by-link
- cryptographic-module-component-has-validation-link
- function
### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
