### PR TITLE
Add POAM Constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -174,6 +174,9 @@ Examples:
   | network-component-has-implementation-point |
   | non-provider-responsible-role-references-user |
   | party-has-name |
+  | poam-item-has-scheduled-completion-date |
+  | poam-item-has-status-date |
+  | poam-item-has-vendor-checkin-date |
   | privilege-level |
   | prop-response-point-has-cardinality-one |
   | resource-has-base64-or-rlink |
@@ -191,9 +194,11 @@ Examples:
   | saas-has-leveraged-authorization |
   | scan-type |
   | scan-type-has-remarks |
+  | scheduled-completion-date-type |
   | security-level |
   | security-sensitivity-level-matches-security-impact-level |
   | statement-has-this-system-component |
+  | status-date-type |
   | unique-inventory-item-asset-id |
   | used-by-link-references-component |
   | user-authentication |
@@ -204,6 +209,7 @@ Examples:
   | user-sensitivity-level |
   | user-type |
   | validation-reference-has-correct-format |
+  | vendor-dependency |
 #END_DYNAMIC_CONSTRAINT_IDS
 
 @constraints
@@ -519,6 +525,12 @@ Examples:
   | non-provider-responsible-role-references-user-PASS.yaml |
   | party-has-name-FAIL.yaml |
   | party-has-name-PASS.yaml |
+  | poam-item-has-scheduled-completion-date-FAIL.yaml |
+  | poam-item-has-scheduled-completion-date-PASS.yaml |
+  | poam-item-has-status-date-FAIL.yaml |
+  | poam-item-has-status-date-PASS.yaml |
+  | poam-item-has-vendor-checkin-date-FAIL.yaml |
+  | poam-item-has-vendor-checkin-date-PASS.yaml |
   | privilege-level-FAIL.yaml |
   | privilege-level-PASS.yaml |
   | resource-has-base64-or-rlink-FAIL.yaml |
@@ -553,12 +565,16 @@ Examples:
   | scan-type-PASS.yaml |
   | scan-type-has-remarks-FAIL.yaml |
   | scan-type-has-remarks-PASS.yaml |
+  | scheduled-completion-date-type-FAIL.yaml |
+  | scheduled-completion-date-type-PASS.yaml |
   | security-level-FAIL.yaml |
   | security-level-PASS.yaml |
   | security-sensitivity-level-matches-security-impact-level-FAIL.yaml |
   | security-sensitivity-level-matches-security-impact-level-PASS.yaml |
   | statement-has-this-system-component-FAIL.yaml |
   | statement-has-this-system-component-PASS.yaml |
+  | status-date-type-FAIL.yaml |
+  | status-date-type-PASS.yaml |
   | unique-inventory-item-asset-id-FAIL.yaml |
   | unique-inventory-item-asset-id-PASS.yaml |
   | used-by-link-references-component-FAIL.yaml |
@@ -579,6 +595,8 @@ Examples:
   | user-type-PASS.yaml |
   | validation-reference-has-correct-format-FAIL.yaml |
   | validation-reference-has-correct-format-PASS.yaml |
+  | vendor-dependency-FAIL.yaml |
+  | vendor-dependency-PASS.yaml |
 #END_DYNAMIC_TEST_CASES
 
 @style-guide

--- a/src/content/awesome-cloud/xml/AwesomeCloudPOAM.xml
+++ b/src/content/awesome-cloud/xml/AwesomeCloudPOAM.xml
@@ -217,7 +217,9 @@
         <title>Asset Inventory Out of Date</title>
         <description>
             <h1>AwesomeCloud asset inventory is out of date.</h1>
-        </description>    
+        </description>
+        <prop name="status-date" ns="http://fedramp.gov/ns/oscal" value="2023-01-01+00:00"/>
+        <prop name="scheduled-completion-date" ns="http://fedramp.gov/ns/oscal" value="2023-05-01+00:00"/>    
         <related-observation observation-uuid="727fd8c7-8bb6-4e2d-add2-0cd32b022d17"/>
         <associated-risk risk-uuid="0683df1e-880b-469c-a146-2bd8a25019dd"/>
     </poam-item>
@@ -225,7 +227,9 @@
         <title>SSL Certificate Expiry</title>
         <description>
             <h1>AwesomeCloud is utilize an expired SSL certificate</h1>
-        </description>        
+        </description>
+        <prop name="status-date" ns="http://fedramp.gov/ns/oscal" value="2023-01-01+00:00"/>
+        <prop name="scheduled-completion-date" ns="http://fedramp.gov/ns/oscal" value="2023-05-01+00:00"/>          
         <related-observation observation-uuid="c6d956e2-e6fa-412a-8143-dbc85d56713e"/>
         <associated-risk risk-uuid="5811184c-af7c-46fa-aaef-c9eef1a043ac"/>
     </poam-item>
@@ -233,7 +237,9 @@
         <title>Ethernet Driver Information Disclosure</title>
         <description>
             <h1>Vulnerabilty Ehternet Driver</h1>
-        </description>        
+        </description>
+        <prop name="status-date" ns="http://fedramp.gov/ns/oscal" value="2023-01-01+00:00"/>  
+        <prop name="scheduled-completion-date" ns="http://fedramp.gov/ns/oscal" value="2023-05-01+00:00"/>       
         <related-observation observation-uuid="5904569a-6efc-4842-ae7c-69199ed7c2bd"/>
         <associated-risk risk-uuid="2eb9e124-1997-4806-8a39-50903bce2c94"/>
     </poam-item>
@@ -241,7 +247,9 @@
         <title>Weak hash algorithm of the SSL certificate</title>
         <description>
             <h1>Weak hashing algorithims are utilized</h1>
-        </description>        
+        </description>
+        <prop name="status-date" ns="http://fedramp.gov/ns/oscal" value="2023-01-01+00:00"/> 
+        <prop name="scheduled-completion-date" ns="http://fedramp.gov/ns/oscal" value="2023-05-01+00:00"/>         
         <related-observation observation-uuid="82a52a6f-cd50-47ba-837a-fefd455da4e8"/>
         <associated-risk risk-uuid="2a59c148-5c5d-4905-852c-fe5ac19850aa"/>
     </poam-item>
@@ -249,7 +257,9 @@
         <title>SMB Signing Enforcement</title>
         <description>
             <h1>SMB Sigining is not enforced</h1>
-        </description>        
+        </description>
+        <prop name="status-date" ns="http://fedramp.gov/ns/oscal" value="2023-01-01+00:00"/> 
+        <prop name="scheduled-completion-date" ns="http://fedramp.gov/ns/oscal" value="2023-05-01+00:00"/>         
         <related-observation observation-uuid="7f9cb6de-5c98-4c2b-a433-4759c034f7a0"/>
         <associated-risk risk-uuid="df607526-c3b5-4891-857f-e6f2956b7410"/>
     </poam-item>
@@ -257,7 +267,9 @@
         <title>RSA Keys Less Than 2048 Bits</title>
         <description>
             <h1>Certificate key length does not meet industry standards.</h1>
-        </description>        
+        </description>
+        <prop name="status-date" ns="http://fedramp.gov/ns/oscal" value="2023-01-01+00:00"/> 
+        <prop name="scheduled-completion-date" ns="http://fedramp.gov/ns/oscal" value="2023-05-01+00:00"/>         
         <related-observation observation-uuid="0f8ae9c9-3355-4d47-bbd2-e4b4cba484d1"/>
         <associated-risk risk-uuid="f4520307-1f24-4843-999c-ca778bf4c320"/>
     </poam-item>
@@ -265,7 +277,9 @@
         <title>TLS Version 1.0 Protocol</title>
         <description>
             <h1>AwesomeCloud employs a week version of TLS</h1>
-        </description>        
+        </description>
+        <prop name="status-date" ns="http://fedramp.gov/ns/oscal" value="2023-01-01+00:00"/> 
+        <prop name="scheduled-completion-date" ns="http://fedramp.gov/ns/oscal" value="2023-05-01+00:00"/>         
         <related-observation observation-uuid="ddec6e55-d009-4491-bd95-f0077957f51b"/>
         <associated-risk risk-uuid="6b595947-145b-4fbe-9f84-0645a076c859"/>
     </poam-item>
@@ -273,7 +287,11 @@
         <title>AwesomeCloud Access Control Procedures Out Of Date</title>
         <description>
             <h1>AwesomeCloud has not update its access control procedures in accordance with defined policy.</h1>
-        </description>        
+        </description>
+        <prop name="status-date" ns="http://fedramp.gov/ns/oscal" value="2023-01-01+00:00"/>    
+        <prop name="scheduled-completion-date" ns="http://fedramp.gov/ns/oscal" value="2023-05-01+00:00"/>  
+        <prop name="has-vendor-dependency" ns="http://fedramp.gov/ns/oscal" value="yes"/> 
+        <prop name="vendor-checkin-date" ns="http://fedramp.gov/ns/oscal" value="2023-06-01+00:00"/>     
         <related-observation observation-uuid="58e34e49-32bb-4c63-b9e6-158a0620fcd5"/>
         <associated-risk risk-uuid="56aff720-e21a-4def-8ea6-e91388c1d96f"/>
     </poam-item>

--- a/src/scripts/dev-constraint.js
+++ b/src/scripts/dev-constraint.js
@@ -148,9 +148,10 @@ async function scaffoldTest(constraintId,context) {
 
     const { model } = await prompt([
         {
-            type: 'string',
+            type: 'list',
             name: 'model',
             message: `What is the constraint targeting?`,
+            choices: ["ssp", "poam"],
             default: "ssp"
         }
     ]);
@@ -172,7 +173,7 @@ async function scaffoldTest(constraintId,context) {
 
     let invalidContent;
     if (useTemplate === 'new') {
-        const templatePath = model === 'ssp' ? path.join(__dirname, '..', '..', 'src', 'content', 'rev5', 'examples', 'ssp/xml', 'fedramp-ssp-example.oscal.xml') : path.join(__dirname, '..', '..', 'src', 'validations', 'constraints', 'content', `${model}-all-VALID.xml`);
+        const templatePath = model === 'ssp' ? path.join(__dirname, '..', '..', 'src', 'content', 'rev5', 'examples', 'ssp/xml', 'fedramp-ssp-example.oscal.xml') : path.join(__dirname, '..', '..', 'src', 'content', 'awesome-cloud', 'xml', 'AwesomeCloudPOAM.xml');
         const newInvalidPath = path.join(__dirname, '..', '..', 'src', 'validations', 'constraints', 'content', `${model}-${constraintId}-INVALID.xml`);
         
         try {
@@ -300,7 +301,7 @@ async function scaffoldTest(constraintId,context) {
         'test-case': {
             name: `Positive Test for ${constraintId}`,
             description: `This test case validates the behavior of constraint ${constraintId}`,
-            content: model === 'ssp' ? '../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml' : `../content/${model}-all-VALID.xml`,
+            content: model === 'ssp' ? '../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml' : `../../../content/awesome-cloud/xml/AwesomeCloudPOAM.xml`,
             expectations: [
                 {
                     'constraint-id': constraintId,

--- a/src/validations/constraints/content/poam-poam-item-has-scheduled-completion-date-INVALID.xml
+++ b/src/validations/constraints/content/poam-poam-item-has-scheduled-completion-date-INVALID.xml
@@ -1,0 +1,5 @@
+<plan-of-action-and-milestones xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="5f7afa40-3d9d-475b-9e34-47a768371be3">
+  <poam-item uuid="a908cb44-446a-450d-970d-73c968fd5389">
+    <!-- <prop name="scheduled-completion-date" ns="http://fedramp.gov/ns/oscal" value="2023-01-01+00:00"/> Missing "scheduled-completion-date" prop. -->
+  </poam-item>
+</plan-of-action-and-milestones>

--- a/src/validations/constraints/content/poam-poam-item-has-status-date-INVALID.xml
+++ b/src/validations/constraints/content/poam-poam-item-has-status-date-INVALID.xml
@@ -1,0 +1,5 @@
+<plan-of-action-and-milestones xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="5f7afa40-3d9d-475b-9e34-47a768371be3">
+  <poam-item uuid="a908cb44-446a-450d-970d-73c968fd5389">
+    <!-- <prop name="status-date" ns="http://fedramp.gov/ns/oscal" value="2023-01-01+00:00"/> Missing "status-date" prop. -->
+  </poam-item>
+</plan-of-action-and-milestones>

--- a/src/validations/constraints/content/poam-poam-item-has-vendor-checkin-date-INVALID.xml
+++ b/src/validations/constraints/content/poam-poam-item-has-vendor-checkin-date-INVALID.xml
@@ -1,0 +1,8 @@
+<plan-of-action-and-milestones xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="5f7afa40-3d9d-475b-9e34-47a768371be3">
+  <poam-item uuid="9f07e816-388f-4096-b625-58bd462f748d">
+        <prop name="has-vendor-dependency" ns="http://fedramp.gov/ns/oscal" value="yes"/>
+        <!-- <prop name="vendor-checkin-date" ns="http://fedramp.gov/ns/oscal" value="2023-06-01+00:00"/> Missing "vendor-checkin-date" prop. -->
+        <related-observation observation-uuid="58e34e49-32bb-4c63-b9e6-158a0620fcd5"/>
+        <associated-risk risk-uuid="56aff720-e21a-4def-8ea6-e91388c1d96f"/>
+    </poam-item>
+</plan-of-action-and-milestones>

--- a/src/validations/constraints/content/poam-scheduled-completion-date-type-INVALID.xml
+++ b/src/validations/constraints/content/poam-scheduled-completion-date-type-INVALID.xml
@@ -1,0 +1,6 @@
+<plan-of-action-and-milestones xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="5f7afa40-3d9d-475b-9e34-47a768371be3">
+  <poam-item uuid="a908cb44-446a-450d-970d-73c968fd5389">
+    <!-- Invalid format for "scheduled-completion-date" prop. -->
+    <prop name="scheduled-completion-date" ns="http://fedramp.gov/ns/oscal" value="Invalid"/> 
+  </poam-item>
+</plan-of-action-and-milestones>

--- a/src/validations/constraints/content/poam-status-date-type-INVALID.xml
+++ b/src/validations/constraints/content/poam-status-date-type-INVALID.xml
@@ -1,0 +1,6 @@
+<plan-of-action-and-milestones xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="5f7afa40-3d9d-475b-9e34-47a768371be3">
+  <poam-item uuid="a908cb44-446a-450d-970d-73c968fd5389">
+    <!-- Invalid format for "status date" prop. -->
+    <prop name="status-date" ns="http://fedramp.gov/ns/oscal" value="Invalid"/>
+  </poam-item>
+</plan-of-action-and-milestones>

--- a/src/validations/constraints/content/poam-vendor-dependency-INVALID.xml
+++ b/src/validations/constraints/content/poam-vendor-dependency-INVALID.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plan-of-action-and-milestones
+    xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+    uuid="5f7afa40-3d9d-475b-9e34-47a768371be3">
+    <poam-item uuid="9f07e816-388f-4096-b625-58bd462f748d">
+        <!-- Invalid value for "has-vendor-dependency" prop. -->
+        <prop name="has-vendor-dependency" ns="http://fedramp.gov/ns/oscal" value="invalid"/>      
+    </poam-item>
+</plan-of-action-and-milestones>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -659,6 +659,14 @@
                 <enum value="privileged">Privileged</enum>
             </allowed-values>
 
+            <allowed-values id="vendor-dependency" target="poam-item/prop[@ns='http://fedramp.gov/ns/oscal' and @name='has-vendor-dependency']/@value" allow-other="no" level="ERROR">
+                <formal-name>Vendor Dependency</formal-name>
+                <description>Identifies if vendor dependency is indicated.</description>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
+                <enum value="yes">Yes</enum>
+                <enum value="no">No</enum>
+            </allowed-values>
+
         </constraints>
     </context>
 

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -214,27 +214,33 @@
             <expect id="poam-item-has-scheduled-completion-date" target="." test="count(prop[@ns='http://fedramp.gov/ns/oscal' and @name='scheduled-completion-date']) = 1" level="ERROR">
                 <formal-name>POAM Item Has Scheduled Completion Date</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
-                <message>A POAM item MUST have a scheduled completion date.</message>
+                <message>A FedRAMP POAM MUST include a scheduled completion date for each POAM item.</message>
             </expect>
             <expect id="poam-item-has-status-date" target="." test="count(prop[@ns='http://fedramp.gov/ns/oscal' and @name='status-date']) = 1" level="ERROR">
                 <formal-name>POAM Item Has Status Date</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
-                <message>A POAM item MUST have a status date.</message>
+                <message>A FedRAMP POAM MUST include a status date for each POAM item.</message>
             </expect>
             <expect id="poam-item-has-vendor-checkin-date" target=".[prop[@ns='http://fedramp.gov/ns/oscal' and @name='has-vendor-dependency' and @value='yes']]" test="count(prop[@ns='http://fedramp.gov/ns/oscal' and @name='vendor-checkin-date']) = 1" level="ERROR">
                 <formal-name>POAM Item Has Vendor Check-in Date</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
-                <message>A POAM item MUST have a vendor check-in date if it is vendor dependent.</message>
+                <message>A FedRAMP POAM MUST include a vendor check-in date for each POAM item if it is vendor dependent.</message>
             </expect>
             <matches id="scheduled-completion-date-type" target="prop[@ns='http://fedramp.gov/ns/oscal' and @name='scheduled-completion-date']/@value" datatype="date-with-timezone" level="ERROR">
                 <formal-name>Scheduled Completion Date Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
-                <message>A POAM item MUST specify the scheduled completion date as a "full-date" per RFC3339 with the addition of a timezone.</message>
+                <message>A FedRAMP POAM MUST specify a scheduled completion date in a valid format for each POAM item.</message>
+                <remarks>
+                    <p>The scheduled completion date MUST be formatted as a "full-date" per RFC3339 with the addition of a timezone.</p>
+                </remarks>
             </matches>
             <matches id="status-date-type" target="prop[@ns='http://fedramp.gov/ns/oscal' and @name='status-date']/@value" datatype="date-with-timezone" level="ERROR">
                 <formal-name>Status Date Type</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
-                <message>A POAM item MUST specify the status date as a "full-date" per RFC3339 with the addition of a timezone.</message>
+                <message>A FedRAMP POAM MUST specify a status date in a valid format for each POAM item.</message>
+                <remarks>
+                    <p>The scheduled completion date MUST be formatted as a "full-date" per RFC3339 with the addition of a timezone.</p>
+                </remarks>
             </matches>
         </constraints>
     </context>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -209,6 +209,37 @@
     </context>
 
     <context>
+        <metapath target="/plan-of-action-and-milestones/poam-item"/>
+        <constraints>
+            <expect id="poam-item-has-scheduled-completion-date" target="." test="count(prop[@ns='http://fedramp.gov/ns/oscal' and @name='scheduled-completion-date']) = 1" level="ERROR">
+                <formal-name>POAM Item Has Scheduled Completion Date</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
+                <message>A POAM item MUST have a scheduled completion date.</message>
+            </expect>
+            <expect id="poam-item-has-status-date" target="." test="count(prop[@ns='http://fedramp.gov/ns/oscal' and @name='status-date']) = 1" level="ERROR">
+                <formal-name>POAM Item Has Status Date</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
+                <message>A POAM item MUST have a status date.</message>
+            </expect>
+            <expect id="poam-item-has-vendor-checkin-date" target=".[prop[@ns='http://fedramp.gov/ns/oscal' and @name='has-vendor-dependency' and @value='yes']]" test="count(prop[@ns='http://fedramp.gov/ns/oscal' and @name='vendor-checkin-date']) = 1" level="ERROR">
+                <formal-name>POAM Item Has Vendor Check-in Date</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
+                <message>A POAM item MUST have a vendor check-in date if it is vendor dependent.</message>
+            </expect>
+            <matches id="scheduled-completion-date-type" target="prop[@ns='http://fedramp.gov/ns/oscal' and @name='scheduled-completion-date']/@value" datatype="date-with-timezone" level="ERROR">
+                <formal-name>Scheduled Completion Date Type</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
+                <message>A POAM item MUST specify the scheduled completion date as a "full-date" per RFC3339 with the addition of a timezone.</message>
+            </matches>
+            <matches id="status-date-type" target="prop[@ns='http://fedramp.gov/ns/oscal' and @name='status-date']/@value" datatype="date-with-timezone" level="ERROR">
+                <formal-name>Status Date Type</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/poam/4-poam-template-to-oscal-mapping/"/>
+                <message>A POAM item MUST specify the status date as a "full-date" per RFC3339 with the addition of a timezone.</message>
+            </matches>
+        </constraints>
+    </context>
+
+    <context>
         <metapath target="/system-security-plan/back-matter"/>
         <constraints>
             <expect id="fedramp-citations-has-correct-link" target="resource[prop[@name='type' and @value='citation' and @class='fedramp-citations']]" test="count(rlink[@href = 'https://www.fedramp.gov/assets/resources/templates/FedRAMP-Laws-Regulations-Standards-and-Guidance-Reference.xlsx']) eq 1" level="ERROR">

--- a/src/validations/constraints/unit-tests/poam-item-has-scheduled-completion-date-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/poam-item-has-scheduled-completion-date-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for poam-item-has-scheduled-completion-date
+  description: >-
+    This test case validates the behavior of constraint
+    poam-item-has-scheduled-completion-date
+  content: ../content/poam-poam-item-has-scheduled-completion-date-INVALID.xml
+  expectations:
+    - constraint-id: poam-item-has-scheduled-completion-date
+      result: fail

--- a/src/validations/constraints/unit-tests/poam-item-has-scheduled-completion-date-PASS.yaml
+++ b/src/validations/constraints/unit-tests/poam-item-has-scheduled-completion-date-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for poam-item-has-scheduled-completion-date
+  description: >-
+    This test case validates the behavior of constraint
+    poam-item-has-scheduled-completion-date
+  content: ../../../content/awesome-cloud/xml/AwesomeCloudPOAM.xml
+  expectations:
+    - constraint-id: poam-item-has-scheduled-completion-date
+      result: pass

--- a/src/validations/constraints/unit-tests/poam-item-has-status-date-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/poam-item-has-status-date-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for poam-item-has-status-date
+  description: >-
+    This test case validates the behavior of constraint
+    poam-item-has-status-date
+  content: ../content/poam-poam-item-has-status-date-INVALID.xml
+  expectations:
+    - constraint-id: poam-item-has-status-date
+      result: fail

--- a/src/validations/constraints/unit-tests/poam-item-has-status-date-PASS.yaml
+++ b/src/validations/constraints/unit-tests/poam-item-has-status-date-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for poam-item-has-status-date
+  description: >-
+    This test case validates the behavior of constraint
+    poam-item-has-status-date
+  content: ../../../content/awesome-cloud/xml/AwesomeCloudPOAM.xml
+  expectations:
+    - constraint-id: poam-item-has-status-date
+      result: pass

--- a/src/validations/constraints/unit-tests/poam-item-has-vendor-checkin-date-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/poam-item-has-vendor-checkin-date-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for poam-item-has-vendor-checkin-date
+  description: >-
+    This test case validates the behavior of constraint
+    poam-item-has-vendor-checkin-date
+  content: ../content/poam-poam-item-has-vendor-checkin-date-INVALID.xml
+  expectations:
+    - constraint-id: poam-item-has-vendor-checkin-date
+      result: fail

--- a/src/validations/constraints/unit-tests/poam-item-has-vendor-checkin-date-PASS.yaml
+++ b/src/validations/constraints/unit-tests/poam-item-has-vendor-checkin-date-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for poam-item-has-vendor-checkin-date
+  description: >-
+    This test case validates the behavior of constraint
+    poam-item-has-vendor-checkin-date
+  content: ../../../content/awesome-cloud/xml/AwesomeCloudPOAM.xml
+  expectations:
+    - constraint-id: poam-item-has-vendor-checkin-date
+      result: pass

--- a/src/validations/constraints/unit-tests/scheduled-completion-date-type-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/scheduled-completion-date-type-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for scheduled-completion-date-type
+  description: >-
+    This test case validates the behavior of constraint
+    scheduled-completion-date-type
+  content: ../content/poam-scheduled-completion-date-type-INVALID.xml
+  expectations:
+    - constraint-id: scheduled-completion-date-type
+      result: fail

--- a/src/validations/constraints/unit-tests/scheduled-completion-date-type-PASS.yaml
+++ b/src/validations/constraints/unit-tests/scheduled-completion-date-type-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for scheduled-completion-date-type
+  description: >-
+    This test case validates the behavior of constraint
+    scheduled-completion-date-type
+  content: ../../../content/awesome-cloud/xml/AwesomeCloudPOAM.xml
+  expectations:
+    - constraint-id: scheduled-completion-date-type
+      result: pass

--- a/src/validations/constraints/unit-tests/status-date-type-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/status-date-type-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for status-date-type
+  description: This test case validates the behavior of constraint status-date-type
+  content: ../content/poam-status-date-type-INVALID.xml
+  expectations:
+    - constraint-id: status-date-type
+      result: fail

--- a/src/validations/constraints/unit-tests/status-date-type-PASS.yaml
+++ b/src/validations/constraints/unit-tests/status-date-type-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for status-date-type
+  description: This test case validates the behavior of constraint status-date-type
+  content: ../../../content/awesome-cloud/xml/AwesomeCloudPOAM.xml
+  expectations:
+    - constraint-id: status-date-type
+      result: pass

--- a/src/validations/constraints/unit-tests/vendor-dependency-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/vendor-dependency-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for vendor-dependency
+  description: This test case validates the behavior of constraint vendor-dependency
+  content: ../content/poam-vendor-dependency-INVALID.xml
+  expectations:
+    - constraint-id: vendor-dependency
+      result: fail

--- a/src/validations/constraints/unit-tests/vendor-dependency-PASS.yaml
+++ b/src/validations/constraints/unit-tests/vendor-dependency-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for vendor-dependency
+  description: This test case validates the behavior of constraint vendor-dependency
+  content: ../../../content/awesome-cloud/xml/AwesomeCloudPOAM.xml
+  expectations:
+    - constraint-id: vendor-dependency
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add 6 new POAM constraints per issue #1176.

## Changes
Modified dev script to handle poam model test scaffolding. 
Added Constraints:
- `poam-item-has-scheduled-completion-date`
- `poam-item-has-status-date`
- `poam-item-has-vendor-checkin-date`
- `scheduled-completion-date-type`
- `status-date-type`
- `vendor-dependency`

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
