### PR TITLE
Add the deprecated message in the `fedramp-jab` enum value

### DIFF
--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -69,7 +69,7 @@
             <allowed-values id="authorization-type" target="system-characteristics/prop[@name='authorization-type'][@ns='http://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
                 <formal-name>Authorization Type</formal-name>
                 <description>The FedRAMP Authorization Type</description>
-                <enum value="fedramp-jab">FedRAMP JAB P-ATO</enum>
+                <enum value="fedramp-jab" deprecated="3.0.0-milestone1">**(deprecated)*** The authorization type of 'fedramp-jab' is deprecated. Use it for pre-existing JAB authorizations only.</enum>
                 <enum value="fedramp-agency">FedRAMP Agency ATO</enum>
                 <enum value="fedramp-li-saas">FedRAMP Tailored for LI-SaaS</enum>
             </allowed-values>


### PR DESCRIPTION
# Committer Notes

In the `fedramp-external-allowed-values.xml` file, add the following **deprecated** message in the `fedramp-jab1` enum value:

`<enum value="fedramp-jab" deprecated="3.0.0-milestone1">**(deprecated)*** The authorization type of 'fedramp-jab' is deprecated. Use it for pre-existing JAB authorizations only.</enum>`

Related issue [#1208](https://github.com/GSA/fedramp-automation/issues/1208).

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
