### PR TITLE
Add `Issue 1195` Constraints

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -167,6 +167,10 @@ Examples:
   | leveraged-authorization-has-system-identifier |
   | leveraged-authorization-has-valid-impact-level |
   | leveraged-authorization-nature-of-agreement |
+  | li-saas-has-saas-cloud-service-model |
+  | li-saas-has-valid-impact-levels |
+  | li-saas-has-valid-sensitivity-level |
+  | li-saas-imports-li-saas-profile |
   | marking |
   | misplaced-response-components |
   | missing-response-components |
@@ -505,6 +509,14 @@ Examples:
   | leveraged-authorization-has-valid-impact-level-PASS.yaml |
   | leveraged-authorization-nature-of-agreement-FAIL.yaml |
   | leveraged-authorization-nature-of-agreement-PASS.yaml |
+  | li-saas-has-saas-cloud-service-model-FAIL.yaml |
+  | li-saas-has-saas-cloud-service-model-PASS.yaml |
+  | li-saas-has-valid-impact-levels-FAIL.yaml |
+  | li-saas-has-valid-impact-levels-PASS.yaml |
+  | li-saas-has-valid-sensitivity-level-FAIL.yaml |
+  | li-saas-has-valid-sensitivity-level-PASS.yaml |
+  | li-saas-imports-li-saas-profile-FAIL.yaml |
+  | li-saas-imports-li-saas-profile-PASS.yaml |
   | marking-FAIL.yaml |
   | marking-PASS.yaml |
   | misplaced-response-components-FAIL.yaml |

--- a/features/steps/fedramp_extensions_steps.ts
+++ b/features/steps/fedramp_extensions_steps.ts
@@ -248,7 +248,7 @@ async function processTestCase({ "test-case": testCase }: any) {
       sarifResponse = validationCache.get(cacheKey)!;
     }else{
       let flags = [];
-      if(currentTestCaseFileName.includes("FAIL")){
+      if(currentTestCaseFileName.includes("FAIL") || currentTestCase['test-case'].content === '../../../content/rev5/examples/ssp/xml/fedramp-ssp-li-saas-example.xml'){
         flags.push("disable-schema")
       }
     const {isValid,log} = await validateDocument(resolve(processedContentPath),{quiet,

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-li-saas-example.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-li-saas-example.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+    <metadata>
+    </metadata>
+
+    <import-profile href="../../../baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml"/>
+
+    <system-characteristics>
+        <prop name="cloud-service-model" value="saas">
+            <remarks>
+                <p>Remarks are required if service model is "other". Optional otherwise.</p>
+            </remarks>
+        </prop>
+        <prop ns="http://fedramp.gov/ns/oscal" name="authorization-type" value="fedramp-li-saas"/>
+        <security-sensitivity-level>fips-199-low</security-sensitivity-level>
+        <security-impact-level>
+            <security-objective-confidentiality>fips-199-low</security-objective-confidentiality>
+            <security-objective-integrity>fips-199-low</security-objective-integrity>
+            <security-objective-availability>fips-199-low</security-objective-availability>
+        </security-impact-level>
+    </system-characteristics>
+
+    <system-implementation>
+    </system-implementation>
+
+    <control-implementation>
+    </control-implementation>
+
+    <back-matter>
+    </back-matter>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-li-saas-has-saas-cloud-service-model-INVALID.xml
+++ b/src/validations/constraints/content/ssp-li-saas-has-saas-cloud-service-model-INVALID.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+
+  <system-characteristics>
+    <!-- Cloud service model should be "sass". -->
+    <prop name="cloud-service-model" value="not-saas">
+      <remarks>
+        <p>Remarks are required if service model is "other". Optional otherwise.</p>
+      </remarks>
+    </prop>
+    <prop ns="http://fedramp.gov/ns/oscal" name="authorization-type" value="fedramp-li-saas"/>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-li-saas-has-saas-cloud-service-model-INVALID.xml
+++ b/src/validations/constraints/content/ssp-li-saas-has-saas-cloud-service-model-INVALID.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.3/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
 
   <system-characteristics>
     <!-- Cloud service model should be "sass". -->

--- a/src/validations/constraints/content/ssp-li-saas-has-valid-impact-levels-INVALID.xml
+++ b/src/validations/constraints/content/ssp-li-saas-has-valid-impact-levels-INVALID.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+
+  <system-characteristics>
+    <prop ns="http://fedramp.gov/ns/oscal" name="authorization-type" value="fedramp-li-saas"/>
+    <security-impact-level>
+      <!-- The highest security impact should be "fips-199-low". -->
+      <security-objective-confidentiality>fips-199-low</security-objective-confidentiality>
+      <security-objective-integrity>fips-199-high</security-objective-integrity>
+      <security-objective-availability>fips-199-low</security-objective-availability>
+    </security-impact-level>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-li-saas-has-valid-sensitivity-level-INVALID.xml
+++ b/src/validations/constraints/content/ssp-li-saas-has-valid-sensitivity-level-INVALID.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+
+  <system-characteristics>
+    <prop ns="http://fedramp.gov/ns/oscal" name="authorization-type" value="fedramp-li-saas"/>
+    <!-- Security sensitivity level should be "fips-199-low". -->
+    <security-sensitivity-level>fips-199-high</security-sensitivity-level>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-li-saas-imports-li-saas-profile-INVALID.xml
+++ b/src/validations/constraints/content/ssp-li-saas-imports-li-saas-profile-INVALID.xml
@@ -1,0 +1,8 @@
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd" uuid="12345678-1234-4321-8765-123456789012">
+  <!-- Import profile is not an LI-SaaS profile/catalog. -->
+  <import-profile href="../../../../src/content/rev5/baselines/xml/some-invalid-file.invalid"/>
+
+  <system-characteristics>
+    <prop ns="http://fedramp.gov/ns/oscal" name="authorization-type" value="fedramp-li-saas"/>
+  </system-characteristics>
+</system-security-plan>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -106,7 +106,9 @@
                     then ('fips-199-high')
                 else if (//security-impact-level//* = 'fips-199-moderate')
                     then ('fips-199-moderate')
-                else ('fips-199-low')"/>
+                else if (//security-impact-level//* = 'fips-199-low')
+                    then ('fips-199-low')                    
+                else ()"/>
             <let var="non-authorized-components" expression="//component[(@type='system' and prop[@name='leveraged-authorization-uuid']) or (@type=('service', 'software') and not(prop[@name='leveraged-authorization-uuid']) and prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type=('service', 'software') and prop[@name='implementation-point' and @value='internal'] and prop[@name='communicates-externally' and @value='yes' and @ns='http://fedramp.gov/ns/oscal'])]"/>
             <let var="system-implementation-users" expression="system-implementation/user"/>
             <let var="non-provider-user-has-function-performed" expression="count($system-implementation-users[@uuid = $non-authorized-components/responsible-role/prop[@name='privilege-uuid' and @ns='http://fedramp.gov/ns/oscal']/@value]/authorized-privilege/function-performed) >= 1"/>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -101,6 +101,12 @@
                 else if (system-characteristics/security-sensitivity-level = 'fips-199-moderate')
                     then ('fips-199-moderate', 'fips-199-high')
                 else ('fips-199-low', 'fips-199-moderate', 'fips-199-high')"/>
+            <let var="highest-security-impact-level" expression=
+                "if (//security-impact-level//* = 'fips-199-high')
+                    then ('fips-199-high')
+                else if (//security-impact-level//* = 'fips-199-moderate')
+                    then ('fips-199-moderate')
+                else ('fips-199-low')"/>
             <let var="non-authorized-components" expression="//component[(@type='system' and prop[@name='leveraged-authorization-uuid']) or (@type=('service', 'software') and not(prop[@name='leveraged-authorization-uuid']) and prop[@name='implementation-point' and @value='external']) or (@type='interconnection') or (@type=('service', 'software') and prop[@name='implementation-point' and @value='internal'] and prop[@name='communicates-externally' and @value='yes' and @ns='http://fedramp.gov/ns/oscal'])]"/>
             <let var="system-implementation-users" expression="system-implementation/user"/>
             <let var="non-provider-user-has-function-performed" expression="count($system-implementation-users[@uuid = $non-authorized-components/responsible-role/prop[@name='privilege-uuid' and @ns='http://fedramp.gov/ns/oscal']/@value]/authorized-privilege/function-performed) >= 1"/>
@@ -198,6 +204,26 @@
                 <formal-name>Leveraged Authorization Has Valid Impact Level</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/4-ssp-template-to-oscal-mapping/#leveraged-fedramp-authorized-services"/>
                 <message>The FIPS-199 impact level of the leveraged system MUST be the same or higher than the impact level of this system.</message>
+            </expect>
+            <expect id="li-saas-has-saas-cloud-service-model" target=".[system-characteristics/prop[@name='authorization-type' and @value='fedramp-li-saas']]" test="exists(system-characteristics/prop[@name='cloud-service-model' and @value='saas'])" level="ERROR">
+                <formal-name>LI-Saas Has SaaS Cloud Service Model</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/#tbd"/>
+                <message>A FedRAMP SSP MUST set the cloud service model to "saas" if it is an LI-SaaS.</message>
+            </expect>
+            <expect id="li-saas-has-valid-impact-levels" target=".[system-characteristics/prop[@name='authorization-type' and @value='fedramp-li-saas']]" test="$highest-security-impact-level = 'fips-199-low'" level="ERROR">
+                <formal-name>LI-Saas Has Valid Impact Levels</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/#tbd"/>
+                <message>A FedRAMP SSP MUST set the security impact levels to "fips-199-low" if it is an LI-SaaS.</message>
+            </expect>
+            <expect id="li-saas-has-valid-sensitivity-level" target=".[system-characteristics/prop[@name='authorization-type' and @value='fedramp-li-saas']]" test="system-characteristics/security-sensitivity-level = 'fips-199-low'" level="ERROR">
+                <formal-name>LI-Saas Has Valid Sensitivity Level</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/#tbd"/>
+                <message>A FedRAMP SSP MUST set the security sensitivity level to "fips-199-low" if it is an LI-SaaS.</message>
+            </expect>
+            <expect id="li-saas-imports-li-saas-profile" target=".[system-characteristics/prop[@name='authorization-type' and @value='fedramp-li-saas']]" test="exists(resolve-profile(doc(resolve-uri($resolved-import-profile-href)))//control//prop[@ns='http://fedramp.gov/ns/oscal' and @class='FedRAMP-Tailored-LI-SaaS'])" level="CRITICAL">
+                <formal-name>LI-Saas Imports LI-SaaS Profile</formal-name>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/#tbd"/>
+                <message>A FedRAMP SSP MUST import an LI-SaaS profile or catalog if it is an LI-SaaS.</message>
             </expect>
             <expect id="non-provider-responsible-role-references-user" target="." test="$non-provider-user-has-function-performed" level="ERROR">
                 <formal-name>Non-Provider Responsible Role References User</formal-name>

--- a/src/validations/constraints/unit-tests/li-saas-has-saas-cloud-service-model-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/li-saas-has-saas-cloud-service-model-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for li-saas-has-saas-cloud-service-model
+  description: >-
+    This test case validates the behavior of constraint
+    li-saas-has-saas-cloud-service-model
+  content: ../content/ssp-li-saas-has-saas-cloud-service-model-INVALID.xml
+  expectations:
+    - constraint-id: li-saas-has-saas-cloud-service-model
+      result: fail

--- a/src/validations/constraints/unit-tests/li-saas-has-saas-cloud-service-model-PASS.yaml
+++ b/src/validations/constraints/unit-tests/li-saas-has-saas-cloud-service-model-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for li-saas-has-saas-cloud-service-model
+  description: >-
+    This test case validates the behavior of constraint
+    li-saas-has-saas-cloud-service-model
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-li-saas-example.xml
+  expectations:
+    - constraint-id: li-saas-has-saas-cloud-service-model
+      result: pass

--- a/src/validations/constraints/unit-tests/li-saas-has-valid-impact-levels-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/li-saas-has-valid-impact-levels-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for li-saas-has-valid-impact-levels
+  description: >-
+    This test case validates the behavior of constraint
+    li-saas-has-valid-impact-levels
+  content: ../content/ssp-li-saas-has-valid-impact-levels-INVALID.xml
+  expectations:
+    - constraint-id: li-saas-has-valid-impact-levels
+      result: fail

--- a/src/validations/constraints/unit-tests/li-saas-has-valid-impact-levels-PASS.yaml
+++ b/src/validations/constraints/unit-tests/li-saas-has-valid-impact-levels-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for li-saas-has-valid-impact-levels
+  description: >-
+    This test case validates the behavior of constraint
+    li-saas-has-valid-impact-levels
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-li-saas-example.xml
+  expectations:
+    - constraint-id: li-saas-has-valid-impact-levels
+      result: pass

--- a/src/validations/constraints/unit-tests/li-saas-has-valid-sensitivity-level-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/li-saas-has-valid-sensitivity-level-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for li-saas-has-valid-sensitivity-level
+  description: >-
+    This test case validates the behavior of constraint
+    li-saas-has-valid-sensitivity-level
+  content: ../content/ssp-li-saas-has-valid-sensitivity-level-INVALID.xml
+  expectations:
+    - constraint-id: li-saas-has-valid-sensitivity-level
+      result: fail

--- a/src/validations/constraints/unit-tests/li-saas-has-valid-sensitivity-level-PASS.yaml
+++ b/src/validations/constraints/unit-tests/li-saas-has-valid-sensitivity-level-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for li-saas-has-valid-sensitivity-level
+  description: >-
+    This test case validates the behavior of constraint
+    li-saas-has-valid-sensitivity-level
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-li-saas-example.xml
+  expectations:
+    - constraint-id: li-saas-has-valid-sensitivity-level
+      result: pass

--- a/src/validations/constraints/unit-tests/li-saas-imports-li-saas-profile-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/li-saas-imports-li-saas-profile-FAIL.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Negative Test for li-saas-imports-li-saas-profile
+  description: >-
+    This test case validates the behavior of constraint
+    li-saas-imports-li-saas-profile
+  content: ../content/ssp-li-saas-imports-li-saas-profile-INVALID.xml
+  expectations:
+    - constraint-id: li-saas-imports-li-saas-profile
+      result: fail

--- a/src/validations/constraints/unit-tests/li-saas-imports-li-saas-profile-PASS.yaml
+++ b/src/validations/constraints/unit-tests/li-saas-imports-li-saas-profile-PASS.yaml
@@ -1,0 +1,9 @@
+test-case:
+  name: Positive Test for li-saas-imports-li-saas-profile
+  description: >-
+    This test case validates the behavior of constraint
+    li-saas-imports-li-saas-profile
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-li-saas-example.xml
+  expectations:
+    - constraint-id: li-saas-imports-li-saas-profile
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add the `LI SaaS` constraints per #1195. 

## Changes
- Added `LI SaaS` constraints.
- Added barebones `LI SaaS` example SSP.
- Disabled schema validation for constraints targeting the new `LI SaaS` example SSP.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?~ Not applicable.
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
