### PR TITLE
Add `Issue 1033` constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -39,6 +39,7 @@ Examples:
   | cloud-service-model |
   | component-has-authenticated-scan |
   | component-has-authentication-method |
+  | component-has-baseline-link |
   | component-has-diagram-label |
   | component-has-non-provider-responsible-role |
   | component-has-provider-responsible-role |
@@ -136,6 +137,7 @@ Examples:
   | inventory-item-asset-types |
   | inventory-item-has-asset-type |
   | inventory-item-has-authenticated-scan |
+  | inventory-item-has-baseline-link |
   | inventory-item-has-diagram-label |
   | inventory-item-has-function |
   | inventory-item-has-is-scanned |
@@ -240,6 +242,8 @@ Examples:
   | component-has-authenticated-scan-PASS.yaml |
   | component-has-authentication-method-FAIL.yaml |
   | component-has-authentication-method-PASS.yaml |
+  | component-has-baseline-link-FAIL.yaml |
+  | component-has-baseline-link-PASS.yaml |
   | component-has-diagram-label-FAIL.yaml |
   | component-has-diagram-label-PASS.yaml |
   | component-has-non-provider-responsible-role-FAIL.yaml |
@@ -434,6 +438,8 @@ Examples:
   | inventory-item-has-asset-type-PASS.yaml |
   | inventory-item-has-authenticated-scan-FAIL.yaml |
   | inventory-item-has-authenticated-scan-PASS.yaml |
+  | inventory-item-has-baseline-link-FAIL.yaml |
+  | inventory-item-has-baseline-link-PASS.yaml |
   | inventory-item-has-diagram-label-FAIL.yaml |
   | inventory-item-has-diagram-label-PASS.yaml |
   | inventory-item-has-function-FAIL.yaml |

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1558,6 +1558,7 @@ leveraged-authorization assembly:</p>
       </prop>
 
       <!-- <link href="11111111-2222-4000-8000-009000000000" rel="used-by"/> -->
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <link rel="api" href="https://api.example.com/v1"/>
       <link rel="used-by" href="#11111111-2222-4000-8000-009000000000"/>
       <status state="operational"/>
@@ -1640,6 +1641,7 @@ property.</p>
           <p/>
         </remarks>
       </prop>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <link rel="provided-by" href="#11111111-2222-4000-8000-009000100001"/>
       <status state="operational"/>
       <responsible-role role-id="provider">
@@ -1665,6 +1667,7 @@ property.</p>
       <prop name="allows-authenticated-scan" value="yes"/>
       <prop name="public" value="yes"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <status state="operational"/>
       
     </component>
@@ -1690,6 +1693,7 @@ property.</p>
         <p>Describe the hardware and what it is used for.</p>
       </description>
       <prop name="implementation-point" value="internal"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <status state="operational"/>
     </component>
 
@@ -1756,6 +1760,7 @@ compliance (e.g., Module in Process).</p>
       <prop name="model" value="Model Number"/>
       <prop name="version" value="Version Number"/>
       <prop name="patch-level" value="Patch Level"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <link rel="validation" href="#11111111-2222-4000-8000-009000000002"/>
       <status state="operational"/>
       <responsible-role role-id="admin-unix">
@@ -1778,6 +1783,7 @@ compliance (e.g., Module in Process).</p>
       <prop name="model" value="Model Number"/>
       <prop name="version" value="Version Number"/>
       <prop name="patch-level" value="Patch Level"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <link rel="validation" href="#11111111-2222-4000-8000-009000000002"/>
       <status state="operational"/>
       <responsible-role role-id="admin-unix">
@@ -1802,6 +1808,7 @@ compliance (e.g., Module in Process).</p>
       <prop name="version" value="11"/>
       <prop name="patch-level" value="Patch Level"/>
       <prop name="asset-id" value="unique-asset-ID-03"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <link rel="validation" href="#11111111-2222-4000-8000-009000000002"/>
       <link href="https://hub.docker.com/layers/library/debian/stable/images/sha256-e83913597ca9deb9d699316a9a9d806c2a87ed61195ac66ae0a8ac55089a84b9"/>
       <status state="operational"/>
@@ -1826,6 +1833,7 @@ compliance (e.g., Module in Process).</p>
           <p>Used to encrypt and decrypt rows in the database.</p>
         </remarks>
       </prop>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <link rel="validation" href="#11111111-2222-4000-8000-009001200001">
         <text>A link to the 3rd party validation information related to this cryptographic module.</text>
       </link>
@@ -1850,6 +1858,7 @@ compliance (e.g., Module in Process).</p>
       <prop name="vendor-name" value="Vendor Name"/>
       <prop name="model" value="Model Number"/>
       <prop name="version" value="Version Number"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <status state="operational"/>
       <responsible-role role-id="asset-administrator">
         <party-uuid>11111111-2222-4000-8000-004000000017</party-uuid>
@@ -1871,6 +1880,7 @@ compliance (e.g., Module in Process).</p>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <prop name="baseline-configuration-name" value="Baseline Config. Name"/>
       <prop name="allows-authenticated-scan" value="yes"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <status state="operational"/>
     </component>
     <component uuid="11111111-2222-4000-8000-009000300005" type="service">
@@ -1932,6 +1942,7 @@ compliance (e.g., Module in Process).</p>
           <p>Vendor appliance. No admin-level access.</p>
         </remarks>
       </prop>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <status state="operational"/>
     </component>
 
@@ -2324,6 +2335,7 @@ approved.</p>
       <prop ns="http://fedramp.gov/ns/oscal" name="ipv6-address" class="local" value="::ffff:10.1.1.5"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="ipv4-address" class="remote" value="10.2.2.5"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="ipv6-address" class="remote" value="::ffff:10.2.2.5"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
 
       <link href="#11111111-2222-4000-8000-009000500005" rel="used-by"/>
       <!-- is-scanned prop applies to inventory-item (not component) -->
@@ -2434,6 +2446,7 @@ approved.</p>
           <p>Optional, longer, formatted description.</p>
         </remarks>
       </prop>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <link rel="validation" href="#11111111-2222-4000-8000-009000000002"/>
       <responsible-party role-id="asset-owner">
         <party-uuid>11111111-2222-4000-8000-004000000016</party-uuid>
@@ -2477,6 +2490,7 @@ approved.</p>
       </prop>
 
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <responsible-party role-id="asset-owner">
         <party-uuid>11111111-2222-4000-8000-004000000010</party-uuid>
       </responsible-party>
@@ -2512,6 +2526,7 @@ approved.</p>
           <p>Required, longer, formatted description.</p>
         </remarks>
       </prop>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000000008"/>
     </inventory-item>
     <inventory-item uuid="11111111-2222-4000-8000-011000000004">
@@ -2531,6 +2546,7 @@ approved.</p>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="other">
         <remarks><p>a different kind of scan</p></remarks>
       </prop>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000500006"/>
     </inventory-item>
     <inventory-item uuid="11111111-2222-4000-8000-011000000005">
@@ -2554,6 +2570,7 @@ approved.</p>
           <p>Required, longer, formatted description.</p>
         </remarks>
       </prop>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
      <implemented-component component-uuid="11111111-2222-4000-8000-009000000011"/>
     </inventory-item>
     <inventory-item uuid="11111111-2222-4000-8000-011000000006">
@@ -2581,6 +2598,7 @@ approved.</p>
       </prop>
 
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000500007"/>
     </inventory-item>
     <inventory-item uuid="11111111-2222-4000-8000-011000000007">
@@ -2603,6 +2621,7 @@ approved.</p>
           <p>Optional, longer, formatted description.</p>
         </remarks>
       </prop>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000000008"/>
     </inventory-item>
     <inventory-item uuid="11111111-2222-4000-8000-011000000008">
@@ -2629,6 +2648,7 @@ approved.</p>
         </remarks>
       </prop>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000500005"/>
     </inventory-item>
     <inventory-item uuid="11111111-2222-4000-8000-011000000009">
@@ -2647,6 +2667,7 @@ approved.</p>
       <prop ns="http://fedramp.gov/ns/oscal" name="vendor-name" value="Vendor"/>
       <prop ns="http://fedramp.gov/ns/oscal" name="scan-type" value="infrastructure"/>
       <prop name='function' value='virtual'><remarks><p>virtual function</p></remarks></prop>
+      <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/>
       <implemented-component component-uuid="11111111-2222-4000-8000-009000000018"/>
     </inventory-item>
   </system-implementation>

--- a/src/validations/constraints/content/ssp-component-has-baseline-link-INVALID.xml
+++ b/src/validations/constraints/content/ssp-component-has-baseline-link-INVALID.xml
@@ -1,0 +1,11 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000500006" type="software">
+      <!-- <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/> Missing baseline-configuration-name href. -->
+    </component>
+  </system-implementation>
+  <back-matter>
+    <resource uuid="11111111-2222-4000-8000-001000000005">
+    </resource>
+  </back-matter>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-inventory-item-has-baseline-link-INVALID.xml
+++ b/src/validations/constraints/content/ssp-inventory-item-has-baseline-link-INVALID.xml
@@ -1,0 +1,15 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="11111111-2222-4000-8000-000000000000">
+  <system-implementation>
+    <component uuid="11111111-2222-4000-8000-009000500006" type="software">
+      <!-- <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/> Missing baseline-configuration-name href. -->
+    </component>
+    <inventory-item uuid="11111111-2222-4000-8000-011000000004">
+      <!-- <link rel="baseline-configuration-name" href="#11111111-2222-4000-8000-001000000005"/> Missing baseline-configuration-name href. -->
+      <implemented-component component-uuid="11111111-2222-4000-8000-009000500006"/>
+    </inventory-item>
+  </system-implementation>
+  <back-matter>
+    <resource uuid="11111111-2222-4000-8000-001000000005">
+    </resource>
+  </back-matter>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -742,10 +742,16 @@
         <metapath target="/system-security-plan/system-implementation/component"/>
         <constraints>
             <let var="interconnection-component-used-by-href" expression=".[@type=('interconnection', 'connection')]/link[@rel='used-by']/@href"/>
+            <let var="component-baseline-configuration-name-href" expression="substring-after(link[@rel='baseline-configuration-name']/@href,'#')"/>
             <expect id="component-has-authenticated-scan" target=".[@type='service' and prop[@name='implementation-point' and @value='internal']]" test="count(prop[@name='allows-authenticated-scan']) = 1" level="ERROR">
                 <formal-name>Component Has Authenticated Scan</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each internal service component MUST state whether it allows authenticated scans.</message>
+            </expect>
+            <expect id="component-has-baseline-link" target=".[(@type='service' and prop[@name='implementation-point' and @value='internal']) or @type=('software', 'hardware')]" test="count(../../back-matter/resource[@uuid=$component-baseline-configuration-name-href]) >= 1" level="ERROR">
+                <formal-name>Component Has Baseline Link</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each internal component and component of type "software", or "hardware" MUST have a baseline configuration link that links to the appropriate baseline resource.</message>
             </expect>
             <expect id="interconnection-component-linked-has-protocol" target=".[@type=('interconnection', 'connection')]" test="some $href in $interconnection-component-used-by-href satisfies count(../component[@uuid=substring-after($href,'#')]/protocol) >= 1" level="ERROR">
                 <formal-name>Linked Interconnection Component Has Protocol</formal-name>
@@ -760,9 +766,10 @@
         <constraints>
             <let var="high-sensitivity" expression="../../system-characteristics/security-sensitivity-level='fips-199-high'"/>
             <let var="moderate-sensitivity" expression="../../system-characteristics/security-sensitivity-level='fips-199-moderate'"/>
-
             <let var ="inventory-component-uuid" expression="implemented-component/@component-uuid"/>
             <let var ="implemented-component" expression="../component[@uuid=$inventory-component-uuid]"/>
+            <let var="inventory-item-baseline-configuration-name-href" expression="substring-after(link[@rel='baseline-configuration-name']/@href,'#')"/>
+            <let var="linked-component-baseline-configuration-name-href" expression="substring-after(../component[@uuid=$inventory-component-uuid]/link[@rel='baseline-configuration-name']/@href,'#')"/>
             <expect id="authenticated-scan-no-has-remarks" target="prop[@name='allows-authenticated-scan' and @value='no']" test="if ($high-sensitivity or $moderate-sensitivity) then exists(remarks) else true()" level="ERROR">
                 <formal-name>Authenticated Scan No Has Remarks</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
@@ -782,6 +789,11 @@
                 <formal-name>Inventory Item Has Authenticated Scan</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each inventory item MUST state whether it allows authenticated scans in the inventory item itself or within the linked component.</message>
+            </expect>
+            <expect id="inventory-item-has-baseline-link" target="." test="count(../../back-matter/resource[@uuid=$inventory-item-baseline-configuration-name-href]) >= 1 or count(../../back-matter/resource[@uuid=$linked-component-baseline-configuration-name-href]) >= 1" level="ERROR">
+                <formal-name>Inventory Item Has Baseline Link</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
+                <message>In a FedRAMP SSP, each inventory item or its linked component MUST have a baseline configuration link that links to the appropriate baseline resource.</message>
             </expect>
             <expect id="inventory-item-has-diagram-label" target="." test="count(prop[@name='diagram-label' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count(../component[@uuid=$inventory-component-uuid]/prop[@name='diagram-label' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
                 <formal-name>Inventory Item Has Diagram Label</formal-name>
@@ -808,7 +820,7 @@
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each inventory item that has a MAC address MUST format the MAC address correctly.</message>
             </expect>
-            <expect id="inventory-item-has-vendor-name" target=".[../component[@uuid=$inventory-component-uuid and @type=('hardware','software')]]" test="count(prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count(../component[@uuid=$by-component-uuid]/prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
+            <expect id="inventory-item-has-vendor-name" target=".[../component[@uuid=$inventory-component-uuid and @type=('hardware','software')]]" test="count(prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1 or count(../component[@uuid=$inventory-component-uuid]/prop[@name='vendor-name' and @ns='http://fedramp.gov/ns/oscal']) >= 1" level="ERROR">
                 <formal-name>Inventory Item Has Vendor Name</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/5-attachments/#system-inventory-approach"/>
                 <message>In a FedRAMP SSP, each inventory item MUST include the vendor name in the inventory item itself or within the linked component.</message>

--- a/src/validations/constraints/unit-tests/component-has-baseline-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/component-has-baseline-link-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for component-has-baseline-link
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-baseline-link
+  content: ../content/ssp-component-has-baseline-link-INVALID.xml
+  expectations:
+    - constraint-id: component-has-baseline-link
+      result: fail

--- a/src/validations/constraints/unit-tests/component-has-baseline-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/component-has-baseline-link-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for component-has-baseline-link
+  description: >-
+    This test case validates the behavior of constraint
+    component-has-baseline-link
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: component-has-baseline-link
+      result: pass

--- a/src/validations/constraints/unit-tests/inventory-item-has-baseline-link-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-baseline-link-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for inventory-item-has-baseline-link
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-baseline-link
+  content: ../content/ssp-inventory-item-has-baseline-link-INVALID.xml
+  expectations:
+    - constraint-id: inventory-item-has-baseline-link
+      result: fail

--- a/src/validations/constraints/unit-tests/inventory-item-has-baseline-link-PASS.yaml
+++ b/src/validations/constraints/unit-tests/inventory-item-has-baseline-link-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for inventory-item-has-baseline-link
+  description: >-
+    This test case validates the behavior of constraint
+    inventory-item-has-baseline-link
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: inventory-item-has-baseline-link
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the constraints from #1033 that focus on ensuring that a component of type "software", "hardware", or "service" and/or inventory-item have an "attachment" link to the appropriate baseline and "Internal" components, and components of type "software" or "hardware" have an "attachment" link to the appropriate baseline.

## Changes
- Added `component-has-baseline-link` and `inventory-item-has-baseline-link` constraints.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
