### PR TITLE
Build resolved profiles of base FR tailoring catalog and workaround upstream content issue

### DIFF
--- a/src/content/module.mk
+++ b/src/content/module.mk
@@ -39,6 +39,8 @@ build-content:
 	@echo "Producing artifacts for SAR..."
 	$(OSCAL_CLI) convert -f $(SRC_DIR)/content/rev5/templates/sar/xml -o $(DIST_DIR)/content/rev5/templates/sar -s
 
+	@echo "Resolving FedRAMP tailoring catalog ..."
+	$(OSCAL_CLI) resolve -f $(SRC_DIR)/content/rev5/baselines/xml/FedRAMP_rev5_catalog_tailoring_profile.xml -o $(XML_DIR)/FedRAMP_rev5_catalog_tailoring-resolved-profile_catalog.xml -s	
 	@echo "Resolving FedRAMP HIGH baseline profile..."
 	$(OSCAL_CLI) resolve -f $(SRC_DIR)/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml -o $(XML_DIR)/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.xml -s
 	@echo "Resolving FedRAMP MODERATE baseline profile..."

--- a/src/content/rev5/baselines/xml/FedRAMP_rev5_catalog_tailoring_profile.xml
+++ b/src/content/rev5/baselines/xml/FedRAMP_rev5_catalog_tailoring_profile.xml
@@ -6405,6 +6405,20 @@
 				<prop ns="http://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
 			</add>
 		</alter>
+		<alter control-id="pe-6.2">
+			<!-- See upstream bug report usnistgov/OSCAL#ABCD why FedRAMP strips the anchor tag to an adjacent parameter. -->
+			<remove by-id="pe-06.02_odp.03"/>
+			<add position="after" by-id="pe-06.02_odp.02">
+				<param id="pe-06.02_odp.03">
+					<prop name="alt-identifier" ns="http://csrc.nist.gov/ns/oscal" value="pe-6.2_prm_3"/>
+					<prop name="label" ns="http://csrc.nist.gov/ns/oscal" value="PE-06(02)_ODP[03]" class="sp800-53a"/>
+					<label>automated mechanisms</label>
+					<guideline>
+						<p>automated mechanisms used to recognize classes or types of intrusions and initiate response actions (defined in PE-06(02)_ODP) are defined;</p>
+					</guideline>
+				</param>			
+			</add>
+		</alter>
 		<alter control-id="pe-6.4">
 			<add position="starting" by-id="pe-6.4_obj">
 				<prop ns="http://fedramp.gov/ns/oscal" name="response-point" value="You must fill in this response point."/>
@@ -9005,7 +9019,7 @@
 			<add position="after" by-id="sc-13_gdn">
 				<part id="sc-13_fr" name="item" ns="http://fedramp.gov/ns/oscal">
 					<title>SC-13 Additional FedRAMP Requirements and Guidance</title>
-
+					
 					<part id="sc-13_fr_gdn.1" name="guidance" ns="http://fedramp.gov/ns/oscal">
 						<prop name="label" value="Guidance:"/>
 						<p>This control applies to all use of cryptography. In addition to encryption, this includes functions such as hashing, random number generation, and key generation. Examples include the following:</p>

--- a/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
+++ b/src/content/rev5/examples/ssp/xml/fedramp-ssp-example.oscal.xml
@@ -564,10 +564,9 @@
     </responsible-party>
   </metadata>
   <import-profile
-    href="https://raw.githubusercontent.com/GSA/fedramp-automation/refs/heads/develop/dist/content/rev5/baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml">
+    href="../../../baselines/xml/FedRAMP_rev5_HIGH-baseline_profile.xml">
     <remarks>
-      <p>This example points to the FedRAMP Rev 5 Moderate baseline that is part of the official
-        FedRAMP 3.0.0 release.</p>
+      <p>This example points to the FedRAMP Rev 5 HIGH baseline that is part of the official FedRAMP 3.0.0 release.</p>
       <p>Must adjust accordingly for applicable baseline and revision.</p>
     </remarks>
   </import-profile>


### PR DESCRIPTION
# Committer Notes

- Published resolved copy of base tailoring profile to `./dist` upon release through change to `Makefile`.
-  Workaround malformed upstream content per https://github.com/metaschema-framework/liboscal-java/issues/144 (an upstream bug fix to work around profile resolution failures from warning will come shortly).
- Port the valid example SSP to use the correct version of the HIGH profile by relative path, not remote URI to improve speed.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/GSA/fedramp-automation/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/GSA/fedramp-automation/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~If applicable, have all [FedRAMP Documents Related to OSCAL Adoption](https://github.com/GSA/fedramp-automation) affected by the changes in this issue have been updated?~
- ~If applicable, does this PR reference the issue it addresses and explain how it addresses the issue?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
