### PR TITLE
add performance test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ clean-oci-image:
 
 test: build-validations ## Test all
 
+performance: performance-validations # test performance
+
 build: init-content test-content build-content  ## Build all artifacts and copy into dist directory
 
 build-oci-image: ## Build OCI image

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:server": "cross-env-shell OSCAL_EXECUTOR='oscal-server' NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js --tags @style-guide",
     "test:integration:server": "cross-env-shell OSCAL_EXECUTOR='oscal-server' NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js --tags @integration",
     "mq": "node ./src/scripts/dev-metaschema-eval.js",
-    "constraint": "node ./src/scripts/dev-constraint.js"
+    "constraint": "node ./src/scripts/dev-constraint.js",
+    "test:performance": "node ./src/scripts/dev-constraints-performance.js"
   },
   "type": "module",
   "dependencies": {

--- a/src/scripts/dev-constraints-performance.js
+++ b/src/scripts/dev-constraints-performance.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises';
+import path from 'path';
+import { performance } from 'perf_hooks';
+import { fileURLToPath } from 'url';
+import { validateDocument } from 'oscal';
+import { resolve } from 'path';
+import { JSDOM } from 'jsdom';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Example SSP to validate against
+const EXAMPLE_SSP = path.join(__dirname, '../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml');
+
+// Directory containing reporting files
+const REPORTS_DIR = path.join(__dirname, '../../reports');
+
+// Directory containing constraint files
+const CONSTRAINTS_DIR = path.join(__dirname, '../validations/constraints');
+
+// Directory to store individual constraints
+const EXPLODED_DIR = path.join(__dirname, '../validations/constraints/exploded');
+
+async function validateWithConstraint(sspPath, constraintPath) {
+  const start = performance.now();
+  
+  try {
+    const { isValid, log } = await validateDocument(
+      resolve(sspPath),
+      {
+        quiet: true,
+        extensions: [resolve(constraintPath)]
+      }
+    );
+    
+    const end = performance.now();
+    return {
+      time: end - start,
+      success: isValid,
+      log
+    };
+  } catch (err) {
+    throw new Error(`Validation error: ${err.message}`);
+  }
+}
+
+async function extractConstraints(xmlPath) {
+  const content = await fs.readFile(xmlPath, 'utf-8');
+  const dom = new JSDOM(content, { contentType: "text/xml" });
+  const doc = dom.window.document;
+
+  // Get all contexts
+  const contexts = doc.getElementsByTagName('context');
+  const constraints = [];
+
+  for (const context of contexts) {
+    // Get metapath and variables
+    const metapaths = Array.from(context.getElementsByTagName('metapath')).map(m => m.getAttribute('target'));
+    const variables = Array.from(context.getElementsByTagName('let')).map(v => ({
+      var: v.getAttribute('var'),
+      expression: v.getAttribute('expression')
+    }));
+
+    // Get individual constraints
+    const constraintElements = context.getElementsByTagName('constraints')[0];
+    if (!constraintElements) continue;
+
+    // Process each constraint type (expect, matches, etc.)
+    for (const child of constraintElements.children) {
+      if (child.tagName === 'let') continue; // Skip variable declarations
+
+      const id = child.getAttribute('id');
+      if (!id) continue;
+
+      // Create XML for this individual constraint
+      const constraintXml = `<?xml version="1.0" encoding="UTF-8"?>
+<metaschema-meta-constraints xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <context>
+        ${metapaths.map(mp => `<metapath target="${mp}"/>`).join('\n        ')}
+        <constraints>
+            ${variables.map(v => `<let var="${v.var}" expression="${v.expression}"/>`).join('\n            ')}
+            ${child.outerHTML.replace(' xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0"', '')}
+        </constraints>
+    </context>
+</metaschema-meta-constraints>`;
+
+      constraints.push({
+        id,
+        xml: constraintXml
+      });
+    }
+  }
+
+  return constraints;
+}
+
+async function main() {
+  try {
+    console.log('Finding constraint files...');
+    
+    // Create exploded directory if it doesn't exist
+    await fs.mkdir(EXPLODED_DIR, { recursive: true });
+
+    // Process main constraints file
+    const mainConstraintsFile = path.join(CONSTRAINTS_DIR, 'fedramp-external-constraints.xml');
+    const constraints = await extractConstraints(mainConstraintsFile);
+    
+    console.log(`Found ${constraints.length} individual constraints\n`);
+
+    // Write individual constraint files
+    for (const constraint of constraints) {
+      const filePath = path.join(EXPLODED_DIR, `${constraint.id}.xml`);
+      await fs.writeFile(filePath, constraint.xml);
+    }
+
+    console.log('Testing constraints...');
+    const results = [];
+    
+    // Test each constraint
+    for (const constraint of constraints) {
+      const constraintPath = path.join(EXPLODED_DIR, `${constraint.id}.xml`);
+      process.stdout.write(`Testing ${constraint.id}... `);
+      
+      try {
+        const result = await validateWithConstraint(EXAMPLE_SSP, constraintPath);
+        results.push({
+          constraint: constraint.id,
+          time: result.time,
+          success: result.success,
+          log: result.log
+        });
+        console.log(`${result.time.toFixed(2)}ms ${result.success ? '✓' : '✗'}`);
+      } catch (err) {
+        console.log('Error!');
+        console.error(`  ${err.message}`);
+        results.push({
+          constraint: constraint.id,
+          time: null,
+          success: false,
+          error: err.message
+        });
+      }
+    }
+
+    // Sort results by time
+    results.sort((a, b) => (b.time || 0) - (a.time || 0));
+
+    // Generate markdown table
+    let markdown = '# Constraint Performance Results\n\n';
+    markdown += '| Constraint ID | Time (ms) | Status |\n';
+    markdown += '|---------------|-----------|--------|\n';
+
+    for (const result of results) {
+      const status = result.time === null ? '❌' : (result.success ? '✓' : '✗');
+      let validationInfo = '';            
+      markdown += `| ${result.constraint} | ${result.time ? result.time.toFixed(2) : 'N/A'} | ${status} |\n`;
+    }
+
+    // Calculate statistics
+    const successfulTimes = results.filter(r => r.time !== null).map(r => r.time);
+    if (successfulTimes.length > 0) {
+      const total = successfulTimes.reduce((a, b) => a + b, 0);
+      const avg = total / successfulTimes.length;
+      const max = Math.max(...successfulTimes);
+      const min = Math.min(...successfulTimes);
+
+      markdown += '\n## Statistics\n\n';
+      markdown += `- Total time: ${total.toFixed(2)}ms\n`;
+      markdown += `- Average time: ${avg.toFixed(2)}ms\n`;
+      markdown += `- Max time: ${max.toFixed(2)}ms\n`;
+      markdown += `- Min time: ${min.toFixed(2)}ms\n`;
+      markdown += `- Success rate: ${successfulTimes.length}/${results.length} (${((successfulTimes.length/results.length)*100).toFixed(1)}%)\n`;
+    }
+
+    // Write results to markdown file
+    await fs.writeFile(path.join(EXPLODED_DIR, 'results.md'), markdown);
+
+    // Copy results file to parent directory before deleting exploded directory
+    await fs.copyFile(path.join(EXPLODED_DIR, 'results.md'), path.join(REPORTS_DIR, 'constraints-performance.md'));
+    console.log('\nResults written to '+path.resolve(REPORTS_DIR, 'constraints-performance.md'));
+    
+    // Delete exploded directory
+    await fs.rm(EXPLODED_DIR, { recursive: true, force: true });
+    console.log('Cleaned up exploded directory');
+
+  } catch (err) {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/scripts/dev-constraints-performance.js
+++ b/src/scripts/dev-constraints-performance.js
@@ -55,11 +55,18 @@ async function extractConstraints(xmlPath) {
   const constraints = [];
 
   for (const context of contexts) {
-    // Get metapath and variables
+    // Get metapath, variables, and indexes
     const metapaths = Array.from(context.getElementsByTagName('metapath')).map(m => m.getAttribute('target'));
     const variables = Array.from(context.getElementsByTagName('let')).map(v => ({
       var: v.getAttribute('var'),
       expression: v.getAttribute('expression')
+    }));
+    const indexes = Array.from(context.getElementsByTagName('index')).map(idx => ({
+      name: idx.getAttribute('name'),
+      target: idx.getAttribute('target'),
+      formalName: idx.getElementsByTagName('formal-name')[0]?.textContent,
+      description: idx.getElementsByTagName('description')[0]?.textContent,
+      keyField: idx.getElementsByTagName('key-field')[0]?.getAttribute('target')
     }));
 
     // Get individual constraints
@@ -80,6 +87,11 @@ async function extractConstraints(xmlPath) {
         ${metapaths.map(mp => `<metapath target="${mp}"/>`).join('\n        ')}
         <constraints>
             ${variables.map(v => `<let var="${v.var}" expression="${v.expression}"/>`).join('\n            ')}
+            ${indexes.map(idx => `<index name="${idx.name}" target="${idx.target}">
+                <formal-name>${idx.formalName || ''}</formal-name>
+                <description>${idx.description || ''}</description>
+                <key-field target="${idx.keyField}"/>
+            </index>`).join('\n            ')}
             ${child.outerHTML.replace(' xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0"', '')}
         </constraints>
     </context>

--- a/src/validations/module.mk
+++ b/src/validations/module.mk
@@ -41,6 +41,16 @@ build-validations:
 	@npm run test:server
 	$(OSCAL_CLI) server stop
 
+# Validation
+.PHONY: performance-validations
+performance-validations:
+	@echo "Running Performance Tests"
+	$(OSCAL_CLI) server stop
+	npx cross-env OSCAL_SERVER_PATH=$(OSCAL_SERVER_PATH)  $(OSCAL_CLI) server start -bg
+	@npm run test:performance
+	$(OSCAL_CLI) server stop
+
+
 clean-validations:
 	@echo "Nothing to clean"
 


### PR DESCRIPTION
# Committer Notes

Add a new make command:

`make performance
`
this script explodes each constraint into an individual file so we can isolate longer running constraints.


When the test is complete a constraint timing result is placed here in the reports directory 

| Constraint ID | Time (ms) | Status |
|---------------|-----------|--------|
| aggregate-parameters-warning | 2923.34 | ✓ |
| incomplete-implemented-requirements | 2354.18 | ✓ |
| cryptographic-module-component-has-function | 2335.88 | ✓ |
| component-has-non-provider-responsible-role | 2282.64 | ✓ |
| component-has-authentication-method | 2264.31 | ✓ |
| import-profile-resolves-to-fedramp-content | 2249.72 | ✓ |
| component-has-provider-responsible-role | 2211.53 | ✓ |
| leveraged-authorization-has-valid-impact-level | 2185.23 | ✓ |
| import-profile-has-available-document | 2177.50 | ✓ |
| has-required-response-points | 2162.97 | ✓ |
| non-provider-responsible-role-references-user | 2159.96 | ✓ |
| has-required-parameters | 2142.16 | ✓ |
| extraneous-implemented-requirements | 2131.44 | ✓ |
| cryptographic-module-component-has-provided-by-link | 863.54 | ✓ |
| cryptographic-module-component-has-used-by-link | 778.62 | ✓ |
| statement-has-this-system-component | 709.14 | ✓ |
| resource-has-title | 694.27 | ✓ |
| cryptographic-module-component-has-validation-link | 683.87 | ✓ |
| has-data-flow-diagram-link-href-target | 681.90 | ✓ |
| user-has-role-id | 673.58 | ✓ |
| has-policy | 671.62 | ✓ |
| responsible-party-is-person | 668.17 | ✓ |
| leveraged-authorization-has-impact-level | 665.71 | ✓ |
| data-center-count | 656.39 | ✓ |
| missing-response-components | 648.34 | ✓ |
| fully-operational-date-is-valid | 640.59 | ✓ |
| data-center-alternate | 638.69 | ✓ |
| has-procedure | 637.20 | ✓ |
| resource-has-base64-or-rlink | 636.19 | ✓ |
| user-has-authorized-privilege | 634.72 | ✓ |
| has-network-architecture-diagram-description | 632.62 | ✓ |
| data-center-country-code | 628.17 | ✓ |
| misplaced-response-components | 627.31 | ✓ |
| by-component-has-responsible-role | 624.80 | ✓ |
| responsible-party-prepared-by | 624.71 | ✓ |
| responsible-party-prepared-by-location-valid | 624.70 | ✓ |
| inventory-item-has-function | 619.26 | ✓ |
| fedramp-version | 611.81 | ✓ |
| information-type-has-availability-impact | 602.11 | ✓ |
| scan-type-has-remarks | 601.25 | ✓ |
| has-network-architecture-diagram-link | 600.62 | ✓ |
| user-has-user-type | 599.38 | ✓ |
| has-cloud-service-model-remarks | 599.23 | ✓ |
| role-defined-system-owner | 599.01 | ✓ |
| data-center-primary | 598.23 | ✓ |
| categorization-has-correct-system-attribute | 597.72 | ✓ |
| has-data-flow-diagram | 597.32 | ✓ |
| has-incident-response-plan | 596.16 | ✓ |
| has-data-flow-diagram-link-rel-allowed-value | 595.15 | ✓ |
| saas-has-leveraged-authorization | 593.97 | ✓ |
| has-network-architecture-diagram | 592.81 | ✓ |
| data-center-us | 591.46 | ✓ |
| has-information-system-contingency-plan | 588.65 | ✓ |
| component-has-used-by-link | 587.86 | ✓ |
| high-impact-inventory-item-has-asset-owner | 585.92 | ✓ |
| information-type-has-confidentiality-impact | 585.70 | ✓ |
| has-authorization-boundary-diagram-caption | 585.27 | ✓ |
| leveraged-authorization-has-system-identifier | 585.25 | ✓ |
| network-component-has-connection-security-prop | 585.01 | ✓ |
| prop-response-point-has-cardinality-one | 584.53 | ✓ |
| leveraged-authorization-component-has-valid-reference | 584.45 | ✓ |
| leveraged-authorization-has-one-system-component | 584.42 | ✓ |
| fedramp-citations-has-correct-link | 584.04 | ✓ |
| has-cloud-deployment-model | 583.75 | ✓ |
| inventory-item-not-system-or-validation | 583.72 | ✓ |
| inventory-item-has-vendor-name | 583.58 | ✓ |
| has-authorization-boundary-diagram-link | 581.21 | ✓ |
| has-data-flow-diagram-caption | 581.13 | ✓ |
| has-user-guide | 580.69 | ✓ |
| has-network-architecture-diagram-link-rel | 579.88 | ✓ |
| cia-impact-has-adjustment-justification | 579.19 | ✓ |
| has-fully-operational-date | 578.90 | ✓ |
| cia-impact-has-selected | 578.88 | ✓ |
| has-inventory-items | 578.45 | ✓ |
| last-accessed-is-datetime | 577.79 | ✓ |
| has-security-sensitivity-level | 577.12 | ✓ |
| unique-inventory-item-asset-id | 577.04 | ✓ |
| leveraged-authorization-has-authorization-type | 576.52 | ✓ |
| role-defined-authorizing-official-poc | 575.96 | ✓ |
| inventory-item-has-asset-type | 575.70 | ✓ |
| has-identity-assurance-level | 575.06 | ✓ |
| end-of-life-date-type | 574.97 | ✓ |
| responsible-party-prepared-for | 574.90 | ✓ |
| has-data-flow-diagram-link | 574.74 | ✓ |
| leveraged-authorization-has-authorized-users | 574.50 | ✓ |
| leveraged-authorization-has-nature-of-agreement | 574.28 | ✓ |
| has-network-architecture-diagram-caption | 573.57 | ✓ |
| authentication-method-has-remarks | 573.42 | ✓ |
| has-authorization-boundary-diagram-description | 573.41 | ✓ |
| has-authorization-boundary-diagram-link-href-target | 573.39 | ✓ |
| party-has-name | 573.31 | ✓ |
| security-sensitivity-level-matches-security-impact-level | 573.20 | ✓ |
| has-system-id | 573.17 | ✓ |
| has-published-date | 572.93 | ✓ |
| role-defined-prepared-for | 571.73 | ✓ |
| has-security-impact-level | 571.32 | ✓ |
| marking | 571.15 | ✓ |
| inventory-item-has-scan-type | 570.98 | ✓ |
| inventory-item-has-is-scanned | 570.72 | ✓ |
| inventory-item-or-component-has-asset-id | 570.55 | ✓ |
| leveraged-authorization-has-implementation-point | 570.54 | ✓ |
| has-fedramp-citations | 570.53 | ✓ |
| role-defined-prepared-by | 570.36 | ✓ |
| information-type-has-class | 569.33 | ✓ |
| inventory-item-has-diagram-label | 569.17 | ✓ |
| image-has-checksum | 569.05 | ✓ |
| has-authenticator-assurance-level | 569.05 | ✓ |
| component-has-authenticated-scan | 568.88 | ✓ |
| network-component-has-implementation-point | 568.85 | ✓ |
| has-cloud-service-model | 568.84 | ✓ |
| inventory-item-has-valid-mac-address | 568.68 | ✓ |
| has-rules-of-behavior | 568.65 | ✓ |
| authenticated-scan-no-has-remarks | 567.85 | ✓ |
| has-configuration-management-plan | 567.59 | ✓ |
| has-data-flow-diagram-description | 567.41 | ✓ |
| inter-boundary-component-has-information-type | 567.29 | ✓ |
| categorization-has-information-type-id | 567.17 | ✓ |
| component-has-diagram-label | 566.95 | ✓ |
| has-data-flow-description | 566.64 | ✓ |
| inventory-item-or-component-has-virtual | 566.53 | ✓ |
| has-authorization-boundary-diagram | 566.00 | ✓ |
| has-cloud-deployment-model-remarks | 565.98 | ✓ |
| has-network-architecture | 565.84 | ✓ |
| inter-boundary-component-information-type-has-class-attribute | 565.61 | ✓ |
| role-defined-information-system-security-officer | 565.59 | ✓ |
| has-network-architecture-diagram-link-rel-allowed-value | 565.40 | ✓ |
| has-authorization-boundary-diagram-link-rel-allowed-value | 565.39 | ✓ |
| interconnection-component-linked-has-protocol | 565.35 | ✓ |
| has-system-name-short | 564.83 | ✓ |
| has-data-flow-diagram-uuid | 564.49 | ✓ |
| used-by-link-references-component | 563.27 | ✓ |
| information-type-has-integrity-impact | 562.31 | ✓ |
| has-network-architecture-diagram-link-href-target | 561.46 | ✓ |
| leveraged-authorization-has-information-type | 560.35 | ✓ |
| responsible-party-prepared-for-location-valid | 559.86 | ✓ |
| inventory-item-has-authenticated-scan | 559.67 | ✓ |
| fully-operational-date-type | 558.12 | ✓ |
| implementation-status-has-remarks | 557.75 | ✓ |
| has-authorization-boundary-diagram-link-rel | 557.42 | ✓ |
| has-federation-assurance-level | 555.37 | ✓ |
| has-data-flow | 554.40 | ✓ |
| has-data-flow-diagram-link-rel | 549.69 | ✓ |
| inventory-item-and-component-has-public | 549.33 | ✓ |

## Statistics

- Total time: 106545.96ms
- Average time: 745.08ms
- Max time: 2923.34ms
- Min time: 549.33ms
- Success rate: 143/143 (100.0%)


### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
