### PR TITLE
PR removing all JAB references from baselines

### DIFF
--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml
@@ -14,10 +14,6 @@
 			<title>The FedRAMP Program Management Office (PMO)</title>
 			<short-name>PMO</short-name>
 		</role>
-		<role id="fedramp-jab">
-			<title>The FedRAMP Joint Authorization Board (JAB)</title>
-			<short-name>JAB</short-name>
-		</role>
 		<party uuid="8cc0b8e5-9650-4d5f-9796-316f05fa9a2d" type="organization">
 			<name>Federal Risk and Authorization Management Program: Program Management Office</name>
 			<short-name>FedRAMP PMO</short-name>
@@ -33,19 +29,11 @@
 				<country>US</country>
 			</address>
 		</party>
-		<party uuid="ca9ba80e-1342-4bfd-b32a-abac468c24b4" type="organization">
-			<name>Federal Risk and Authorization Management Program: Joint Authorization Board</name>
-			<short-name>FedRAMP JAB</short-name>
-			<link href="#a2381e87-3d04-4108-a30b-b4d2f36d001f" rel="logo"/>
-		</party>
 		<responsible-party role-id="prepared-by">
 			<party-uuid>8cc0b8e5-9650-4d5f-9796-316f05fa9a2d</party-uuid>
 		</responsible-party>
 		<responsible-party role-id="fedramp-pmo">
 			<party-uuid>8cc0b8e5-9650-4d5f-9796-316f05fa9a2d</party-uuid>
-		</responsible-party>
-		<responsible-party role-id="fedramp-jab">
-			<party-uuid>ca9ba80e-1342-4bfd-b32a-abac468c24b4</party-uuid>
 		</responsible-party>
 	</metadata>
 	<import href="#051a77c1-b61d-4995-8275-dacfe688d510">
@@ -960,14 +948,14 @@
 		<set-parameter param-id="ca-02.03_odp.03">
 			<constraint>
 				<description>
-					<p>the conditions of the JAB/AO in the FedRAMP Repository</p>
+					<p>the conditions of the AO in the FedRAMP Repository</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="ca-03_odp.03">
 			<constraint>
 				<description>
-					<p>at least annually and on input from JAB/AO</p>
+					<p>at least annually and on input from AO</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -988,14 +976,14 @@
 		<set-parameter param-id="ca-07_odp.04">
 			<constraint>
 				<description>
-					<p>to include JAB/AO</p>
+					<p>to include AO</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="ca-07_odp.06">
 			<constraint>
 				<description>
-					<p>to include JAB/AO</p>
+					<p>to include AO</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -1044,7 +1032,7 @@
 		<set-parameter param-id="cm-02_odp.02">
 			<constraint>
 				<description>
-					<p>to include when directed by the JAB</p>
+					<p>to include when directed by the AO</p>
 				</description>
 			</constraint>
 		</set-parameter>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LI-SaaS-baseline_profile.xml
@@ -456,7 +456,7 @@
         <set-parameter param-id="ca-03_odp.03">
             <constraint>
                 <description>
-                    <p>at least annually and on input from JAB/AO</p>
+                    <p>at least annually and on input from AO</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -477,14 +477,14 @@
         <set-parameter param-id="ca-07_odp.04">
             <constraint>
                 <description>
-                    <p>to include JAB/AO</p>
+                    <p>to include AO</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ca-07_odp.06">
             <constraint>
                 <description>
-                    <p>to include JAB/AO</p>
+                    <p>to include AO</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -526,7 +526,7 @@
         <set-parameter param-id="cm-02_odp.02">
             <constraint>
                 <description>
-                    <p>to include when directed by the JAB</p>
+                    <p>to include when directed by the AO</p>
                 </description>
             </constraint>
         </set-parameter>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_LOW-baseline_profile.xml
@@ -456,7 +456,7 @@
         <set-parameter param-id="ca-03_odp.03">
             <constraint>
                 <description>
-                    <p>at least annually and on input from JAB/AO</p>
+                    <p>at least annually and on input from AO</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -477,14 +477,14 @@
         <set-parameter param-id="ca-07_odp.04">
             <constraint>
                 <description>
-                    <p>to include JAB/AO</p>
+                    <p>to include AO</p>
                 </description>
             </constraint>
         </set-parameter>
         <set-parameter param-id="ca-07_odp.06">
             <constraint>
                 <description>
-                    <p>to include JAB/AO</p>
+                    <p>to include AO</p>
                 </description>
             </constraint>
         </set-parameter>
@@ -526,12 +526,10 @@
         <set-parameter param-id="cm-02_odp.02">
             <constraint>
                 <description>
-                    <p>to include when directed by the JAB</p>
+                    <p>to include when directed by the AO</p>
                 </description>
             </constraint>
         </set-parameter>
-
-
         <set-parameter param-id="cm-08_odp.02">
             <constraint>
                 <description>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml
@@ -736,14 +736,14 @@
 		<set-parameter param-id="ca-02.03_odp.03">
 			<constraint>
 				<description>
-					<p>the conditions of the JAB/AO in the FedRAMP Repository</p>
+					<p>the conditions of the AO in the FedRAMP Repository</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="ca-03_odp.03">
 			<constraint>
 				<description>
-					<p>at least annually and on input from JAB/AO</p>
+					<p>at least annually and on input from AO</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -764,14 +764,14 @@
 		<set-parameter param-id="ca-07_odp.04">
 			<constraint>
 				<description>
-					<p>to include JAB/AO</p>
+					<p>to include AO</p>
 				</description>
 			</constraint>
 		</set-parameter>
 		<set-parameter param-id="ca-07_odp.06">
 			<constraint>
 				<description>
-					<p>to include JAB/AO</p>
+					<p>to include AO</p>
 				</description>
 			</constraint>
 		</set-parameter>
@@ -820,7 +820,7 @@
 		<set-parameter param-id="cm-02_odp.02">
 			<constraint>
 				<description>
-					<p>to include when directed by the JAB</p>
+					<p>to include when directed by the AO</p>
 				</description>
 			</constraint>
 		</set-parameter>

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_catalog_tailoring_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_catalog_tailoring_profile.xml
@@ -520,7 +520,7 @@
 					<title>AC-2 (3) Additional FedRAMP Requirements and Guidance</title>
 					<part id="ac-2.3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>The service provider defines the time period for non-user accounts (e.g., accounts associated with devices). The time periods are approved and accepted by the JAB/AO. Where user management is a function of the service, reports of activity of consumer users shall be made available.</p>
+						<p>The service provider defines the time period for non-user accounts (e.g., accounts associated with devices). The time periods are approved and accepted by the AO. Where user management is a function of the service, reports of activity of consumer users shall be made available.</p>
 					</part>
 					<part id="ac-2.3_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(d) Requirement:"/>
@@ -1023,15 +1023,15 @@
 					<title>AC-8 Additional FedRAMP Requirements and Guidance</title>
 					<part id="ac-8_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>The service provider shall determine elements of the cloud environment that require the System Use Notification control. The elements of the cloud environment that require System Use Notification are approved and accepted by the JAB/AO.</p>
+						<p>The service provider shall determine elements of the cloud environment that require the System Use Notification control. The elements of the cloud environment that require System Use Notification are approved and accepted by the AO.</p>
 					</part>
 					<part id="ac-8_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>The service provider shall determine how System Use Notification is going to be verified and provide appropriate periodicity of the check. The System Use Notification verification and periodicity are approved and accepted by the JAB/AO.</p>
+						<p>The service provider shall determine how System Use Notification is going to be verified and provide appropriate periodicity of the check. The System Use Notification verification and periodicity are approved and accepted by the AO.</p>
 					</part>
 					<part id="ac-8_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>If not performed as part of a Configuration Baseline check, then there must be documented agreement on how to provide results of verification and the necessary periodicity of the verification by the service provider. The documented agreement on how to provide verification of the results are approved and accepted by the JAB/AO.</p>
+						<p>If not performed as part of a Configuration Baseline check, then there must be documented agreement on how to provide results of verification and the necessary periodicity of the verification by the service provider. The documented agreement on how to provide verification of the results are approved and accepted by the AO.</p>
 					</part>
 					<part id="ac-8_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
@@ -1418,11 +1418,11 @@
 					<title>AU-2 Additional FedRAMP Requirements and Guidance</title>
 					<part id="au-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>Coordination between service provider and consumer shall be documented and accepted by the JAB/AO.</p>
+						<p>Coordination between service provider and consumer shall be documented and accepted by the AO.</p>
 					</part>
 					<part id="au-2_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Guidance:"/>
-						<p>Annually or whenever changes in the threat environment are communicated to the service provider by the JAB/AO.</p>
+						<p>Annually or whenever changes in the threat environment are communicated to the service provider by the AO.</p>
 					</part>
 				</part>
 			</add>
@@ -1589,7 +1589,7 @@
 					<title>AU-6 Additional FedRAMP Requirements and Guidance</title>
 					<part id="au-6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>Coordination between service provider and consumer shall be documented and accepted by the JAB/AO. In multi-tenant environments, capability and means for providing review, analysis, and reporting to consumer for data pertaining to consumer shall be documented.</p>
+						<p>Coordination between service provider and consumer shall be documented and accepted by the AO. In multi-tenant environments, capability and means for providing review, analysis, and reporting to consumer for data pertaining to consumer shall be documented.</p>
 					</part>
 				</part>
 			</add>
@@ -1679,7 +1679,7 @@
 					<title>AU-6 (6) Additional FedRAMP Requirements and Guidance</title>
 					<part id="au-6.6_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>Coordination between service provider and consumer shall be documented and accepted by the JAB/AO.</p>
+						<p>Coordination between service provider and consumer shall be documented and accepted by the AO.</p>
 					</part>
 				</part>
 			</add>
@@ -1970,15 +1970,6 @@
 			</add>
 		</alter>
 		<alter control-id="ca-2.1">
-			<add position="after" by-id="ca-2.1_gdn">
-				<part id="ca-2.1_fr" name="item" ns="http://fedramp.gov/ns/oscal">
-					<title>CA-2 (1) Additional FedRAMP Requirements and Guidance</title>
-					<part id="ca-2.1_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
-						<prop name="label" value="Requirement:"/>
-						<p>For JAB Authorization, must use an accredited 3PAO.</p>
-					</part>
-				</part>
-			</add>
 			<add position="starting" by-id="ca-2.1_obj">
 				<prop ns="http://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
 				<prop ns="http://fedramp.gov/ns/oscal" name="method" class="fedramp" value="EXAMINE"/>
@@ -2089,7 +2080,7 @@
 					<title>CA-6 Additional FedRAMP Requirements and Guidance</title>
 					<part id="ca-6_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Guidance:"/>
-						<p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F and according to FedRAMP Significant Change Policies and Procedures. The service provider describes the types of changes to the information system or the environment of operations that would impact the risk posture. The types of changes are approved and accepted by the JAB/AO.</p>
+						<p>Significant change is defined in NIST Special Publication 800-37 Revision 2, Appendix F and according to FedRAMP Significant Change Policies and Procedures. The service provider describes the types of changes to the information system or the environment of operations that would impact the risk posture. The types of changes are approved and accepted by the AO.</p>
 					</part>
 				</part>
 			</add>
@@ -2148,7 +2139,7 @@
 					</part>
 					<part id="ca-7_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>CSOs with more than one agency ATO must implement a collaborative Continuous Monitoring (ConMon) approach described in the FedRAMP Guide for Multi-Agency Continuous Monitoring. This requirement applies to CSOs authorized via the Agency path as each agency customer is responsible for performing ConMon oversight. It does not apply to CSOs authorized via the JAB path because the JAB performs ConMon oversight.</p>
+						<p>CSOs with more than one agency ATO must implement a collaborative Continuous Monitoring (ConMon) approach described in the FedRAMP Guide for Multi-Agency Continuous Monitoring. This requirement applies to CSOs authorized via the Agency path as each agency customer is responsible for performing ConMon oversight.</p>
 					</part>
 					<part id="ca-7_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
@@ -2537,7 +2528,7 @@
 					<title>CM-3 Additional FedRAMP Requirements and Guidance</title>
 					<part id="cm-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>The service provider establishes a central means of communicating major changes to or developments in the information system or environment of operations that may affect its services to the federal government and associated service consumers (e.g., electronic bulletin board, web status page). The means of communication are approved and accepted by the JAB/AO.</p>
+						<p>The service provider establishes a central means of communicating major changes to or developments in the information system or environment of operations that may affect its services to the federal government and associated service consumers (e.g., electronic bulletin board, web status page). The means of communication are approved and accepted by the AO.</p>
 					</part>
 					<part id="cm-3_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Guidance:"/>
@@ -3309,10 +3300,6 @@
 					<title>CP-2 Additional FedRAMP Requirements and Guidance</title>
 					<part id="cp-2_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>For JAB authorizations the contingency lists include designated FedRAMP personnel.</p>
-					</part>
-					<part id="cp-2_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
-						<prop name="label" value="Requirement:"/>
 						<p>CSPs must use the FedRAMP Information System Contingency Plan (ISCP) Template (available on the fedramp.gov: https://www.fedramp.gov/assets/resources/templates/SSP-A06-FedRAMP-ISCP-Template.docx).</p>
 					</part>
 				</part>
@@ -3534,7 +3521,7 @@
 					<title>CP-4 Additional FedRAMP Requirements and Guidance</title>
 					<part id="cp-4_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
-						<p>The service provider develops test plans in accordance with NIST Special Publication 800-34 (as amended); plans are approved by the JAB/AO prior to initiating testing.</p>
+						<p>The service provider develops test plans in accordance with NIST Special Publication 800-34 (as amended); plans are approved by the AO prior to initiating testing.</p>
 					</part>
 					<part id="cp-4_fr_smt.2" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(b) Requirement:"/>
@@ -4842,7 +4829,7 @@
 					<title>IR-3-2 Additional FedRAMP Requirements and Guidance</title>
 					<part id="ir-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Requirement:"/>
-						<p>The service provider defines tests and/or exercises in accordance with NIST Special Publication 800-61 (as amended). Functional testing must occur prior to testing for initial authorization. Annual functional testing may be concurrent with required penetration tests (see CA-8). The service provider provides test plans to the JAB/AO annually. Test plans are approved and accepted by the JAB/AO prior to test commencing.</p>
+						<p>The service provider defines tests and/or exercises in accordance with NIST Special Publication 800-61 (as amended). Functional testing must occur prior to testing for initial authorization. Annual functional testing may be concurrent with required penetration tests (see CA-8). The service provider provides test plans to the AO annually. Test plans are approved and accepted by the AO prior to test commencing.</p>
 					</part>
 				</part>
 			</add>
@@ -5738,7 +5725,7 @@
 					<title>MP-5 Additional FedRAMP Requirements and Guidance</title>
 					<part id="mp-5_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(a) Requirement:"/>
-						<p>The service provider defines security measures to protect digital and non-digital media in transport. The security measures are approved and accepted by the JAB/AO.</p>
+						<p>The service provider defines security measures to protect digital and non-digital media in transport. The security measures are approved and accepted by the AO.</p>
 					</part>
 				</part>
 			</add>
@@ -7233,7 +7220,7 @@
 					</part>
 					<part id="ra-3_fr_smt.1" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Requirement:"/>
-						<p>Include all Authorizing Officials; for JAB authorizations to include FedRAMP.</p>
+						<p>Include all Authorizing Officials.</p>
 					</part>
 				</part>
 			</add>
@@ -7331,7 +7318,7 @@
 					</part>
 					<part id="ra-5_fr_smt.3" name="item" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="(e) Requirement:"/>
-						<p>to include all Authorizing Officials; for JAB authorizations to include FedRAMP</p>
+						<p>to include all Authorizing Officials.</p>
 					</part>
 					<part id="ra-5_fr_gdn.2" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
@@ -8854,15 +8841,6 @@
 			</add>
 		</alter>
 		<alter control-id="sc-7.5">
-			<add position="after" by-id="sc-7.5_gdn">
-				<part id="sc-7.5_fr" name="item" ns="http://fedramp.gov/ns/oscal">
-					<title>SC-7 (5) Additional FedRAMP Requirements and Guidance</title>
-					<part id="sc-7.5_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
-						<prop name="label" value="Guidance:"/>
-						<p>For JAB Authorization, CSPs shall include details of this control in their Architecture Briefing</p>
-					</part>
-				</part>
-			</add>
 			<add position="starting" by-id="sc-7.5_obj">
 				<prop ns="http://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
 				<prop ns="http://fedramp.gov/ns/oscal" name="method" class="fedramp" value="EXAMINE"/>


### PR DESCRIPTION
# Committer Notes

This PR addresses issue #904 removing all JAB references from the baselines.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated.?
- [x] If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
