### PR TITLE
Remove NPM targets for Schematron-based validations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "author": "",
   "license": "CC0-1.0",
   "scripts": {
-    "build:validation-ui": "cd src/web && npm install && npm run build && cd ../..",
-    "federalist": "make init-repo && npm run build:validation-ui && npm run link:validation-ui",
-    "link:validation-ui": "ln -sf ./src/web/dist _site",
     "test": "cross-env-shell NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js",
     "test:server": "cross-env-shell OSCAL_EXECUTOR='oscal-server' NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js",
     "test:parallel": "cross-env-shell NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js  --parallel 4 2>/dev/null 2>NUL",


### PR DESCRIPTION
# Committer Notes

While reviewing and experiment with `dev-constraint.js` changes for #1203, I noticed there are now very obsolete targets for the `npm run ...` commands we no longer need. It is probably time to remove them completely.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?~
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
