### PR TITLE
Fix incorrect syntax with misplaced remarks for FRR277

### DIFF
--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -81,12 +81,12 @@
                 <formal-name>Prop Response Point Has Cardinality One</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/help/constraint/frr277"/>
                 <message>MUST NOT have Duplicate response point at '{ path(.) }'.</message>
+                <remarks>
+                    <p>This appears in FedRAMP profiles and resolved profile catalogs.</p>
+                    <p>For control statements, it signals to the CSP which statements require a response in the SSP.</p>
+                    <p>For control objectives, it signals to the assessor which control objectives must appear in the assessment results, which aligns with the FedRAMP test case workbook.</p>
+                </remarks>
             </expect>
-            <remarks>
-                <p>This appears in FedRAMP profiles and resolved profile catalogs.</p>
-                <p>For control statements, it signals to the CSP which statements require a response in the SSP.</p>
-                <p>For control objectives, it signals to the assessor which control objectives must appear in the assessment results, which aligns with the FedRAMP test case workbook.</p>
-            </remarks>
         </constraints>
     </context>
 


### PR DESCRIPTION
# Committer Notes

The remarks assembly for F277 was outside its `expect` constraint parent assembly, and left as a sibling to it. This incorrect syntax broke restored style checks we want to clean up before release.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?~
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
