### PR TITLE
Make constraint ID ordering a warning

### DIFF
--- a/features/fedramp_extensions.feature
+++ b/features/fedramp_extensions.feature
@@ -211,6 +211,7 @@ Examples:
   | frr305 |
   | frr306 |
   | frr307 |
+  | frr512 |
 #END_DYNAMIC_CONSTRAINT_IDS
 
 @constraints

--- a/features/steps/fedramp_extensions_steps.ts
+++ b/features/steps/fedramp_extensions_steps.ts
@@ -823,9 +823,7 @@ Then(
               const line = fileContent
                 .substring(0, fileContent.indexOf(currentId))
                 .split("\n").length;
-              errors.push(
-                `[ERROR] frr103 ${fileName}:${line}: "${currentId}" is out of order. It should come after "${nextId}"`
-              );
+                console.warn(`[WARN] frr103 ${fileName}:${line}: "${currentId}" is out of order. It should come after "${nextId}"`);
             }
           }
         });


### PR DESCRIPTION
# Committer Notes

Adjust Typescript-based style guide rule for ID ordering to warning.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?~
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
