### PR TITLE
use different cert uri

### DIFF
--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -1717,7 +1717,7 @@ compliance (e.g., Module in Process).</p>
       <prop name="validation-type" value="fips-140-2"/>
       <!-- Provide the certificate number (CMVP #) -->
       <prop name="validation-reference" value="4811"/>
-      <link rel="validation-details" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4811"/>
+      <link rel="validation-details" href="https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/certificates/September%202024_011024_0217.pdf"/>
       <status state="operational"/>
     </component>
     <!-- List all cryptographic modules for Data-in-Transit (DIT) - must referenced by using component(s), provide CMVP #, FIPS validation status, Vendor Name, Module Name, and brief usage description -->
@@ -1736,7 +1736,7 @@ compliance (e.g., Module in Process).</p>
       <prop name="validation-type" value="fips-140-3"/>
       <!-- Provide the certificate number (CMVP #) -->
       <prop name="validation-reference" value="4811"/>
-      <link rel="validation-details" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4811"/>
+      <link rel="validation-details" href="https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/certificates/September%202024_011024_0217.pdf"/>
       <status state="operational"/>
     </component>
 


### PR DESCRIPTION
# Committer Notes

use a URI that passes doc-available

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [ ] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
