### PR TITLE
Add Control Origination Allowed Values

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -211,6 +211,7 @@ Examples:
   | frr304 |
   | frr305 |
   | frr306 |
+  | frr307 |
 #END_DYNAMIC_CONSTRAINT_IDS
 
 @constraints
@@ -600,6 +601,8 @@ Examples:
   | frr305-PASS.yaml |
   | frr306-FAIL.yaml |
   | frr306-PASS.yaml |
+  | frr307-FAIL.yaml |
+  | frr307-PASS.yaml |
 #END_DYNAMIC_TEST_CASES
 
 @style-guide

--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -210,6 +210,7 @@ Examples:
   | frr303 |
   | frr304 |
   | frr305 |
+  | frr306 |
 #END_DYNAMIC_CONSTRAINT_IDS
 
 @constraints
@@ -597,6 +598,8 @@ Examples:
   | frr304-PASS.yaml |
   | frr305-FAIL.yaml |
   | frr305-PASS.yaml |
+  | frr306-FAIL.yaml |
+  | frr306-PASS.yaml |
 #END_DYNAMIC_TEST_CASES
 
 @style-guide

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -3202,7 +3202,6 @@
       </statement>
     </implemented-requirement>
     <implemented-requirement control-id="ia-1" uuid="11111111-2222-4000-8000-012000030000">
-      <prop ns="http://fedramp.gov/ns/oscal" name="control-origination" value="sp-system"/>
       <set-parameter param-id="ia-01_odp.08">
         <value>merger or acquisition, change in organizational structure, or update to identity and access management system</value>
       </set-parameter><set-parameter param-id="ia-01_odp.07">
@@ -3249,6 +3248,7 @@
             <p>That component contains a link to the policy, so it does not have to be linked here
               too.</p>
           </description>
+          <prop ns="http://fedramp.gov/ns/oscal" name="control-origination" value="sp-system"/>
           <implementation-status state="implemented"/>
           <responsible-role role-id="isso">
             <party-uuid>11111111-2222-4000-8000-004000000008</party-uuid>
@@ -3263,6 +3263,7 @@
             <p>That component contains a link to the policy, so it does not have to be linked here
               too.</p>
           </description>
+          <prop ns="http://fedramp.gov/ns/oscal" name="control-origination" value="customer-provided"/>
           <implementation-status state="implemented"/>
           <responsible-role role-id="isso">
             <party-uuid>11111111-2222-4000-8000-004000000008</party-uuid>

--- a/src/validations/constraints/content/ssp-frr306-INVALID.xml
+++ b/src/validations/constraints/content/ssp-frr306-INVALID.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
+                      uuid="12345678-1234-4321-8765-123456789012">
+  <control-implementation>
+    <implemented-requirement uuid="11111111-2222-4000-8000-012000000001" control-id="ia-1">
+      <!-- Control origination prop doesn't have one of the allowed values. -->
+      <prop name="control-origination" ns="http://fedramp.gov/ns/oscal" value="sp-INVALID"/>
+    </implemented-requirement>
+  </control-implementation>
+</system-security-plan>

--- a/src/validations/constraints/content/ssp-frr307-INVALID.xml
+++ b/src/validations/constraints/content/ssp-frr307-INVALID.xml
@@ -4,7 +4,7 @@
                       xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.xsd"
                       uuid="12345678-1234-4321-8765-123456789012">
   <system-implementation>
-    <component uuid="11111111-2222-4000-8000-009000600001" type="policy">
+    <component uuid="11111111-2222-4000-8000-009000600001" type="process-procedure">
     </component>
   </system-implementation>
   <control-implementation>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -659,12 +659,28 @@
                 <enum value="privileged">Privileged</enum>
             </allowed-values>
 
-            <allowed-values id="frr306" target="control-implementation/implemented-requirement/prop[@name='control-origination'][@ns='http://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
-                <formal-name>Control Origination</formal-name>
-                <description>Identifies the control origination of an implemented requirement.</description>
-                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/oscal-representation/security-controls/control-origination/#control-origination"/>
+        </constraints>
+    </context>
+
+    <context>
+        <metapath target="/system-security-plan/control-implementation/implemented-requirement/statement/by-component"/>
+        <constraints>
+            <let var="component-uuid" expression="@component-uuid"/>
+            <allowed-values id="frr306" target=".[../../../../system-implementation/component[@uuid=$component-uuid and @type='policy']]/prop[@name='control-origination' and @ns='http://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
+                <formal-name>Control Origination Policy</formal-name>
+                <description>Identifies the control origination of a "policy" control.</description>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/help/constraint/frr306"/>
                 <enum value="sp-corporate">Service Provider (Corporate)</enum>
                 <enum value="sp-system">Service Provider (System Specific)</enum>
+            </allowed-values>
+
+            <allowed-values id="frr307" target=".[../../../../system-implementation/component[@uuid=$component-uuid and not(@type='policy')]]/prop[@name='control-origination' and @ns='http://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
+                <formal-name>Control Origination Non-Policy</formal-name>
+                <description>Identifies the control origination of a "non-policy" control.</description>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/help/constraint/frr307"/>
+                <enum value="customer-configured">Configured by Customer</enum>
+                <enum value="customer-provided">Provided by Customer</enum>
+                <enum value="inherited">Inherited from pre-existing FedRAMP Authorization</enum>
             </allowed-values>
 
         </constraints>

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -659,6 +659,14 @@
                 <enum value="privileged">Privileged</enum>
             </allowed-values>
 
+            <allowed-values id="frr306" target="control-implementation/implemented-requirement/prop[@name='control-origination'][@ns='http://fedramp.gov/ns/oscal']/@value" allow-other="no" level="ERROR">
+                <formal-name>Control Origination</formal-name>
+                <description>Identifies the control origination of an implemented requirement.</description>
+                <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/documentation/ssp/oscal-representation/security-controls/control-origination/#control-origination"/>
+                <enum value="sp-corporate">Service Provider (Corporate)</enum>
+                <enum value="sp-system">Service Provider (System Specific)</enum>
+            </allowed-values>
+
         </constraints>
     </context>
 

--- a/src/validations/constraints/fedramp-external-allowed-values.xml
+++ b/src/validations/constraints/fedramp-external-allowed-values.xml
@@ -678,6 +678,8 @@
                 <formal-name>Control Origination Non-Policy</formal-name>
                 <description>Identifies the control origination of a "non-policy" control.</description>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/help/constraint/frr307"/>
+                <enum value="sp-corporate">Service Provider (Corporate)</enum>
+                <enum value="sp-system">Service Provider (System Specific)</enum>
                 <enum value="customer-configured">Configured by Customer</enum>
                 <enum value="customer-provided">Provided by Customer</enum>
                 <enum value="inherited">Inherited from pre-existing FedRAMP Authorization</enum>

--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -50,7 +50,7 @@
             </expect>
         </constraints>
     </context>
-
+ 
     <context>
         <metapath target="//user"/>
         <constraints>

--- a/src/validations/constraints/unit-tests/frr306-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/frr306-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for frr306
+  description: This test case validates the behavior of constraint frr306
+  content: ../content/ssp-frr306-INVALID.xml
+  expectations:
+    - constraint-id: frr306
+      result: fail

--- a/src/validations/constraints/unit-tests/frr306-PASS.yaml
+++ b/src/validations/constraints/unit-tests/frr306-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for frr306
+  description: This test case validates the behavior of constraint frr306
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: frr306
+      result: pass

--- a/src/validations/constraints/unit-tests/frr307-FAIL.yaml
+++ b/src/validations/constraints/unit-tests/frr307-FAIL.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Negative Test for frr307
+  description: This test case validates the behavior of constraint frr307
+  content: ../content/ssp-frr307-INVALID.xml
+  expectations:
+    - constraint-id: frr307
+      result: fail

--- a/src/validations/constraints/unit-tests/frr307-PASS.yaml
+++ b/src/validations/constraints/unit-tests/frr307-PASS.yaml
@@ -1,0 +1,7 @@
+test-case:
+  name: Positive Test for frr307
+  description: This test case validates the behavior of constraint frr307
+  content: ../../../content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+  expectations:
+    - constraint-id: frr307
+      result: pass


### PR DESCRIPTION
# Committer Notes
## Purpose
This PR aims to add a `Control Origination` `Allowed Values` constraint that verifies that the control origination of an implemented requirement aligns with one the FedRAMP designated allowed values.

## Changes
- Added `frr306` and `frr307` constraints.
- Added associated negative test data.
- Added associated pass/fail YAML files.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
