### PR TITLE
Fix FRR252 use of deprecated datatype

### DIFF
--- a/src/validations/constraints/fedramp-external-constraints.xml
+++ b/src/validations/constraints/fedramp-external-constraints.xml
@@ -1060,7 +1060,7 @@
     <context>
         <metapath target="//back-matter/resource"/>
         <constraints>
-            <matches id="frr252" target="prop[@ns='http://fedramp.gov/ns/oscal' and @name='last-accessed']/@value" datatype="dateTime-with-timezone" level="WARNING">
+            <matches id="frr252" target="prop[@ns='http://fedramp.gov/ns/oscal' and @name='last-accessed']/@value" datatype="date-time-with-timezone" level="WARNING">
                 <formal-name>Last Accessed is Type DateTime</formal-name>
                 <prop namespace="https://docs.oasis-open.org/sarif/sarif/v2.1.0" name="help-url" value="https://automate.fedramp.gov/help/constraint/frr252"/>
                 <message>A FedRAMP document SHOULD specify the last accessed date for resources where the specification publication date is unknown.  In such cases, the last accessed date MUST be be a date with an explicit timezone, per RFC-3339.</message>


### PR DESCRIPTION
# Committer Notes

Remove deprecated datatype, throwing exceptions with edge in style constraint validations.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?~
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
